### PR TITLE
Fix PATH loss after deferred zsh loading

### DIFF
--- a/core/path.zsh
+++ b/core/path.zsh
@@ -1,4 +1,4 @@
-typeset -U path PATH
+typeset -gU path PATH
 path=(${path:#.})
 path=(${path:#./bin})
 path=(

--- a/tests/shell_loading.bats
+++ b/tests/shell_loading.bats
@@ -57,6 +57,20 @@ run_loader() {
   [[ ":$output:" == *":$REPO_ROOT/bin:"* ]]
 }
 
+@test "core path changes persist after function-scoped loading" {
+  run env HOME="$HOME" PATH="/usr/bin:/bin" zsh -dfc '
+    load_path() {
+      ZSH="$1"
+      source "$1/core/path.zsh"
+    }
+    load_path "$1"
+    print -r -- "$PATH"
+  ' _ "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+  [[ ":$output:" == *":$REPO_ROOT/bin:"* ]]
+  [[ ":$output:" == *":/usr/bin:"* ]]
+}
+
 @test "zshrc loads customizations from configured DOTFILES root" {
   local custom_root="$TEST_ROOT/custom-dotfiles"
   mkdir -p "$custom_root/core/shell"


### PR DESCRIPTION
## Summary
- make the zsh `path`/`PATH` declaration global when sourced from deferred loader functions
- preserve inherited system paths and mise-managed runtime paths after `load_custom` returns
- add regression coverage for function-scoped path loading

## Root cause
`core/path.zsh` used `typeset -U path PATH` while being sourced inside `load_custom`. In zsh, that declaration became function-local and initially empty, dropping `/usr/bin` before mise activation and restoring the pre-load PATH when the function returned.

## Verification
- [x] `make check` — 40 Bats tests, ShellCheck, shfmt, AI validation
- [x] clean-shell resolution of `node`, `npm`, `claude`, `codex`, and `mise`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PATH updates now persist when the path configuration is loaded from within a shell function.
  * Existing PATH uniqueness behavior remains unchanged.

* **Tests**
  * Added coverage verifying that configured project tools and standard system paths remain available after function-scoped loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->