### PR TITLE
feat: add global coauthor removal hook

### DIFF
--- a/core/git/git-hooks.symlink/commit-msg
+++ b/core/git/git-hooks.symlink/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+message_file=$1
+temporary_file="${message_file}.without-coauthors.$$"
+
+trap 'rm -f "$temporary_file"' 0 1 2 3 15
+
+awk '
+  tolower($0) !~ /^[[:space:]]*co-authored-by:[[:space:]]*/
+' "$message_file" >"$temporary_file"
+
+cat "$temporary_file" >"$message_file"

--- a/core/git/git-hooks.symlink/commit-msg
+++ b/core/git/git-hooks.symlink/commit-msg
@@ -7,8 +7,44 @@ temporary_file="${message_file}.without-coauthors.$$"
 
 trap 'rm -f "$temporary_file"' 0 1 2 3 15
 
-awk '
-  tolower($0) !~ /^[[:space:]]*co-authored-by:[[:space:]]*/
-' "$message_file" >"$temporary_file"
+if ! awk '
+  {
+    lines[NR] = $0
+  }
 
-cat "$temporary_file" >"$message_file"
+  END {
+    last_line = NR
+    while (last_line > 0 && lines[last_line] ~ /^[[:space:]]*$/) {
+      last_line--
+    }
+
+    trailer_start = last_line + 1
+    for (line = last_line; line > 0; line--) {
+      if (lines[line] ~ /^[[:space:]]*$/) {
+        trailer_start = line + 1
+        break
+      }
+    }
+
+    valid_trailer_block = trailer_start <= last_line
+    seen_trailer = 0
+    for (line = trailer_start; line <= last_line; line++) {
+      if (lines[line] ~ /^[[:space:]]*[^[:space:]:]+[[:space:]]*:[[:space:]]*/) {
+        seen_trailer = 1
+      } else if (!(seen_trailer && lines[line] ~ /^[[:space:]]+/)) {
+        valid_trailer_block = 0
+      }
+    }
+
+    for (line = 1; line <= NR; line++) {
+      is_coauthor = tolower(lines[line]) ~ /^[[:space:]]*co-authored-by:[[:space:]]*/
+      if (!(valid_trailer_block && line >= trailer_start && line <= last_line && is_coauthor)) {
+        print lines[line]
+      }
+    }
+  }
+' "$message_file" >"$temporary_file"; then
+  exit 1
+fi
+
+mv "$temporary_file" "$message_file"

--- a/core/git/gitconfig.symlink
+++ b/core/git/gitconfig.symlink
@@ -10,6 +10,7 @@
         ui = true
 [core]
 	excludesfile = ~/.gitignore
+	hooksPath = ~/.git-hooks
         editor = nvim
 [apply]
         whitespace = nowarn

--- a/tests/git_commit_msg_hook.bats
+++ b/tests/git_commit_msg_hook.bats
@@ -35,14 +35,25 @@ EOF
   cmp "$EXPECTED_FILE" "$MESSAGE_FILE"
 }
 
-@test "commit-msg preserves non-trailer co-author text" {
+@test "commit-msg preserves co-author text in the body" {
   cat >"$MESSAGE_FILE" <<'EOF'
-Document Co-authored-by: as ordinary prose
+Document attribution behavior
 
-X-Co-authored-by: This is not the Git trailer
+Co-authored-by: This body line documents the trailer format.
+Keep this body line too.
+
+Reviewed-by: Reviewer <reviewer@example.com>
+Co-authored-by: Actual Author <author@example.com>
 EOF
 
-  cp "$MESSAGE_FILE" "$EXPECTED_FILE"
+  cat >"$EXPECTED_FILE" <<'EOF'
+Document attribution behavior
+
+Co-authored-by: This body line documents the trailer format.
+Keep this body line too.
+
+Reviewed-by: Reviewer <reviewer@example.com>
+EOF
 
   run "$HOOK" "$MESSAGE_FILE"
 
@@ -50,9 +61,43 @@ EOF
   cmp "$EXPECTED_FILE" "$MESSAGE_FILE"
 }
 
+@test "commit-msg atomically replaces the message file" {
+  printf 'Commit subject\n' >"$MESSAGE_FILE"
+  original_inode=$(ls -i "$MESSAGE_FILE" | awk '{print $1}')
+
+  run "$HOOK" "$MESSAGE_FILE"
+
+  [ "$status" -eq 0 ]
+  replacement_inode=$(ls -i "$MESSAGE_FILE" | awk '{print $1}')
+  [ "$replacement_inode" != "$original_inode" ]
+}
+
 @test "gitconfig uses the managed global hooks directory" {
   run git config --file "$REPO_ROOT/core/git/gitconfig.symlink" --get core.hooksPath
 
   [ "$status" -eq 0 ]
   [ "$output" = "~/.git-hooks" ]
+
+  run bash "$REPO_ROOT/bin/relink"
+  [ "$status" -eq 0 ]
+
+  local repository="$TEST_ROOT/repository"
+  run git init --quiet "$repository"
+  [ "$status" -eq 0 ]
+
+  run git -C "$repository" config --path --get core.hooksPath
+  [ "$status" -eq 0 ]
+  local hooks_path="$output"
+  [ "$hooks_path" = "$HOME/.git-hooks" ]
+  [ -x "$hooks_path/commit-msg" ]
+
+  cat >"$MESSAGE_FILE" <<'EOF'
+Verify installed hook
+
+Co-authored-by: Installed Author <author@example.com>
+EOF
+
+  run "$hooks_path/commit-msg" "$MESSAGE_FILE"
+  [ "$status" -eq 0 ]
+  ! grep -qi '^[[:space:]]*co-authored-by:' "$MESSAGE_FILE"
 }

--- a/tests/git_commit_msg_hook.bats
+++ b/tests/git_commit_msg_hook.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  HOOK="$REPO_ROOT/core/git/git-hooks.symlink/commit-msg"
+  MESSAGE_FILE="$TEST_ROOT/COMMIT_EDITMSG"
+  EXPECTED_FILE="$TEST_ROOT/expected"
+}
+
+@test "commit-msg removes co-author trailers case-insensitively" {
+  cat >"$MESSAGE_FILE" <<'EOF'
+Add global Git hook
+
+Keep this body unchanged.
+
+Co-authored-by: First Person <first@example.com>
+  cO-AuThOrEd-By: Second Person <second@example.com>
+Reviewed-by: Reviewer <reviewer@example.com>
+CO-AUTHORED-BY: Third Person <third@example.com>
+EOF
+
+  cat >"$EXPECTED_FILE" <<'EOF'
+Add global Git hook
+
+Keep this body unchanged.
+
+Reviewed-by: Reviewer <reviewer@example.com>
+EOF
+
+  run "$HOOK" "$MESSAGE_FILE"
+
+  [ "$status" -eq 0 ]
+  cmp "$EXPECTED_FILE" "$MESSAGE_FILE"
+}
+
+@test "commit-msg preserves non-trailer co-author text" {
+  cat >"$MESSAGE_FILE" <<'EOF'
+Document Co-authored-by: as ordinary prose
+
+X-Co-authored-by: This is not the Git trailer
+EOF
+
+  cp "$MESSAGE_FILE" "$EXPECTED_FILE"
+
+  run "$HOOK" "$MESSAGE_FILE"
+
+  [ "$status" -eq 0 ]
+  cmp "$EXPECTED_FILE" "$MESSAGE_FILE"
+}
+
+@test "gitconfig uses the managed global hooks directory" {
+  run git config --file "$REPO_ROOT/core/git/gitconfig.symlink" --get core.hooksPath
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "~/.git-hooks" ]
+}


### PR DESCRIPTION
## Summary
- add a managed global `commit-msg` hook that removes `Co-authored-by:` lines case-insensitively
- configure Git to use the dotfiles-managed `~/.git-hooks` directory
- add Bats coverage for filtering behavior and hooks-path configuration

## Test Plan
- [x] `sh -n core/git/git-hooks.symlink/commit-msg`
- [x] `shellcheck -S warning core/git/git-hooks.symlink/commit-msg`
- [x] `shfmt -d -i 2 -ci core/git/git-hooks.symlink/commit-msg`
- [x] `make syntax`
- [x] `make lint`
- [x] `make test` (43 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Git `commit-msg` hook that automatically removes `Co-authored-by:` trailers (case-insensitive) when they appear in the trailer block.
  * Configured Git to use a managed global hooks directory via `hooksPath`.

* **Bug Fixes**
  * Ensures `co-authored-by`-like text in the commit body is preserved and only valid trailer blocks are affected.
  * Uses atomic message file replacement behavior when updating commit messages.

* **Tests**
  * Expanded Bats coverage for case variations, body preservation, atomic replacement, and hook installation/config resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->