### PR TITLE
Automate feature workflow around Superpowers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ docs/*
 docs/superpowers/*
 !docs/superpowers/plans/
 !docs/superpowers/plans/*.md
+!docs/superpowers/specs/
+!docs/superpowers/specs/*.md
 platforms/macos/brewfile.lock.json
 core/git/gitconfig.local.symlink
 .dotfiles-profile

--- a/ai/claude/CLAUDE.md
+++ b/ai/claude/CLAUDE.md
@@ -32,6 +32,32 @@ implementing, track discoveries and deviations, and verify comprehensively.
 Match the effort to the risk. Do not impose heavy process on trivial tasks, and
 do not skip it on consequential ones.
 
+## Automatic feature workflow
+
+For repository-changing work, inspect and clarify in the current checkout, then
+enter a linked worktree before the first feature-related write. Use
+`superpowers:using-git-worktrees` when available, and reuse an existing linked
+worktree rather than nesting another. Specs, plans, tests, source, configuration,
+and documentation all count as writes.
+
+- During discovery, before the design is locked in, run `my:blindspot-pass` for
+  non-trivial work. Summarize material findings and continue automatically for
+  routine work. Pause only when unresolved high-impact decisions involving
+  architecture, public interfaces, persisted data, migrations, security,
+  compatibility, deployment, or similarly consequential behavior could
+  materially change the implementation.
+- Continue with the normal Superpowers brainstorming, planning, TDD, review, and
+  verification workflow. The personal skills complement rather than replace
+  those phases.
+- After implementation, run `my:polish-core --fix`, inspect the resulting edits,
+  and re-run the affected verification before making completion claims.
+- Then run `my:change-explainer` for non-trivial completed work. Include its five
+  knowledge-check questions only for substantial changes; omit them for routine
+  non-trivial changes.
+
+Trivial edits may skip blindspot-pass and change-explainer, but they do not skip
+the linked-worktree-before-writing rule.
+
 ## Repository inspection
 
 Before substantial implementation, inspect what is relevant: source, tests,

--- a/ai/claude/hooks/worktree-guard.sh
+++ b/ai/claude/hooks/worktree-guard.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PreToolUse hook: deny Edit/Write/NotebookEdit when the target file's repo is
+# checked out on its default branch, so implementation happens in a worktree.
+# Fails open: any unexpected condition allows the edit.
+set -u
+
+allow() { exit 0; }
+
+[ "${CLAUDE_WORKTREE_GUARD:-on}" = "off" ] && allow
+
+input=$(cat 2>/dev/null) || allow
+command -v jq >/dev/null 2>&1 || allow
+path=$(printf '%s' "$input" \
+  | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' \
+    2>/dev/null) || allow
+[ -n "$path" ] || allow
+
+# Nearest existing ancestor (the file or its directories may not exist yet).
+dir="$path"
+while [ ! -d "$dir" ]; do
+  parent=$(dirname "$dir")
+  [ "$parent" = "$dir" ] && allow
+  dir="$parent"
+done
+
+command -v git >/dev/null 2>&1 || allow
+repo_root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || allow
+repo_root=$(cd "$repo_root" && pwd -P) || allow
+
+allowfile="$HOME/.claude/worktree-guard-allow"
+if [ -f "$allowfile" ]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] || continue
+    case "$line" in "~"*) line="$HOME${line#\~}" ;; esac
+    resolved=$(cd "$line" 2>/dev/null && pwd -P) || continue
+    [ "$resolved" = "$repo_root" ] && allow
+  done <"$allowfile"
+fi
+
+# Detached HEAD counts as "not on the default branch".
+branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || allow
+
+default=$(git -C "$dir" symbolic-ref --quiet --short \
+  refs/remotes/origin/HEAD 2>/dev/null || true)
+default=${default#origin/}
+if [ -z "$default" ]; then
+  if git -C "$dir" show-ref --verify --quiet refs/heads/main; then
+    default=main
+  elif git -C "$dir" show-ref --verify --quiet refs/heads/master; then
+    default=master
+  else
+    allow
+  fi
+fi
+
+[ "$branch" = "$default" ] || allow
+
+reason="Edits are blocked on the default branch ($default) of $repo_root. \
+Create a worktree first (superpowers:using-git-worktrees skill). If this repo \
+is intentionally edited on its default branch, add its path to \
+~/.claude/worktree-guard-allow."
+jq -n --arg r "$reason" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+exit 0

--- a/ai/claude/hooks/worktree-guard.sh
+++ b/ai/claude/hooks/worktree-guard.sh
@@ -15,6 +15,12 @@ path=$(printf '%s' "$input" |
     2>/dev/null) || allow
 [ -n "$path" ] || allow
 
+# Resolve symlinks (including a symlinked final component, e.g. the live
+# ~/.claude/settings.json) so the write is attributed to the repo it lands in.
+# -m tolerates not-yet-created components; on failure keep the original path.
+canonical=$(readlink -m -- "$path" 2>/dev/null) &&
+  [ -n "$canonical" ] && path="$canonical"
+
 # Nearest existing ancestor (the file or its directories may not exist yet).
 dir="$path"
 while [ ! -d "$dir" ]; do
@@ -42,9 +48,11 @@ fi
 
 git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || allow
 common_dir=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || allow
+# A relative --git-common-dir is relative to the `git -C` directory, not the
+# repo root (e.g. ../../.git from a subdirectory).
 case "$common_dir" in
   /*) ;;
-  *) common_dir="$repo_root/$common_dir" ;;
+  *) common_dir="$dir/$common_dir" ;;
 esac
 git_dir=$(cd "$git_dir" 2>/dev/null && pwd -P) || allow
 common_dir=$(cd "$common_dir" 2>/dev/null && pwd -P) || allow

--- a/ai/claude/hooks/worktree-guard.sh
+++ b/ai/claude/hooks/worktree-guard.sh
@@ -17,9 +17,17 @@ path=$(printf '%s' "$input" |
 
 # Resolve symlinks (including a symlinked final component, e.g. the live
 # ~/.claude/settings.json) so the write is attributed to the repo it lands in.
-# -m tolerates not-yet-created components; on failure keep the original path.
-canonical=$(readlink -m -- "$path" 2>/dev/null) &&
-  [ -n "$canonical" ] && path="$canonical"
+# GNU readlink -m tolerates missing components; realpath and Python provide
+# portable fallbacks for macOS/BSD. On failure, keep the original path.
+canonical=$(readlink -m -- "$path" 2>/dev/null) || canonical=""
+if [ -z "$canonical" ] && command -v realpath >/dev/null 2>&1; then
+  canonical=$(realpath "$path" 2>/dev/null) || canonical=""
+fi
+if [ -z "$canonical" ] && command -v python3 >/dev/null 2>&1; then
+  canonical=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' \
+    "$path" 2>/dev/null) || canonical=""
+fi
+[ -n "$canonical" ] && path="$canonical"
 
 # Nearest existing ancestor (the file or its directories may not exist yet).
 dir="$path"

--- a/ai/claude/hooks/worktree-guard.sh
+++ b/ai/claude/hooks/worktree-guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # PreToolUse hook: deny Edit/Write/NotebookEdit when the target file's repo is
-# checked out on its default branch, so implementation happens in a worktree.
+# the primary checkout, so implementation happens in a linked worktree.
 # Fails open: any unexpected condition allows the edit.
 set -u
 
@@ -10,8 +10,8 @@ allow() { exit 0; }
 
 input=$(cat 2>/dev/null) || allow
 command -v jq >/dev/null 2>&1 || allow
-path=$(printf '%s' "$input" \
-  | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' \
+path=$(printf '%s' "$input" |
+  jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' \
     2>/dev/null) || allow
 [ -n "$path" ] || allow
 
@@ -40,27 +40,20 @@ if [ -f "$allowfile" ]; then
   done <"$allowfile"
 fi
 
-# Detached HEAD counts as "not on the default branch".
-branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || allow
+git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || allow
+common_dir=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || allow
+case "$common_dir" in
+  /*) ;;
+  *) common_dir="$repo_root/$common_dir" ;;
+esac
+git_dir=$(cd "$git_dir" 2>/dev/null && pwd -P) || allow
+common_dir=$(cd "$common_dir" 2>/dev/null && pwd -P) || allow
 
-default=$(git -C "$dir" symbolic-ref --quiet --short \
-  refs/remotes/origin/HEAD 2>/dev/null || true)
-default=${default#origin/}
-if [ -z "$default" ]; then
-  if git -C "$dir" show-ref --verify --quiet refs/heads/main; then
-    default=main
-  elif git -C "$dir" show-ref --verify --quiet refs/heads/master; then
-    default=master
-  else
-    allow
-  fi
-fi
+[ "$git_dir" = "$common_dir" ] || allow
 
-[ "$branch" = "$default" ] || allow
-
-reason="Edits are blocked on the default branch ($default) of $repo_root. \
-Create a worktree first (superpowers:using-git-worktrees skill). If this repo \
-is intentionally edited on its default branch, add its path to \
+reason="Edits are blocked in the primary checkout of $repo_root. Create a \
+linked worktree first (superpowers:using-git-worktrees skill). If this repo \
+must exceptionally be edited in place, add its path to \
 ~/.claude/worktree-guard-allow."
 jq -n --arg r "$reason" \
   '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'

--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -2,6 +2,19 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.dotfiles/ai/claude/hooks/worktree-guard.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(git:*)",

--- a/ai/codex/AGENTS.md
+++ b/ai/codex/AGENTS.md
@@ -32,6 +32,32 @@ implementing, track discoveries and deviations, and verify comprehensively.
 Match the effort to the risk. Do not impose heavy process on trivial tasks, and
 do not skip it on consequential ones.
 
+## Automatic feature workflow
+
+For repository-changing work, inspect and clarify in the current checkout, then
+enter a linked worktree before the first feature-related write. Use
+`superpowers:using-git-worktrees` when available, and reuse an existing linked
+worktree rather than nesting another. Specs, plans, tests, source, configuration,
+and documentation all count as writes.
+
+- During discovery, before the design is locked in, run `my:blindspot-pass` for
+  non-trivial work. Summarize material findings and continue automatically for
+  routine work. Pause only when unresolved high-impact decisions involving
+  architecture, public interfaces, persisted data, migrations, security,
+  compatibility, deployment, or similarly consequential behavior could
+  materially change the implementation.
+- Continue with the normal Superpowers brainstorming, planning, TDD, review, and
+  verification workflow. The personal skills complement rather than replace
+  those phases.
+- After implementation, run `my:polish-core --fix`, inspect the resulting edits,
+  and re-run the affected verification before making completion claims.
+- Then run `my:change-explainer` for non-trivial completed work. Include its five
+  knowledge-check questions only for substantial changes; omit them for routine
+  non-trivial changes.
+
+Trivial edits may skip blindspot-pass and change-explainer, but they do not skip
+the linked-worktree-before-writing rule.
+
 ## Repository inspection
 
 Before substantial implementation, inspect what is relevant: source, tests,

--- a/ai/codex/install.sh
+++ b/ai/codex/install.sh
@@ -59,6 +59,17 @@ EOF
   log_success "Generated Codex config at $dst"
 }
 
+refresh_personal_plugin() {
+  local codex_home="$1"
+  if ! command_exists codex; then
+    log_warning "Codex CLI not found; skipping personal plugin refresh."
+    return 0
+  fi
+
+  CODEX_HOME="$codex_home" codex plugin add my@guarzo
+  log_success "Refreshed my@guarzo from the local marketplace."
+}
+
 main() {
   check_only=false
   if [[ "${1:-}" == "--check" ]]; then
@@ -76,12 +87,14 @@ main() {
     fi
     log_info "[dry-run] Would register the local marketplace at $MARKETPLACE_DIR"
     log_info "[dry-run] Would link $DOTFILES_ROOT/codex/AGENTS.md -> $codex_home/AGENTS.md"
+    log_info "[dry-run] Would refresh my@guarzo from the local marketplace"
     return
   fi
 
   mkdir -p "$codex_home"
   render_config "$codex_home"
   link_file "$DOTFILES_ROOT/codex/AGENTS.md" "$codex_home/AGENTS.md" "global AGENTS.md"
+  refresh_personal_plugin "$codex_home"
 }
 
 main "$@"

--- a/ai/marketplace/plugins/my/.codex-plugin/plugin.json
+++ b/ai/marketplace/plugins/my/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "my",
-  "version": "0.1.0+codex.20260712233106",
+  "version": "0.1.0+codex.20260719084910",
   "description": "Personal commands, skills, and agents",
   "author": {
     "name": "guarzo"

--- a/ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: blindspot-pass
-description: Inspect the relevant repository and surface hidden constraints and unknown unknowns before implementation — current understanding, confirmed constraints, likely blind spots, and the decisions that could materially change the approach. Use when the user explicitly asks for a blind-spot pass, a pre-implementation risk review, or "what am I missing" before building. Does not implement unless explicitly asked.
+description: Inspect the relevant repository and surface hidden constraints and unknown unknowns before implementation — current understanding, confirmed constraints, likely blind spots, and decisions that could materially change the approach. Use proactively during discovery for non-trivial work, after initial requirements are understood and before the design is locked in. Also use for explicit blind-spot, pre-implementation risk, or "what am I missing" requests.
 ---
 
 # Blind-spot pass
 
-Deliberate, read-only analysis run **before** implementation to expose hidden
-constraints and unknown unknowns. Do not implement the feature unless the user
-explicitly asks you to after seeing the findings.
+Read-only analysis run **during discovery**, before the design is locked in, to
+expose hidden constraints and unknown unknowns. The skill itself does not edit
+files or implement the feature.
+
+## Workflow modes
+
+- **Automatic workflow mode:** when the user has already requested the feature
+  or change, treat this analysis as a phase of that request. Summarize material
+  findings and continue into design for routine work. Pause only when an
+  unresolved high-impact decision involving architecture, public interfaces,
+  persisted data, migration, security, compatibility, deployment, or similarly
+  consequential behavior could materially change the implementation.
+- **Standalone mode:** when the user asks only for analysis, return the report
+  and stop without moving into design or implementation.
 
 ## Steps
 
@@ -38,7 +49,8 @@ Produce these sections:
   - the available evidence,
   - the likely options,
   - the consequence of choosing incorrectly.
-- **Recommended next step** — e.g. ask a specific high-impact question, run the
-  `implementation-plan` skill, prototype a spike, or proceed.
+- **Recommended next step** — ask a specific high-impact question only when the
+  risk-scaled pause rule applies; otherwise recommend proceeding into the normal
+  design workflow.
 
 Keep it evidence-based and concise. Separate confirmed facts from inferences.

--- a/ai/marketplace/plugins/my/skills/change-explainer/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/change-explainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-explainer
-description: Inspect the final diff, relevant code, tests, and implementation-notes.md, then produce a reviewer-facing explanation of a completed change — what changed, how it works, key decisions, deviations, edge cases, verification actually performed, where reviewers should focus, plus five knowledge-check questions. Use when the user explicitly asks to explain, write up, or summarize a completed change for review.
+description: Inspect the final diff, relevant code, tests, and implementation-notes.md, then produce a reviewer-facing explanation of a completed change — what changed, how it works, key decisions, deviations, edge cases, verification actually performed, and reviewer focus. Use proactively after polish and fresh verification for non-trivial work, before branch completion or a PR. Also use for explicit explanation, write-up, or review-summary requests. Include knowledge-check questions only for substantial changes.
 ---
 
 # Change explainer
@@ -16,6 +16,11 @@ claim on evidence you can see; never assert a check ran unless it actually did.
    fits and behaves.
 3. **Read `implementation-notes.md`** if present, for decisions, deviations, and
    unresolved risks recorded during the work.
+4. **Classify the change scope.** Treat work as substantial when it is
+   architectural, cross-cutting, security-sensitive, migration-related, changes
+   public interfaces or persisted data, affects deployment, or otherwise needs
+   deeper reviewer understanding. Other meaningful completed work is routine
+   non-trivial work.
 
 ## Output
 
@@ -30,6 +35,8 @@ claim on evidence you can see; never assert a check ran unless it actually did.
   results. For anything not run, state which check, why, and the remaining
   uncertainty.
 - **Reviewer focus** — the areas most worth scrutiny.
-- **Knowledge check** — exactly five questions about the change, without answers.
+- **Knowledge check** — For substantial changes, include exactly five questions
+  about the change, without answers. For routine non-trivial changes, omit the
+  knowledge check.
 
 Keep it accurate and specific. Do not hide uncertainty behind confident wording.

--- a/ai/marketplace/plugins/my/skills/polish-core/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/polish-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polish-core
-description: Review code changes since a commit, classify correctness and maintainability findings, optionally apply only high-confidence safe fixes, and report remaining issues. Use when the user asks to polish changed code, review a commit range, run a pre-PR quality pass, or invokes $my:polish-core.
+description: Review code changes since a commit, classify correctness and maintainability findings, apply only high-confidence safe fixes when enabled, and report remaining issues. Run proactively with --fix after non-trivial implementation, before fresh verification, change explanation, or branch completion. Also use for explicit polish, changed-code review, commit-range review, or pre-PR quality requests.
 ---
 
 # Polish — Review & Fix
@@ -10,6 +10,8 @@ You are performing a thorough analysis of all changes since a specified commit, 
 **Invocation input**: Interpret text supplied with the skill invocation or the user's surrounding request. When no commit reference is specified, default to all changes on the current branch: the merge-base between `HEAD` and the default branch (see Phase 0).
 
 Parse arguments:
+- When invoked proactively as the automatic post-implementation workflow phase,
+  set FIX_MODE=true unless the user explicitly requested report-only behavior.
 - If `--fix` is present (in any position), set FIX_MODE=true and remove it from the commit reference.
 - If `--path <prefix>` is present, set PATH_FILTER to the given prefix and remove both tokens from the arguments. This limits analysis to files under that directory.
 - Remaining argument is the commit reference (default: merge-base with the default branch).

--- a/docs/superpowers/plans/2026-07-19-feature-workflow-automation.md
+++ b/docs/superpowers/plans/2026-07-19-feature-workflow-automation.md
@@ -96,7 +96,25 @@ hooks.
    allowlist or a redundant SessionStart contract.
 4. Re-run the focused test and installer tests.
 
-## Task 5: Polish and Verify
+## Task 5: Refresh the Codex Plugin Cache
+
+**Files:**
+
+- Modify: `ai/codex/install.sh`
+- Modify: `ai/marketplace/plugins/my/.codex-plugin/plugin.json`
+- Extend: `tests/ai_installers.bats`
+
+1. Add a failing installer test requiring `codex plugin add my@guarzo` after
+   the local marketplace configuration is generated.
+2. Add a best-effort installer step that refreshes the plugin when the Codex CLI
+   is available and logs a warning when it is not.
+3. Use the plugin-creator cachebuster helper rather than hand-editing the
+   manifest version.
+4. Run an isolated real install with a temporary `CODEX_HOME` and confirm all
+   seven canonical skills, especially blindspot-pass, polish-core, and
+   change-explainer, exist in the installed cache.
+
+## Task 6: Polish and Verify
 
 1. Inspect the complete diff against `main` and compare it to the corrected
    spec.

--- a/docs/superpowers/plans/2026-07-19-feature-workflow-automation.md
+++ b/docs/superpowers/plans/2026-07-19-feature-workflow-automation.md
@@ -1,525 +1,111 @@
 # Feature-Workflow Automation Overlay Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task.
 
-**Goal:** Make the user's three personal skills (blindspot-pass, polish-core, change-explainer) fire automatically at the right phases of the superpowers workflow, and hard-enforce git-worktree use before any file edits.
+**Goal:** Automatically layer the personal blindspot, polish, and change-
+explanation phases around the Superpowers workflow, with linked-worktree use
+required before feature-related writes.
 
-**Architecture:** A PreToolUse hook script denies Edit/Write/NotebookEdit when the target file's repo is on its default branch (fail-open on errors, with allowlist + env-var escape hatches). A SessionStart hook injects a short workflow contract. Both are wired in the dotfiles-managed `ai/claude/settings.json` (already symlinked to `~/.claude/settings.json`). Skill `description:` frontmatter is rewritten from "when the user explicitly asks" to phase-based triggers.
+**Architecture:** Matching global guidance provides the cross-tool Claude/Codex
+policy. Shared personal-skill metadata and bodies define phase triggers and
+risk scaling. A Claude Code `PreToolUse` hook adds deterministic protection for
+Claude edit tools by detecting linked-worktree topology rather than branch
+names.
 
-**Tech Stack:** POSIX-ish bash, `jq`, git, Bats (existing `tests/` conventions via `test_helper.bash`), Claude Code hooks (PreToolUse JSON `permissionDecision`, SessionStart stdout-as-context).
+**Tech Stack:** Markdown skill/guidance files, Bash, `jq`, git, Bats, Claude Code
+hooks.
 
 **Spec:** `docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md`
 
-## Global Constraints
+## Constraints
 
-- The guard must **fail open**: any unexpected condition (no jq, no git, unparsable input, detached HEAD, not a repo) allows the edit. A broken hook must never lock the user out of editing.
-- Escape hatches (exact names): file `~/.claude/worktree-guard-allow` (one repo path per line, `~` allowed, `#` comments), and env `CLAUDE_WORKTREE_GUARD=off`.
-- Deny messages must name the remedy: create a worktree via `superpowers:using-git-worktrees`, or add the repo to `~/.claude/worktree-guard-allow`.
-- Do not modify any superpowers plugin file, nor the `/polish`, `/polish-pr`, `/fix-pr`, `/review-prs` commands.
-- No Stop-gate hook (explicitly out of scope).
-- Tests follow existing conventions: `#!/usr/bin/env bats`, `load test_helper`, `setup_dotfiles_test` (which sandboxes `$HOME` and sets `PATH="$STUB_BIN:/usr/bin:/bin"`). Run with `bats tests` (see `Makefile`).
+- Do not modify Superpowers plugin files.
+- Preserve the existing personal skill names and command wrappers.
+- Do not seed a permanent exemption for `~/.dotfiles`.
+- The hook must fail open on missing tools, invalid input, non-repositories, or
+  unexpected git errors.
+- Do not describe the Claude edit-tool hook as universal enforcement for shell
+  commands or Codex.
+- Preserve unrelated local changes in the primary checkout.
 
----
-
-### Task 1: Worktree guard hook
-
-**Files:**
-- Create: `ai/claude/hooks/worktree-guard.sh` (executable)
-- Test: `tests/worktree_guard.bats`
-
-**Interfaces:**
-- Consumes: PreToolUse stdin JSON: `{"tool_name": "...", "tool_input": {"file_path": "..."}}` (NotebookEdit uses `notebook_path`).
-- Produces: on deny, stdout JSON `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}` and exit 0; on allow, no output and exit 0. Task 3 wires this script's path into settings.json.
-
-- [ ] **Step 1: Write the failing tests**
-
-Create `tests/worktree_guard.bats` with exactly this content:
-
-```bash
-#!/usr/bin/env bats
-
-load test_helper
-
-setup() {
-  setup_dotfiles_test
-  GUARD="$REPO_ROOT/ai/claude/hooks/worktree-guard.sh"
-  REPO="$TEST_ROOT/repo"
-  mkdir -p "$REPO"
-  git -C "$REPO" init --quiet --initial-branch=main
-  git -C "$REPO" -c user.email=t@example.com -c user.name=t \
-    commit --quiet --allow-empty -m init
-  INPUT_FILE="$TEST_ROOT/input.json"
-}
-
-write_input() {
-  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' "$1" >"$INPUT_FILE"
-}
-
-@test "denies edit on the default branch" {
-  write_input "$REPO/file.txt"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *'"permissionDecision"'* ]]
-  [[ "$output" == *'"deny"'* ]]
-  [[ "$output" == *'worktree'* ]]
-}
-
-@test "allows edit on a feature branch" {
-  git -C "$REPO" checkout --quiet -b feature
-  write_input "$REPO/file.txt"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
-
-@test "allows edit outside any git repo" {
-  mkdir -p "$TEST_ROOT/plain"
-  write_input "$TEST_ROOT/plain/file.txt"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
-
-@test "allows repo listed in the allowlist" {
-  mkdir -p "$HOME/.claude"
-  printf '%s\n' "$REPO" >"$HOME/.claude/worktree-guard-allow"
-  write_input "$REPO/file.txt"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
-
-@test "allowlist supports tilde paths and comments" {
-  mkdir -p "$HOME/.claude" "$HOME/repo2"
-  git -C "$HOME/repo2" init --quiet --initial-branch=main
-  git -C "$HOME/repo2" -c user.email=t@example.com -c user.name=t \
-    commit --quiet --allow-empty -m init
-  printf '# comment\n~/repo2\n' >"$HOME/.claude/worktree-guard-allow"
-  write_input "$HOME/repo2/file.txt"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
-
-@test "allows when CLAUDE_WORKTREE_GUARD=off" {
-  write_input "$REPO/file.txt"
-  run env CLAUDE_WORKTREE_GUARD=off bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
-
-@test "allows on detached HEAD" {
-  git -C "$REPO" checkout --quiet --detach
-  write_input "$REPO/file.txt"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
-
-@test "fails open when jq is unavailable" {
-  write_input "$REPO/file.txt"
-  run env PATH="$STUB_BIN" bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
-
-@test "denies via notebook_path for NotebookEdit" {
-  printf '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"%s"}}' \
-    "$REPO/nb.ipynb" >"$INPUT_FILE"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *'"deny"'* ]]
-}
-
-@test "denies for a new file in a not-yet-created subdirectory" {
-  write_input "$REPO/newdir/sub/file.txt"
-  run bash "$GUARD" <"$INPUT_FILE"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *'"deny"'* ]]
-}
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `bats tests/worktree_guard.bats`
-Expected: all tests FAIL (guard script does not exist yet; `bash: .../worktree-guard.sh: No such file or directory`).
-
-- [ ] **Step 3: Implement the guard**
-
-Create `ai/claude/hooks/worktree-guard.sh`:
-
-```bash
-#!/usr/bin/env bash
-# PreToolUse hook: deny Edit/Write/NotebookEdit when the target file's repo is
-# checked out on its default branch, so implementation happens in a worktree.
-# Fails open: any unexpected condition allows the edit.
-set -u
-
-allow() { exit 0; }
-
-[ "${CLAUDE_WORKTREE_GUARD:-on}" = "off" ] && allow
-
-input=$(cat 2>/dev/null) || allow
-command -v jq >/dev/null 2>&1 || allow
-path=$(printf '%s' "$input" \
-  | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' \
-    2>/dev/null) || allow
-[ -n "$path" ] || allow
-
-# Nearest existing ancestor (the file or its directories may not exist yet).
-dir="$path"
-while [ ! -d "$dir" ]; do
-  parent=$(dirname "$dir")
-  [ "$parent" = "$dir" ] && allow
-  dir="$parent"
-done
-
-command -v git >/dev/null 2>&1 || allow
-repo_root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || allow
-repo_root=$(cd "$repo_root" && pwd -P) || allow
-
-allowfile="$HOME/.claude/worktree-guard-allow"
-if [ -f "$allowfile" ]; then
-  while IFS= read -r line; do
-    line="${line%%#*}"
-    line="${line#"${line%%[![:space:]]*}"}"
-    line="${line%"${line##*[![:space:]]}"}"
-    [ -n "$line" ] || continue
-    case "$line" in "~"*) line="$HOME${line#\~}" ;; esac
-    resolved=$(cd "$line" 2>/dev/null && pwd -P) || continue
-    [ "$resolved" = "$repo_root" ] && allow
-  done <"$allowfile"
-fi
-
-# Detached HEAD counts as "not on the default branch".
-branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || allow
-
-default=$(git -C "$dir" symbolic-ref --quiet --short \
-  refs/remotes/origin/HEAD 2>/dev/null || true)
-default=${default#origin/}
-if [ -z "$default" ]; then
-  if git -C "$dir" show-ref --verify --quiet refs/heads/main; then
-    default=main
-  elif git -C "$dir" show-ref --verify --quiet refs/heads/master; then
-    default=master
-  else
-    allow
-  fi
-fi
-
-[ "$branch" = "$default" ] || allow
-
-reason="Edits are blocked on the default branch ($default) of $repo_root. \
-Create a worktree first (superpowers:using-git-worktrees skill). If this repo \
-is intentionally edited on its default branch, add its path to \
-~/.claude/worktree-guard-allow."
-jq -n --arg r "$reason" \
-  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
-exit 0
-```
-
-Then: `chmod +x ai/claude/hooks/worktree-guard.sh`
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `bats tests/worktree_guard.bats`
-Expected: all 10 tests PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add ai/claude/hooks/worktree-guard.sh tests/worktree_guard.bats
-git commit -m "feat: add worktree-guard PreToolUse hook"
-```
-
----
-
-### Task 2: Workflow-contract SessionStart hook
+## Task 1: Correct Linked-Worktree Guard
 
 **Files:**
-- Create: `ai/claude/feature-workflow.md`
-- Create: `ai/claude/hooks/feature-workflow-contract.sh` (executable)
-- Test: `tests/worktree_guard.bats` → add contract tests to a new file `tests/feature_workflow_contract.bats`
 
-**Interfaces:**
-- Consumes: nothing (SessionStart hook; stdin ignored).
-- Produces: contract markdown on stdout, exit 0. Claude Code adds SessionStart stdout to session context. Task 3 wires the script path into settings.json.
+- Modify: `tests/worktree_guard.bats`
+- Modify: `ai/claude/hooks/worktree-guard.sh`
 
-- [ ] **Step 1: Write the failing test**
+1. Replace the feature-branch allowance test with a regression test proving a
+   feature branch in the primary checkout is denied.
+2. Add real `git worktree add` fixtures proving linked branch and detached
+   worktrees are allowed.
+3. Run `bats tests/worktree_guard.bats` and confirm the new primary-feature
+   regression fails against the existing branch-based implementation.
+4. Replace default-branch detection with resolved git-directory versus
+   common-directory comparison.
+5. Update the denial message to say the checkout is the primary worktree and
+   instruct the agent to use `superpowers:using-git-worktrees`.
+6. Run the focused Bats file and confirm all cases pass.
 
-Create `tests/feature_workflow_contract.bats`:
-
-```bash
-#!/usr/bin/env bats
-
-load test_helper
-
-setup() {
-  setup_dotfiles_test
-  HOOK="$REPO_ROOT/ai/claude/hooks/feature-workflow-contract.sh"
-}
-
-@test "prints the feature workflow contract" {
-  run bash "$HOOK"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"my:blindspot-pass"* ]]
-  [[ "$output" == *"my:polish-core --fix"* ]]
-  [[ "$output" == *"my:change-explainer"* ]]
-  [[ "$output" == *"worktree"* ]]
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `bats tests/feature_workflow_contract.bats`
-Expected: FAIL (hook script does not exist).
-
-- [ ] **Step 3: Write the contract and the hook**
-
-Create `ai/claude/feature-workflow.md`:
-
-```markdown
-## Feature workflow contract (user-defined, always applies)
-
-For non-trivial feature work, follow this pipeline without being asked:
-
-1. **Worktree before edits** — create one via superpowers:using-git-worktrees.
-   A PreToolUse hook hard-blocks Edit/Write on a repo's default branch.
-2. **my:blindspot-pass** — after brainstorming/requirements, before
-   superpowers:writing-plans or any substantial implementation.
-3. Implement per the superpowers workflow (plans, TDD, review).
-4. **my:polish-core --fix** — after implementation is complete, before any PR.
-5. **my:change-explainer** — after polish, before
-   superpowers:finishing-a-development-branch / opening a PR.
-
-Trivial changes (typos, one-line fixes, config tweaks) skip steps 2 and 5.
-These personal skills complement superpowers; do not skip them because a
-superpowers phase feels equivalent.
-```
-
-Create `ai/claude/hooks/feature-workflow-contract.sh`:
-
-```bash
-#!/usr/bin/env bash
-# SessionStart hook: inject the user's feature-workflow contract as context.
-set -u
-cat "$(cd "$(dirname "$0")/.." && pwd -P)/feature-workflow.md"
-```
-
-Then: `chmod +x ai/claude/hooks/feature-workflow-contract.sh`
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `bats tests/feature_workflow_contract.bats`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add ai/claude/feature-workflow.md ai/claude/hooks/feature-workflow-contract.sh tests/feature_workflow_contract.bats
-git commit -m "feat: add SessionStart feature-workflow contract hook"
-```
-
----
-
-### Task 3: Wire hooks into settings.json and seed the allowlist
+## Task 2: Add Shared Workflow Policy
 
 **Files:**
-- Modify: `ai/claude/settings.json` (add top-level `"hooks"` key)
-- Modify: `ai/claude/install.sh` (seed `~/.claude/worktree-guard-allow`)
-- Test: `tests/ai_installers.bats` conventions apply; add seeding test to `tests/feature_workflow_contract.bats`
 
-**Interfaces:**
-- Consumes: script paths from Tasks 1–2 (`$HOME/.dotfiles/ai/claude/hooks/worktree-guard.sh`, `$HOME/.dotfiles/ai/claude/hooks/feature-workflow-contract.sh`).
-- Produces: active hooks in every new Claude Code session; seeded allowlist exempting `~/.dotfiles`.
+- Modify: `ai/claude/CLAUDE.md`
+- Modify: `ai/codex/AGENTS.md`
+- Create: `tests/feature_workflow_policy.bats`
 
-- [ ] **Step 1: Seed the live allowlist FIRST (ordering matters)**
+1. Add a failing test that requires matching policy markers in both global
+   guidance files: worktree before writes, blindspot during discovery,
+   risk-scaled pause, polish with `--fix`, fresh verification, and conditional
+   knowledge checks.
+2. Run the focused test and confirm it fails before the guidance changes.
+3. Add substantially matching `Feature workflow` sections to both files.
+4. Run the focused test and `diff` the extracted sections to prevent drift.
 
-The settings symlink is live; once committed, new sessions enforce the guard. Seed the allowlist before wiring so future sessions in `~/.dotfiles` (edited on main by design) are never blocked:
-
-```bash
-mkdir -p "$HOME/.claude"
-grep -qxF "$HOME/.dotfiles" "$HOME/.claude/worktree-guard-allow" 2>/dev/null \
-  || printf '%s\n' "$HOME/.dotfiles" >>"$HOME/.claude/worktree-guard-allow"
-cat "$HOME/.claude/worktree-guard-allow"
-```
-
-Expected output includes: `/home/tng/.dotfiles`
-
-- [ ] **Step 2: Write the failing installer-seeding test**
-
-Append to `tests/feature_workflow_contract.bats`:
-
-```bash
-@test "install.sh seeds the worktree-guard allowlist with ~/.dotfiles" {
-  stub_command claude 'exit 0'
-  stub_command curl 'exit 0'
-  run env HOME="$HOME" bash "$REPO_ROOT/ai/claude/install.sh"
-  [ -f "$HOME/.claude/worktree-guard-allow" ]
-  grep -qxF "$HOME/.dotfiles" "$HOME/.claude/worktree-guard-allow"
-}
-
-@test "install.sh does not duplicate an existing allowlist entry" {
-  stub_command claude 'exit 0'
-  stub_command curl 'exit 0'
-  mkdir -p "$HOME/.claude"
-  printf '%s\n' "$HOME/.dotfiles" >"$HOME/.claude/worktree-guard-allow"
-  run env HOME="$HOME" bash "$REPO_ROOT/ai/claude/install.sh"
-  [ "$(grep -cxF "$HOME/.dotfiles" "$HOME/.claude/worktree-guard-allow")" -eq 1 ]
-}
-```
-
-Run: `bats tests/feature_workflow_contract.bats`
-Expected: the two new tests FAIL (no seeding logic in install.sh yet).
-
-- [ ] **Step 3: Add seeding to install.sh**
-
-In `ai/claude/install.sh`, add this function after `link_file()`:
-
-```bash
-seed_worktree_guard_allowlist() {
-  local allowfile="$HOME/.claude/worktree-guard-allow"
-  local entry="$HOME/.dotfiles"
-  if [[ "$check_only" == true ]]; then
-    log_info "[dry-run] Would ensure $entry is in $allowfile"
-    return 0
-  fi
-  mkdir -p "$HOME/.claude"
-  if ! grep -qxF "$entry" "$allowfile" 2>/dev/null; then
-    printf '%s\n' "$entry" >>"$allowfile"
-    log_success "Added $entry to worktree-guard allowlist."
-  fi
-}
-```
-
-And call it in `main()` immediately after the two existing `link_file` calls (both the normal path and, as a dry-run log line, it is already handled by the `check_only` branch inside the function — also add `seed_worktree_guard_allowlist` to the `--check` branch after the `link_file` dry-run call):
-
-```bash
-  link_file "$DOTFILES_ROOT/claude/settings.json" "$HOME/.claude/settings.json" "settings"
-  link_file "$DOTFILES_ROOT/claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md" "global CLAUDE.md"
-  seed_worktree_guard_allowlist
-```
-
-- [ ] **Step 4: Add the hooks key to settings.json**
-
-In `ai/claude/settings.json`, add this top-level key (sibling of `"permissions"`):
-
-```json
-"hooks": {
-  "PreToolUse": [
-    {
-      "matcher": "Edit|Write|NotebookEdit",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "$HOME/.dotfiles/ai/claude/hooks/worktree-guard.sh"
-        }
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "hooks": [
-        {
-          "type": "command",
-          "command": "$HOME/.dotfiles/ai/claude/hooks/feature-workflow-contract.sh"
-        }
-      ]
-    }
-  ]
-}
-```
-
-Validate: `jq . ai/claude/settings.json >/dev/null && echo OK`
-Expected: `OK`
-
-- [ ] **Step 5: Run the full test suite**
-
-Run: `bats tests`
-Expected: all tests PASS (new tests plus no regressions in `ai_installers.bats`, which snapshots `$HOME` — the seeding function writes under `$HOME/.claude`, so re-check `assert_check_is_immutable` still passes because the `--check` branch only logs).
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add ai/claude/settings.json ai/claude/install.sh tests/feature_workflow_contract.bats
-git commit -m "feat: wire worktree-guard and workflow-contract hooks into settings"
-```
-
----
-
-### Task 4: Rewrite skill trigger descriptions
+## Task 3: Update Personal Skill Phases
 
 **Files:**
-- Modify: `ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md:3`
-- Modify: `ai/marketplace/plugins/my/skills/polish-core/SKILL.md:3`
-- Modify: `ai/marketplace/plugins/my/skills/change-explainer/SKILL.md:3`
 
-**Interfaces:**
-- Consumes: nothing from other tasks.
-- Produces: phase-triggered descriptions matching the contract injected in Task 2 (skill names `my:blindspot-pass`, `my:polish-core`, `my:change-explainer` must stay unchanged).
+- Modify: `ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md`
+- Modify: `ai/marketplace/plugins/my/skills/polish-core/SKILL.md`
+- Modify: `ai/marketplace/plugins/my/skills/change-explainer/SKILL.md`
+- Extend: `tests/feature_workflow_policy.bats`
 
-- [ ] **Step 1: Rewrite blindspot-pass description**
+1. Add failing assertions for proactive phase triggers, the risk-scaled
+   blindspot rule, automatic `--fix`, and substantial-only knowledge checks.
+2. Run the focused test and confirm the new assertions fail.
+3. Rewrite the three descriptions and the minimum necessary body text.
+4. Keep standalone explicit invocations supported.
+5. Run the focused test and `bash bin/validate-ai --verbose`.
 
-Replace the `description:` line in `ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md` with:
+## Task 4: Register the Claude Guard
 
-```yaml
-description: Inspect the relevant repository and surface hidden constraints and unknown unknowns before implementation — current understanding, confirmed constraints, likely blind spots, and the decisions that could materially change the approach. Use proactively for any non-trivial feature: after requirements are understood (e.g. after brainstorming) and BEFORE writing an implementation plan or starting substantial implementation — do not wait to be asked. Also use when the user asks for a blind-spot pass, a pre-implementation risk review, or "what am I missing". Does not implement unless explicitly asked.
-```
+**Files:**
 
-- [ ] **Step 2: Rewrite polish-core description**
+- Modify: `ai/claude/settings.json`
+- Extend: `tests/feature_workflow_policy.bats`
 
-Replace the `description:` line in `ai/marketplace/plugins/my/skills/polish-core/SKILL.md` with:
+1. Add a failing test that validates the JSON and requires a `PreToolUse`
+   `Edit|Write|NotebookEdit` hook pointing at
+   `$HOME/.dotfiles/ai/claude/hooks/worktree-guard.sh`.
+2. Run the focused test and confirm it fails.
+3. Add only the hook registration to settings; do not add an installer-seeded
+   allowlist or a redundant SessionStart contract.
+4. Re-run the focused test and installer tests.
 
-```yaml
-description: Review code changes since a commit, classify correctness and maintainability findings, optionally apply only high-confidence safe fixes, and report remaining issues. Run proactively with --fix after completing non-trivial implementation work, before change-explainer or opening a PR — do not wait to be asked. Also use when the user asks to polish changed code, review a commit range, run a pre-PR quality pass, or invokes $my:polish-core.
-```
+## Task 5: Polish and Verify
 
-- [ ] **Step 3: Rewrite change-explainer description**
-
-Replace the `description:` line in `ai/marketplace/plugins/my/skills/change-explainer/SKILL.md` with:
-
-```yaml
-description: Inspect the final diff, relevant code, tests, and implementation-notes.md, then produce a reviewer-facing explanation of a completed change — what changed, how it works, key decisions, deviations, edge cases, verification actually performed, where reviewers should focus, plus five knowledge-check questions. Use proactively after completing a non-trivial change, after polish and before finishing the branch or opening a PR — do not wait to be asked. Also use when the user asks to explain, write up, or summarize a completed change for review.
-```
-
-- [ ] **Step 4: Verify frontmatter still parses**
-
-Run: `head -5 ai/marketplace/plugins/my/skills/*/SKILL.md | grep -c 'description:'`
-Expected: `7` (all seven skills still have exactly one description line; the three edited files each remain valid single-line YAML).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md ai/marketplace/plugins/my/skills/polish-core/SKILL.md ai/marketplace/plugins/my/skills/change-explainer/SKILL.md
-git commit -m "feat: phase-based auto-triggering for blindspot/polish/change-explainer skills"
-```
-
----
-
-### Task 5: Manual end-to-end verification
-
-**Files:** none (verification only)
-
-- [ ] **Step 1: Verify the guard against the live repo state**
-
-```bash
-printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' \
-  "$HOME/.dotfiles/README.md" | bash ai/claude/hooks/worktree-guard.sh
-```
-
-Expected: no output (allowed — `~/.dotfiles` is in the seeded allowlist).
-
-```bash
-printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' \
-  "$HOME/some-other-main-branch-repo/file" | bash ai/claude/hooks/worktree-guard.sh
-```
-
-Use any real repo checked out on main; expected: deny JSON naming the worktree remedy. If no second repo exists, create a throwaway one under `/tmp` per the bats setup and test against it.
-
-- [ ] **Step 2: Verify hooks register in a new session**
-
-Ask the user to start a fresh `claude` session and run `/hooks` (or check that the contract text appears in context). Expected: PreToolUse and SessionStart entries listed; contract visible at session start. This cannot be verified from inside the current session (hooks snapshot at session start).
-
-- [ ] **Step 3: Final suite + review**
-
-Run: `bats tests` → all PASS. Inspect `git log --oneline` for the four commits; inspect `git diff` vs the branch base against the spec's component list.
+1. Inspect the complete diff against `main` and compare it to the corrected
+   spec.
+2. Run `my:polish-core --fix` over the branch changes and review any edits or
+   deferred findings.
+3. Re-run focused tests after polish.
+4. Run `shfmt -d` for changed shell files, `bash bin/validate-ai --verbose`, and
+   `bats tests`.
+5. Check for accidental exemptions, stale branch-based language, placeholders,
+   debug output, and unrelated changes.
+6. Run `my:change-explainer`; this change is substantial, so include exactly
+   five knowledge-check questions.

--- a/docs/superpowers/plans/2026-07-19-feature-workflow-automation.md
+++ b/docs/superpowers/plans/2026-07-19-feature-workflow-automation.md
@@ -1,0 +1,525 @@
+# Feature-Workflow Automation Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the user's three personal skills (blindspot-pass, polish-core, change-explainer) fire automatically at the right phases of the superpowers workflow, and hard-enforce git-worktree use before any file edits.
+
+**Architecture:** A PreToolUse hook script denies Edit/Write/NotebookEdit when the target file's repo is on its default branch (fail-open on errors, with allowlist + env-var escape hatches). A SessionStart hook injects a short workflow contract. Both are wired in the dotfiles-managed `ai/claude/settings.json` (already symlinked to `~/.claude/settings.json`). Skill `description:` frontmatter is rewritten from "when the user explicitly asks" to phase-based triggers.
+
+**Tech Stack:** POSIX-ish bash, `jq`, git, Bats (existing `tests/` conventions via `test_helper.bash`), Claude Code hooks (PreToolUse JSON `permissionDecision`, SessionStart stdout-as-context).
+
+**Spec:** `docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md`
+
+## Global Constraints
+
+- The guard must **fail open**: any unexpected condition (no jq, no git, unparsable input, detached HEAD, not a repo) allows the edit. A broken hook must never lock the user out of editing.
+- Escape hatches (exact names): file `~/.claude/worktree-guard-allow` (one repo path per line, `~` allowed, `#` comments), and env `CLAUDE_WORKTREE_GUARD=off`.
+- Deny messages must name the remedy: create a worktree via `superpowers:using-git-worktrees`, or add the repo to `~/.claude/worktree-guard-allow`.
+- Do not modify any superpowers plugin file, nor the `/polish`, `/polish-pr`, `/fix-pr`, `/review-prs` commands.
+- No Stop-gate hook (explicitly out of scope).
+- Tests follow existing conventions: `#!/usr/bin/env bats`, `load test_helper`, `setup_dotfiles_test` (which sandboxes `$HOME` and sets `PATH="$STUB_BIN:/usr/bin:/bin"`). Run with `bats tests` (see `Makefile`).
+
+---
+
+### Task 1: Worktree guard hook
+
+**Files:**
+- Create: `ai/claude/hooks/worktree-guard.sh` (executable)
+- Test: `tests/worktree_guard.bats`
+
+**Interfaces:**
+- Consumes: PreToolUse stdin JSON: `{"tool_name": "...", "tool_input": {"file_path": "..."}}` (NotebookEdit uses `notebook_path`).
+- Produces: on deny, stdout JSON `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}` and exit 0; on allow, no output and exit 0. Task 3 wires this script's path into settings.json.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/worktree_guard.bats` with exactly this content:
+
+```bash
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  GUARD="$REPO_ROOT/ai/claude/hooks/worktree-guard.sh"
+  REPO="$TEST_ROOT/repo"
+  mkdir -p "$REPO"
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" -c user.email=t@example.com -c user.name=t \
+    commit --quiet --allow-empty -m init
+  INPUT_FILE="$TEST_ROOT/input.json"
+}
+
+write_input() {
+  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' "$1" >"$INPUT_FILE"
+}
+
+@test "denies edit on the default branch" {
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision"'* ]]
+  [[ "$output" == *'"deny"'* ]]
+  [[ "$output" == *'worktree'* ]]
+}
+
+@test "allows edit on a feature branch" {
+  git -C "$REPO" checkout --quiet -b feature
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows edit outside any git repo" {
+  mkdir -p "$TEST_ROOT/plain"
+  write_input "$TEST_ROOT/plain/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows repo listed in the allowlist" {
+  mkdir -p "$HOME/.claude"
+  printf '%s\n' "$REPO" >"$HOME/.claude/worktree-guard-allow"
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allowlist supports tilde paths and comments" {
+  mkdir -p "$HOME/.claude" "$HOME/repo2"
+  git -C "$HOME/repo2" init --quiet --initial-branch=main
+  git -C "$HOME/repo2" -c user.email=t@example.com -c user.name=t \
+    commit --quiet --allow-empty -m init
+  printf '# comment\n~/repo2\n' >"$HOME/.claude/worktree-guard-allow"
+  write_input "$HOME/repo2/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows when CLAUDE_WORKTREE_GUARD=off" {
+  write_input "$REPO/file.txt"
+  run env CLAUDE_WORKTREE_GUARD=off bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows on detached HEAD" {
+  git -C "$REPO" checkout --quiet --detach
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "fails open when jq is unavailable" {
+  write_input "$REPO/file.txt"
+  run env PATH="$STUB_BIN" bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "denies via notebook_path for NotebookEdit" {
+  printf '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"%s"}}' \
+    "$REPO/nb.ipynb" >"$INPUT_FILE"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+
+@test "denies for a new file in a not-yet-created subdirectory" {
+  write_input "$REPO/newdir/sub/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/worktree_guard.bats`
+Expected: all tests FAIL (guard script does not exist yet; `bash: .../worktree-guard.sh: No such file or directory`).
+
+- [ ] **Step 3: Implement the guard**
+
+Create `ai/claude/hooks/worktree-guard.sh`:
+
+```bash
+#!/usr/bin/env bash
+# PreToolUse hook: deny Edit/Write/NotebookEdit when the target file's repo is
+# checked out on its default branch, so implementation happens in a worktree.
+# Fails open: any unexpected condition allows the edit.
+set -u
+
+allow() { exit 0; }
+
+[ "${CLAUDE_WORKTREE_GUARD:-on}" = "off" ] && allow
+
+input=$(cat 2>/dev/null) || allow
+command -v jq >/dev/null 2>&1 || allow
+path=$(printf '%s' "$input" \
+  | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' \
+    2>/dev/null) || allow
+[ -n "$path" ] || allow
+
+# Nearest existing ancestor (the file or its directories may not exist yet).
+dir="$path"
+while [ ! -d "$dir" ]; do
+  parent=$(dirname "$dir")
+  [ "$parent" = "$dir" ] && allow
+  dir="$parent"
+done
+
+command -v git >/dev/null 2>&1 || allow
+repo_root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || allow
+repo_root=$(cd "$repo_root" && pwd -P) || allow
+
+allowfile="$HOME/.claude/worktree-guard-allow"
+if [ -f "$allowfile" ]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] || continue
+    case "$line" in "~"*) line="$HOME${line#\~}" ;; esac
+    resolved=$(cd "$line" 2>/dev/null && pwd -P) || continue
+    [ "$resolved" = "$repo_root" ] && allow
+  done <"$allowfile"
+fi
+
+# Detached HEAD counts as "not on the default branch".
+branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || allow
+
+default=$(git -C "$dir" symbolic-ref --quiet --short \
+  refs/remotes/origin/HEAD 2>/dev/null || true)
+default=${default#origin/}
+if [ -z "$default" ]; then
+  if git -C "$dir" show-ref --verify --quiet refs/heads/main; then
+    default=main
+  elif git -C "$dir" show-ref --verify --quiet refs/heads/master; then
+    default=master
+  else
+    allow
+  fi
+fi
+
+[ "$branch" = "$default" ] || allow
+
+reason="Edits are blocked on the default branch ($default) of $repo_root. \
+Create a worktree first (superpowers:using-git-worktrees skill). If this repo \
+is intentionally edited on its default branch, add its path to \
+~/.claude/worktree-guard-allow."
+jq -n --arg r "$reason" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+exit 0
+```
+
+Then: `chmod +x ai/claude/hooks/worktree-guard.sh`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bats tests/worktree_guard.bats`
+Expected: all 10 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai/claude/hooks/worktree-guard.sh tests/worktree_guard.bats
+git commit -m "feat: add worktree-guard PreToolUse hook"
+```
+
+---
+
+### Task 2: Workflow-contract SessionStart hook
+
+**Files:**
+- Create: `ai/claude/feature-workflow.md`
+- Create: `ai/claude/hooks/feature-workflow-contract.sh` (executable)
+- Test: `tests/worktree_guard.bats` → add contract tests to a new file `tests/feature_workflow_contract.bats`
+
+**Interfaces:**
+- Consumes: nothing (SessionStart hook; stdin ignored).
+- Produces: contract markdown on stdout, exit 0. Claude Code adds SessionStart stdout to session context. Task 3 wires the script path into settings.json.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/feature_workflow_contract.bats`:
+
+```bash
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  HOOK="$REPO_ROOT/ai/claude/hooks/feature-workflow-contract.sh"
+}
+
+@test "prints the feature workflow contract" {
+  run bash "$HOOK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"my:blindspot-pass"* ]]
+  [[ "$output" == *"my:polish-core --fix"* ]]
+  [[ "$output" == *"my:change-explainer"* ]]
+  [[ "$output" == *"worktree"* ]]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/feature_workflow_contract.bats`
+Expected: FAIL (hook script does not exist).
+
+- [ ] **Step 3: Write the contract and the hook**
+
+Create `ai/claude/feature-workflow.md`:
+
+```markdown
+## Feature workflow contract (user-defined, always applies)
+
+For non-trivial feature work, follow this pipeline without being asked:
+
+1. **Worktree before edits** — create one via superpowers:using-git-worktrees.
+   A PreToolUse hook hard-blocks Edit/Write on a repo's default branch.
+2. **my:blindspot-pass** — after brainstorming/requirements, before
+   superpowers:writing-plans or any substantial implementation.
+3. Implement per the superpowers workflow (plans, TDD, review).
+4. **my:polish-core --fix** — after implementation is complete, before any PR.
+5. **my:change-explainer** — after polish, before
+   superpowers:finishing-a-development-branch / opening a PR.
+
+Trivial changes (typos, one-line fixes, config tweaks) skip steps 2 and 5.
+These personal skills complement superpowers; do not skip them because a
+superpowers phase feels equivalent.
+```
+
+Create `ai/claude/hooks/feature-workflow-contract.sh`:
+
+```bash
+#!/usr/bin/env bash
+# SessionStart hook: inject the user's feature-workflow contract as context.
+set -u
+cat "$(cd "$(dirname "$0")/.." && pwd -P)/feature-workflow.md"
+```
+
+Then: `chmod +x ai/claude/hooks/feature-workflow-contract.sh`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bats tests/feature_workflow_contract.bats`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai/claude/feature-workflow.md ai/claude/hooks/feature-workflow-contract.sh tests/feature_workflow_contract.bats
+git commit -m "feat: add SessionStart feature-workflow contract hook"
+```
+
+---
+
+### Task 3: Wire hooks into settings.json and seed the allowlist
+
+**Files:**
+- Modify: `ai/claude/settings.json` (add top-level `"hooks"` key)
+- Modify: `ai/claude/install.sh` (seed `~/.claude/worktree-guard-allow`)
+- Test: `tests/ai_installers.bats` conventions apply; add seeding test to `tests/feature_workflow_contract.bats`
+
+**Interfaces:**
+- Consumes: script paths from Tasks 1–2 (`$HOME/.dotfiles/ai/claude/hooks/worktree-guard.sh`, `$HOME/.dotfiles/ai/claude/hooks/feature-workflow-contract.sh`).
+- Produces: active hooks in every new Claude Code session; seeded allowlist exempting `~/.dotfiles`.
+
+- [ ] **Step 1: Seed the live allowlist FIRST (ordering matters)**
+
+The settings symlink is live; once committed, new sessions enforce the guard. Seed the allowlist before wiring so future sessions in `~/.dotfiles` (edited on main by design) are never blocked:
+
+```bash
+mkdir -p "$HOME/.claude"
+grep -qxF "$HOME/.dotfiles" "$HOME/.claude/worktree-guard-allow" 2>/dev/null \
+  || printf '%s\n' "$HOME/.dotfiles" >>"$HOME/.claude/worktree-guard-allow"
+cat "$HOME/.claude/worktree-guard-allow"
+```
+
+Expected output includes: `/home/tng/.dotfiles`
+
+- [ ] **Step 2: Write the failing installer-seeding test**
+
+Append to `tests/feature_workflow_contract.bats`:
+
+```bash
+@test "install.sh seeds the worktree-guard allowlist with ~/.dotfiles" {
+  stub_command claude 'exit 0'
+  stub_command curl 'exit 0'
+  run env HOME="$HOME" bash "$REPO_ROOT/ai/claude/install.sh"
+  [ -f "$HOME/.claude/worktree-guard-allow" ]
+  grep -qxF "$HOME/.dotfiles" "$HOME/.claude/worktree-guard-allow"
+}
+
+@test "install.sh does not duplicate an existing allowlist entry" {
+  stub_command claude 'exit 0'
+  stub_command curl 'exit 0'
+  mkdir -p "$HOME/.claude"
+  printf '%s\n' "$HOME/.dotfiles" >"$HOME/.claude/worktree-guard-allow"
+  run env HOME="$HOME" bash "$REPO_ROOT/ai/claude/install.sh"
+  [ "$(grep -cxF "$HOME/.dotfiles" "$HOME/.claude/worktree-guard-allow")" -eq 1 ]
+}
+```
+
+Run: `bats tests/feature_workflow_contract.bats`
+Expected: the two new tests FAIL (no seeding logic in install.sh yet).
+
+- [ ] **Step 3: Add seeding to install.sh**
+
+In `ai/claude/install.sh`, add this function after `link_file()`:
+
+```bash
+seed_worktree_guard_allowlist() {
+  local allowfile="$HOME/.claude/worktree-guard-allow"
+  local entry="$HOME/.dotfiles"
+  if [[ "$check_only" == true ]]; then
+    log_info "[dry-run] Would ensure $entry is in $allowfile"
+    return 0
+  fi
+  mkdir -p "$HOME/.claude"
+  if ! grep -qxF "$entry" "$allowfile" 2>/dev/null; then
+    printf '%s\n' "$entry" >>"$allowfile"
+    log_success "Added $entry to worktree-guard allowlist."
+  fi
+}
+```
+
+And call it in `main()` immediately after the two existing `link_file` calls (both the normal path and, as a dry-run log line, it is already handled by the `check_only` branch inside the function — also add `seed_worktree_guard_allowlist` to the `--check` branch after the `link_file` dry-run call):
+
+```bash
+  link_file "$DOTFILES_ROOT/claude/settings.json" "$HOME/.claude/settings.json" "settings"
+  link_file "$DOTFILES_ROOT/claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md" "global CLAUDE.md"
+  seed_worktree_guard_allowlist
+```
+
+- [ ] **Step 4: Add the hooks key to settings.json**
+
+In `ai/claude/settings.json`, add this top-level key (sibling of `"permissions"`):
+
+```json
+"hooks": {
+  "PreToolUse": [
+    {
+      "matcher": "Edit|Write|NotebookEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "$HOME/.dotfiles/ai/claude/hooks/worktree-guard.sh"
+        }
+      ]
+    }
+  ],
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "$HOME/.dotfiles/ai/claude/hooks/feature-workflow-contract.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Validate: `jq . ai/claude/settings.json >/dev/null && echo OK`
+Expected: `OK`
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `bats tests`
+Expected: all tests PASS (new tests plus no regressions in `ai_installers.bats`, which snapshots `$HOME` — the seeding function writes under `$HOME/.claude`, so re-check `assert_check_is_immutable` still passes because the `--check` branch only logs).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ai/claude/settings.json ai/claude/install.sh tests/feature_workflow_contract.bats
+git commit -m "feat: wire worktree-guard and workflow-contract hooks into settings"
+```
+
+---
+
+### Task 4: Rewrite skill trigger descriptions
+
+**Files:**
+- Modify: `ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md:3`
+- Modify: `ai/marketplace/plugins/my/skills/polish-core/SKILL.md:3`
+- Modify: `ai/marketplace/plugins/my/skills/change-explainer/SKILL.md:3`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: phase-triggered descriptions matching the contract injected in Task 2 (skill names `my:blindspot-pass`, `my:polish-core`, `my:change-explainer` must stay unchanged).
+
+- [ ] **Step 1: Rewrite blindspot-pass description**
+
+Replace the `description:` line in `ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md` with:
+
+```yaml
+description: Inspect the relevant repository and surface hidden constraints and unknown unknowns before implementation — current understanding, confirmed constraints, likely blind spots, and the decisions that could materially change the approach. Use proactively for any non-trivial feature: after requirements are understood (e.g. after brainstorming) and BEFORE writing an implementation plan or starting substantial implementation — do not wait to be asked. Also use when the user asks for a blind-spot pass, a pre-implementation risk review, or "what am I missing". Does not implement unless explicitly asked.
+```
+
+- [ ] **Step 2: Rewrite polish-core description**
+
+Replace the `description:` line in `ai/marketplace/plugins/my/skills/polish-core/SKILL.md` with:
+
+```yaml
+description: Review code changes since a commit, classify correctness and maintainability findings, optionally apply only high-confidence safe fixes, and report remaining issues. Run proactively with --fix after completing non-trivial implementation work, before change-explainer or opening a PR — do not wait to be asked. Also use when the user asks to polish changed code, review a commit range, run a pre-PR quality pass, or invokes $my:polish-core.
+```
+
+- [ ] **Step 3: Rewrite change-explainer description**
+
+Replace the `description:` line in `ai/marketplace/plugins/my/skills/change-explainer/SKILL.md` with:
+
+```yaml
+description: Inspect the final diff, relevant code, tests, and implementation-notes.md, then produce a reviewer-facing explanation of a completed change — what changed, how it works, key decisions, deviations, edge cases, verification actually performed, where reviewers should focus, plus five knowledge-check questions. Use proactively after completing a non-trivial change, after polish and before finishing the branch or opening a PR — do not wait to be asked. Also use when the user asks to explain, write up, or summarize a completed change for review.
+```
+
+- [ ] **Step 4: Verify frontmatter still parses**
+
+Run: `head -5 ai/marketplace/plugins/my/skills/*/SKILL.md | grep -c 'description:'`
+Expected: `7` (all seven skills still have exactly one description line; the three edited files each remain valid single-line YAML).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md ai/marketplace/plugins/my/skills/polish-core/SKILL.md ai/marketplace/plugins/my/skills/change-explainer/SKILL.md
+git commit -m "feat: phase-based auto-triggering for blindspot/polish/change-explainer skills"
+```
+
+---
+
+### Task 5: Manual end-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Verify the guard against the live repo state**
+
+```bash
+printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' \
+  "$HOME/.dotfiles/README.md" | bash ai/claude/hooks/worktree-guard.sh
+```
+
+Expected: no output (allowed — `~/.dotfiles` is in the seeded allowlist).
+
+```bash
+printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' \
+  "$HOME/some-other-main-branch-repo/file" | bash ai/claude/hooks/worktree-guard.sh
+```
+
+Use any real repo checked out on main; expected: deny JSON naming the worktree remedy. If no second repo exists, create a throwaway one under `/tmp` per the bats setup and test against it.
+
+- [ ] **Step 2: Verify hooks register in a new session**
+
+Ask the user to start a fresh `claude` session and run `/hooks` (or check that the contract text appears in context). Expected: PreToolUse and SessionStart entries listed; contract visible at session start. This cannot be verified from inside the current session (hooks snapshot at session start).
+
+- [ ] **Step 3: Final suite + review**
+
+Run: `bats tests` → all PASS. Inspect `git log --oneline` for the four commits; inspect `git diff` vs the branch base against the spec's component list.

--- a/docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md
+++ b/docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md
@@ -1,116 +1,132 @@
-# Feature-workflow automation overlay — design
+# Feature-Workflow Automation Overlay — Design
 
 **Date:** 2026-07-19
-**Status:** Approved
+**Status:** Approved with corrections
 
 ## Problem
 
-In a normal feature session the user must manually ask for the same steps every
-time: `my:blindspot-pass` before implementation, `my:polish-core` and
-`my:change-explainer` after, and creating a git worktree before edits. The
-skills never auto-fire because their descriptions restrict them to "when the
-user explicitly asks", and nothing enforces worktree use.
+Normal feature work repeatedly requires the same manual prompts: create a linked
+git worktree before writing, run `my:blindspot-pass` during discovery, run
+`my:polish-core --fix` after implementation, verify again, and finish with
+`my:change-explainer`. The personal skill descriptions currently make those
+steps mostly opt-in, and the global guidance does not define their exact place
+in the Superpowers lifecycle.
 
 ## Goal
 
-Superpowers keeps providing the spine (brainstorming → writing-plans →
-implementation → finishing-a-development-branch). This overlay makes the three
-personal skills fire at the correct phases without being asked, and makes
-worktree use a hard guarantee rather than a convention.
+Keep Superpowers as the workflow spine while adding a shared personal policy:
 
-Superpowers is not replaced or modified. `/using-superpowers` remains
-auto-injected at SessionStart by the plugin; typing it stays optional.
+```text
+inspect and clarify
+→ enter a linked worktree before the first feature-related write
+→ run a risk-scaled blind-spot pass during discovery
+→ use the normal Superpowers design, planning, TDD, and review flow
+→ run my:polish-core --fix
+→ re-run relevant verification
+→ explain the completed change
+→ finish the development branch
+```
+
+The overlay must work as guidance in both Claude Code and Codex. Claude Code
+also gets a deterministic edit-tool guard. Superpowers plugin files remain
+unchanged.
 
 ## Components
 
-### 1. Worktree guard (hard enforcement)
+### 1. Shared Workflow Policy
 
-- New executable `ai/claude/hooks/worktree-guard.sh`.
-- Wired in `ai/claude/settings.json` (symlinked to `~/.claude/settings.json`)
-  as a **PreToolUse** hook matching `Edit|Write|NotebookEdit`.
-- Behavior per invocation:
-  1. Resolve the target file path from the tool input; find the git repository
-     containing it (or the cwd when no file path applies).
-  2. If the path is not inside a git work tree → **allow** (scratchpad,
-     `~/.claude` memory, etc.).
-  3. Determine the repo's default branch: `git symbolic-ref
-     refs/remotes/origin/HEAD` (strip `origin/`), falling back to `main` if it
-     exists, else `master`.
-  4. If the currently checked-out branch equals the default branch → **deny**
-     (PreToolUse `permissionDecision: deny`) with a message instructing Claude
-     to create a worktree first via `superpowers:using-git-worktrees`.
-  5. Otherwise → allow.
-- Escape hatches:
-  - `~/.claude/worktree-guard-allow`: one repo path per line; listed repos are
-    always allowed. Seeded with `~/.dotfiles` (edited directly on main by
-    design).
-  - `CLAUDE_WORKTREE_GUARD=off` disables the guard for a session.
-- Tested with bats in `tests/` following existing test conventions
-  (`tests/*.bats`).
+Add matching feature-workflow sections to `ai/claude/CLAUDE.md` and
+`ai/codex/AGENTS.md`.
 
-### 2. Skill description rewrites (auto-triggering)
+The policy requires:
 
-Rewrite the `description:` frontmatter of three skills under
-`ai/marketplace/plugins/my/skills/` so they trigger on workflow phase instead
-of explicit request:
+- Repository inspection and clarification may happen in the current checkout.
+- Before writing a spec, plan, source, test, config, or documentation for new
+  work, enter a linked worktree using `superpowers:using-git-worktrees`.
+- If already inside a linked worktree, reuse it rather than nesting another.
+- Run `my:blindspot-pass` after initial discovery and requirements clarification,
+  but before presenting or locking in the design. This placement avoids
+  conflicting with the Superpowers rule that `writing-plans` follows an
+  approved brainstorming spec.
+- For routine work, summarize blind-spot findings and continue. Pause only when
+  unresolved architecture, public-interface, data, migration, security,
+  compatibility, deployment, or similarly high-impact decisions could change
+  the implementation materially.
+- After implementation, run `my:polish-core --fix`, then re-run affected tests
+  and other relevant verification before making completion claims.
+- Run `my:change-explainer` for non-trivial completed work. Include its five
+  knowledge-check questions only for substantial changes.
 
-- **blindspot-pass** — trigger after requirements are understood (e.g. after
-  brainstorming) and before writing an implementation plan or starting
-  substantial implementation; run proactively without being asked. Explicit
-  requests still trigger it.
-- **polish-core** — additionally trigger proactively with `--fix` after
-  completing implementation, before change-explainer or a PR.
-- **change-explainer** — trigger after completing a non-trivial change, before
-  finishing the branch or opening a PR; run proactively.
+### 2. Personal Skill Trigger and Behavior Updates
 
-Skill bodies are unchanged except where a sentence assumes explicit invocation.
+Update the shared personal skills under `ai/marketplace/plugins/my/skills/`:
 
-### 3. Injected workflow contract
+- `blindspot-pass`: trigger proactively during discovery for non-trivial work;
+  distinguish automatic workflow use from a standalone read-only request; and
+  encode the risk-scaled pause rule.
+- `polish-core`: trigger proactively with `--fix` after non-trivial
+  implementation and before final verification or branch completion.
+- `change-explainer`: trigger proactively after polish and verification; make
+  the knowledge check conditional on substantial scope.
 
-- New `ai/claude/hooks/feature-workflow-contract.sh` wired as a **SessionStart**
-  hook in `ai/claude/settings.json`, emitting a ~10-line contract as
-  additional context (same mechanism superpowers uses):
+These descriptions are shared by Claude Code and Codex through the `my` plugin.
 
-  > For non-trivial feature work: worktree before edits (hook-enforced) →
-  > `my:blindspot-pass` between brainstorming and writing-plans → implement →
-  > `my:polish-core --fix` → `my:change-explainer` →
-  > `superpowers:finishing-a-development-branch`. Trivial changes (typos,
-  > small fixes) skip blindspot-pass and change-explainer.
+### 3. Claude Linked-Worktree Guard
 
-- Contract text lives in `ai/claude/feature-workflow.md` so it can be edited
-  without touching the script.
+Add `ai/claude/hooks/worktree-guard.sh` as a Claude Code `PreToolUse` hook for
+`Edit|Write|NotebookEdit`.
 
-## Decisions
+The guard determines whether the target repository checkout is a linked
+worktree by comparing its resolved git directory and common git directory:
 
-- **Polish runs with `--fix`** in the pipeline (matches `my:polish-pr`
-  behavior), not report-only.
-- **Scaling rule:** trivial changes skip blindspot-pass and change-explainer,
-  mirroring the global CLAUDE.md "scale the workflow to the task" principle.
-- **Extend superpowers, don't wrap it:** no `/feature` orchestrator command; the
-  overlay hooks into phases superpowers already sequences.
-- **Two reinforcing soft signals** (descriptions + injected contract) for skill
-  triggering; hard enforcement only for the worktree rule, where a
-  deterministic hook is possible.
+- Primary checkout: git directory equals common directory → deny.
+- Linked worktree: git directory differs from common directory → allow,
+  regardless of branch name or detached-HEAD state.
+- Outside a git repository or on an unexpected detection error → allow.
 
-## Error handling
+This intentionally checks worktree topology rather than branch names. A feature
+branch in the primary checkout is still denied, while a detached linked
+worktree is allowed.
 
-- The guard fails **open** on unexpected errors (e.g. git not available,
-  detached HEAD): a broken hook must not lock the user out of editing. Detached
-  HEAD counts as "not on the default branch" → allow.
-- Deny messages must name the exact remedy (create a worktree; or add the repo
-  to `~/.claude/worktree-guard-allow` if it is intentionally edited on its
-  default branch).
+Escape hatches remain available for exceptional recovery:
 
-## Testing / verification
+- `CLAUDE_WORKTREE_GUARD=off` disables the guard for one process/session.
+- `~/.claude/worktree-guard-allow` may list explicitly exempted repository
+  roots, with `~` expansion and `#` comments.
 
-- Bats tests for `worktree-guard.sh`: deny on default branch, allow on feature
-  branch, allow outside a repo, allow via allowlist, allow via env var,
-  fail-open on git errors.
-- Manual: start a new session, confirm the contract appears; attempt an edit on
-  a main-branch repo, confirm denial message; confirm ~/.dotfiles is exempt.
+The installer does not seed exemptions. In particular, `~/.dotfiles` is not
+automatically exempted.
 
-## Out of scope
+The hook is a strong Claude edit-tool guard, not a universal filesystem
+sandbox: shell commands and Codex are governed by the shared workflow policy.
+The implementation and documentation must not claim otherwise.
 
-- No Stop-gate hook forcing polish/change-explainer before ending a turn.
-- No changes to superpowers plugin files or its SessionStart injection.
-- No changes to the `/polish`, `/polish-pr`, `/fix-pr`, `/review-prs` commands.
+## Scaling Rules
+
+- **Trivial:** typo-only or similarly mechanical edits still require a linked
+  worktree before writing, but may skip blindspot-pass and change-explainer.
+- **Routine non-trivial:** run all phases, continue automatically after a concise
+  blind-spot summary, and omit knowledge-check questions.
+- **Substantial or high-risk:** run all phases, pause on material unresolved
+  decisions, and include exactly five knowledge-check questions in the final
+  explanation.
+
+## Verification
+
+- Bats tests prove that primary checkouts are denied even on feature branches.
+- Bats tests prove that linked worktrees are allowed on branches and detached
+  HEADs.
+- Existing allowlist, environment override, new-file, notebook, outside-repo,
+  and fail-open cases remain covered.
+- Tests verify the Claude hook registration and the presence of matching policy
+  markers in both global guidance files.
+- Run focused Bats tests, `bash bin/validate-ai --verbose`, formatting/linting,
+  and the full `bats tests` suite.
+
+## Out of Scope
+
+- Modifying or forking the Superpowers plugin.
+- Pretending Claude hooks can hard-enforce writes made through arbitrary shell
+  commands or other tools.
+- A `/feature` command or separate orchestrator that duplicates Superpowers.
+- A Stop hook that prevents a session from ending.

--- a/docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md
+++ b/docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md
@@ -1,0 +1,116 @@
+# Feature-workflow automation overlay — design
+
+**Date:** 2026-07-19
+**Status:** Approved
+
+## Problem
+
+In a normal feature session the user must manually ask for the same steps every
+time: `my:blindspot-pass` before implementation, `my:polish-core` and
+`my:change-explainer` after, and creating a git worktree before edits. The
+skills never auto-fire because their descriptions restrict them to "when the
+user explicitly asks", and nothing enforces worktree use.
+
+## Goal
+
+Superpowers keeps providing the spine (brainstorming → writing-plans →
+implementation → finishing-a-development-branch). This overlay makes the three
+personal skills fire at the correct phases without being asked, and makes
+worktree use a hard guarantee rather than a convention.
+
+Superpowers is not replaced or modified. `/using-superpowers` remains
+auto-injected at SessionStart by the plugin; typing it stays optional.
+
+## Components
+
+### 1. Worktree guard (hard enforcement)
+
+- New executable `ai/claude/hooks/worktree-guard.sh`.
+- Wired in `ai/claude/settings.json` (symlinked to `~/.claude/settings.json`)
+  as a **PreToolUse** hook matching `Edit|Write|NotebookEdit`.
+- Behavior per invocation:
+  1. Resolve the target file path from the tool input; find the git repository
+     containing it (or the cwd when no file path applies).
+  2. If the path is not inside a git work tree → **allow** (scratchpad,
+     `~/.claude` memory, etc.).
+  3. Determine the repo's default branch: `git symbolic-ref
+     refs/remotes/origin/HEAD` (strip `origin/`), falling back to `main` if it
+     exists, else `master`.
+  4. If the currently checked-out branch equals the default branch → **deny**
+     (PreToolUse `permissionDecision: deny`) with a message instructing Claude
+     to create a worktree first via `superpowers:using-git-worktrees`.
+  5. Otherwise → allow.
+- Escape hatches:
+  - `~/.claude/worktree-guard-allow`: one repo path per line; listed repos are
+    always allowed. Seeded with `~/.dotfiles` (edited directly on main by
+    design).
+  - `CLAUDE_WORKTREE_GUARD=off` disables the guard for a session.
+- Tested with bats in `tests/` following existing test conventions
+  (`tests/*.bats`).
+
+### 2. Skill description rewrites (auto-triggering)
+
+Rewrite the `description:` frontmatter of three skills under
+`ai/marketplace/plugins/my/skills/` so they trigger on workflow phase instead
+of explicit request:
+
+- **blindspot-pass** — trigger after requirements are understood (e.g. after
+  brainstorming) and before writing an implementation plan or starting
+  substantial implementation; run proactively without being asked. Explicit
+  requests still trigger it.
+- **polish-core** — additionally trigger proactively with `--fix` after
+  completing implementation, before change-explainer or a PR.
+- **change-explainer** — trigger after completing a non-trivial change, before
+  finishing the branch or opening a PR; run proactively.
+
+Skill bodies are unchanged except where a sentence assumes explicit invocation.
+
+### 3. Injected workflow contract
+
+- New `ai/claude/hooks/feature-workflow-contract.sh` wired as a **SessionStart**
+  hook in `ai/claude/settings.json`, emitting a ~10-line contract as
+  additional context (same mechanism superpowers uses):
+
+  > For non-trivial feature work: worktree before edits (hook-enforced) →
+  > `my:blindspot-pass` between brainstorming and writing-plans → implement →
+  > `my:polish-core --fix` → `my:change-explainer` →
+  > `superpowers:finishing-a-development-branch`. Trivial changes (typos,
+  > small fixes) skip blindspot-pass and change-explainer.
+
+- Contract text lives in `ai/claude/feature-workflow.md` so it can be edited
+  without touching the script.
+
+## Decisions
+
+- **Polish runs with `--fix`** in the pipeline (matches `my:polish-pr`
+  behavior), not report-only.
+- **Scaling rule:** trivial changes skip blindspot-pass and change-explainer,
+  mirroring the global CLAUDE.md "scale the workflow to the task" principle.
+- **Extend superpowers, don't wrap it:** no `/feature` orchestrator command; the
+  overlay hooks into phases superpowers already sequences.
+- **Two reinforcing soft signals** (descriptions + injected contract) for skill
+  triggering; hard enforcement only for the worktree rule, where a
+  deterministic hook is possible.
+
+## Error handling
+
+- The guard fails **open** on unexpected errors (e.g. git not available,
+  detached HEAD): a broken hook must not lock the user out of editing. Detached
+  HEAD counts as "not on the default branch" → allow.
+- Deny messages must name the exact remedy (create a worktree; or add the repo
+  to `~/.claude/worktree-guard-allow` if it is intentionally edited on its
+  default branch).
+
+## Testing / verification
+
+- Bats tests for `worktree-guard.sh`: deny on default branch, allow on feature
+  branch, allow outside a repo, allow via allowlist, allow via env var,
+  fail-open on git errors.
+- Manual: start a new session, confirm the contract appears; attempt an edit on
+  a main-branch repo, confirm denial message; confirm ~/.dotfiles is exempt.
+
+## Out of scope
+
+- No Stop-gate hook forcing polish/change-explainer before ending a turn.
+- No changes to superpowers plugin files or its SessionStart injection.
+- No changes to the `/polish`, `/polish-pr`, `/fix-pr`, `/review-prs` commands.

--- a/docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md
+++ b/docs/superpowers/specs/2026-07-19-feature-workflow-automation-design.md
@@ -70,6 +70,11 @@ Update the shared personal skills under `ai/marketplace/plugins/my/skills/`:
   the knowledge check conditional on substantial scope.
 
 These descriptions are shared by Claude Code and Codex through the `my` plugin.
+Because Codex installs local plugins into a versioned cache, changing canonical
+skill files is not sufficient by itself: the plugin manifest needs a fresh
+Codex cachebuster, and `ai/codex/install.sh` must refresh `my@guarzo` after
+registering the local marketplace. Claude continues reading the local
+marketplace source directly on its next session.
 
 ### 3. Claude Linked-Worktree Guard
 
@@ -120,6 +125,9 @@ The implementation and documentation must not claim otherwise.
   and fail-open cases remain covered.
 - Tests verify the Claude hook registration and the presence of matching policy
   markers in both global guidance files.
+- Installer tests verify that Codex refreshes `my@guarzo`, and an isolated real
+  Codex installation confirms that blindspot-pass, polish-core, and
+  change-explainer are present in the resulting plugin cache.
 - Run focused Bats tests, `bash bin/validate-ai --verbose`, formatting/linting,
   and the full `bats tests` suite.
 

--- a/tests/ai_installers.bats
+++ b/tests/ai_installers.bats
@@ -63,6 +63,21 @@ SCRIPT
   assert_symlink_target "$codex_home/AGENTS.md" "$REPO_ROOT/ai/codex/AGENTS.md"
 }
 
+@test "codex install refreshes the personal plugin from the local marketplace" {
+  local codex_home="$HOME/generated-codex"
+  cat >"$STUB_BIN/codex" <<'SCRIPT'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$HOME/codex-invocation"
+SCRIPT
+  chmod +x "$STUB_BIN/codex"
+
+  run env HOME="$HOME" CODEX_HOME="$codex_home" PATH="$PATH" \
+    bash "$REPO_ROOT/ai/codex/install.sh"
+
+  [ "$status" -eq 0 ]
+  grep -Fxq "plugin add my@guarzo" "$HOME/codex-invocation"
+}
+
 @test "claude check mode changes no files" {
   assert_check_is_immutable ai/claude/install.sh
 }

--- a/tests/feature_workflow_policy.bats
+++ b/tests/feature_workflow_policy.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  CLAUDE_GUIDANCE="$REPO_ROOT/ai/claude/CLAUDE.md"
+  CODEX_GUIDANCE="$REPO_ROOT/ai/codex/AGENTS.md"
+  BLINDSPOT_SKILL="$REPO_ROOT/ai/marketplace/plugins/my/skills/blindspot-pass/SKILL.md"
+  POLISH_SKILL="$REPO_ROOT/ai/marketplace/plugins/my/skills/polish-core/SKILL.md"
+  EXPLAINER_SKILL="$REPO_ROOT/ai/marketplace/plugins/my/skills/change-explainer/SKILL.md"
+  CLAUDE_SETTINGS="$REPO_ROOT/ai/claude/settings.json"
+}
+
+@test "Claude settings register the linked-worktree edit guard" {
+  run jq -e '
+    .hooks.PreToolUse[]
+    | select(.matcher == "Edit|Write|NotebookEdit")
+    | .hooks[]
+    | select(
+        .type == "command"
+        and .command == "$HOME/.dotfiles/ai/claude/hooks/worktree-guard.sh"
+      )
+  ' "$CLAUDE_SETTINGS"
+  [ "$status" -eq 0 ]
+}
+
+@test "personal skills advertise their automatic workflow phases" {
+  run grep -F "Use proactively during discovery for non-trivial work" "$BLINDSPOT_SKILL"
+  [ "$status" -eq 0 ]
+
+  run grep -F "Run proactively with --fix after non-trivial implementation" "$POLISH_SKILL"
+  [ "$status" -eq 0 ]
+
+  run grep -F "Use proactively after polish and fresh verification" "$EXPLAINER_SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "blindspot workflow pauses only for material unresolved decisions" {
+  run grep -F "Automatic workflow mode" "$BLINDSPOT_SKILL"
+  [ "$status" -eq 0 ]
+  run grep -F "findings and continue into design for routine work. Pause only when an" "$BLINDSPOT_SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "change explainer limits knowledge checks to substantial changes" {
+  run grep -F "For substantial changes, include exactly five questions" "$EXPLAINER_SKILL"
+  [ "$status" -eq 0 ]
+  run grep -F "about the change, without answers. For routine non-trivial changes, omit the" "$EXPLAINER_SKILL"
+  [ "$status" -eq 0 ]
+}
+
+extract_workflow() {
+  awk '
+    found && /^## / { exit }
+    /^## Automatic feature workflow$/ { found = 1 }
+    found { print }
+  ' "$1"
+}
+
+@test "Claude and Codex share the automatic feature workflow policy" {
+  claude_workflow=$(extract_workflow "$CLAUDE_GUIDANCE")
+  codex_workflow=$(extract_workflow "$CODEX_GUIDANCE")
+
+  [ -n "$claude_workflow" ]
+  [ "$claude_workflow" = "$codex_workflow" ]
+  [[ "$claude_workflow" == *"linked worktree before the first feature-related write"* ]]
+  [[ "$claude_workflow" == *"During discovery, before the design is locked in"* ]]
+  [[ "$claude_workflow" == *"Pause only when unresolved high-impact decisions"* ]]
+  [[ "$claude_workflow" == *'`my:polish-core --fix`'* ]]
+  [[ "$claude_workflow" == *"re-run the affected verification"* ]]
+  [[ "$claude_workflow" == *"knowledge-check questions only for substantial changes"* ]]
+}

--- a/tests/worktree_guard.bats
+++ b/tests/worktree_guard.bats
@@ -103,6 +103,43 @@ write_input() {
   [ -z "$output" ]
 }
 
+@test "fails open when git is unavailable" {
+  tool_bin="$TEST_ROOT/no-git-bin"
+  mkdir -p "$tool_bin"
+  for tool in cat dirname jq readlink; do
+    ln -s "$(command -v "$tool")" "$tool_bin/$tool"
+  done
+
+  write_input "$REPO/file.txt"
+  run env PATH="$tool_bin" /bin/bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "uses a portable fallback when readlink -m is unsupported" {
+  mkdir -p "$TEST_ROOT/outside"
+  printf 'x\n' >"$REPO/target.txt"
+  ln -s "$REPO/target.txt" "$TEST_ROOT/outside/link.txt"
+  cat >"$STUB_BIN/readlink" <<'SCRIPT'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" ]]; then
+  exit 1
+fi
+exec /usr/bin/readlink "$@"
+SCRIPT
+  cat >"$STUB_BIN/realpath" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 1
+SCRIPT
+  chmod +x "$STUB_BIN/readlink"
+  chmod +x "$STUB_BIN/realpath"
+
+  write_input "$TEST_ROOT/outside/link.txt"
+  run env PATH="$PATH" /bin/bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+
 @test "denies edit through a symlink into a primary checkout" {
   mkdir -p "$TEST_ROOT/outside"
   printf 'x\n' >"$REPO/target.txt"

--- a/tests/worktree_guard.bats
+++ b/tests/worktree_guard.bats
@@ -17,7 +17,7 @@ write_input() {
   printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' "$1" >"$INPUT_FILE"
 }
 
-@test "denies edit on the default branch" {
+@test "denies edit in the primary worktree on the default branch" {
   write_input "$REPO/file.txt"
   run bash "$GUARD" <"$INPUT_FILE"
   [ "$status" -eq 0 ]
@@ -26,9 +26,18 @@ write_input() {
   [[ "$output" == *'worktree'* ]]
 }
 
-@test "allows edit on a feature branch" {
+@test "denies edit in the primary worktree on a feature branch" {
   git -C "$REPO" checkout --quiet -b feature
   write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+
+@test "allows edit in a linked worktree on a feature branch" {
+  linked="$TEST_ROOT/linked-feature"
+  git -C "$REPO" worktree add --quiet -b feature "$linked"
+  write_input "$linked/file.txt"
   run bash "$GUARD" <"$INPUT_FILE"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
@@ -70,9 +79,18 @@ write_input() {
   [ -z "$output" ]
 }
 
-@test "allows on detached HEAD" {
+@test "denies detached HEAD in the primary worktree" {
   git -C "$REPO" checkout --quiet --detach
   write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+
+@test "allows detached HEAD in a linked worktree" {
+  linked="$TEST_ROOT/linked-detached"
+  git -C "$REPO" worktree add --quiet --detach "$linked" HEAD
+  write_input "$linked/file.txt"
   run bash "$GUARD" <"$INPUT_FILE"
   [ "$status" -eq 0 ]
   [ -z "$output" ]

--- a/tests/worktree_guard.bats
+++ b/tests/worktree_guard.bats
@@ -103,12 +103,52 @@ write_input() {
   [ -z "$output" ]
 }
 
+@test "denies edit through a symlink into a primary checkout" {
+  mkdir -p "$TEST_ROOT/outside"
+  printf 'x\n' >"$REPO/target.txt"
+  ln -s "$REPO/target.txt" "$TEST_ROOT/outside/link.txt"
+  write_input "$TEST_ROOT/outside/link.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+
+@test "allows edit through a symlink into a linked worktree" {
+  linked="$TEST_ROOT/linked-sym"
+  git -C "$REPO" worktree add --quiet -b sym-feature "$linked"
+  printf 'x\n' >"$linked/target.txt"
+  mkdir -p "$TEST_ROOT/outside"
+  ln -s "$linked/target.txt" "$TEST_ROOT/outside/wt-link.txt"
+  write_input "$TEST_ROOT/outside/wt-link.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 @test "denies via notebook_path for NotebookEdit" {
   printf '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"%s"}}' \
     "$REPO/nb.ipynb" >"$INPUT_FILE"
   run bash "$GUARD" <"$INPUT_FILE"
   [ "$status" -eq 0 ]
   [[ "$output" == *'"deny"'* ]]
+}
+
+@test "denies edit in an existing subdirectory of a primary checkout" {
+  mkdir -p "$REPO/sub/deeper"
+  write_input "$REPO/sub/deeper/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+
+@test "allows edit in an existing subdirectory of a linked worktree" {
+  linked="$TEST_ROOT/linked-sub"
+  git -C "$REPO" worktree add --quiet -b sub-feature "$linked"
+  mkdir -p "$linked/sub/deeper"
+  write_input "$linked/sub/deeper/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }
 
 @test "denies for a new file in a not-yet-created subdirectory" {

--- a/tests/worktree_guard.bats
+++ b/tests/worktree_guard.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  GUARD="$REPO_ROOT/ai/claude/hooks/worktree-guard.sh"
+  REPO="$TEST_ROOT/repo"
+  mkdir -p "$REPO"
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" -c user.email=t@example.com -c user.name=t \
+    commit --quiet --allow-empty -m init
+  INPUT_FILE="$TEST_ROOT/input.json"
+}
+
+write_input() {
+  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' "$1" >"$INPUT_FILE"
+}
+
+@test "denies edit on the default branch" {
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision"'* ]]
+  [[ "$output" == *'"deny"'* ]]
+  [[ "$output" == *'worktree'* ]]
+}
+
+@test "allows edit on a feature branch" {
+  git -C "$REPO" checkout --quiet -b feature
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows edit outside any git repo" {
+  mkdir -p "$TEST_ROOT/plain"
+  write_input "$TEST_ROOT/plain/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows repo listed in the allowlist" {
+  mkdir -p "$HOME/.claude"
+  printf '%s\n' "$REPO" >"$HOME/.claude/worktree-guard-allow"
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allowlist supports tilde paths and comments" {
+  mkdir -p "$HOME/.claude" "$HOME/repo2"
+  git -C "$HOME/repo2" init --quiet --initial-branch=main
+  git -C "$HOME/repo2" -c user.email=t@example.com -c user.name=t \
+    commit --quiet --allow-empty -m init
+  printf '# comment\n~/repo2\n' >"$HOME/.claude/worktree-guard-allow"
+  write_input "$HOME/repo2/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows when CLAUDE_WORKTREE_GUARD=off" {
+  write_input "$REPO/file.txt"
+  run env CLAUDE_WORKTREE_GUARD=off bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "allows on detached HEAD" {
+  git -C "$REPO" checkout --quiet --detach
+  write_input "$REPO/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "fails open when jq is unavailable" {
+  write_input "$REPO/file.txt"
+  run env PATH="$STUB_BIN" /bin/bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "denies via notebook_path for NotebookEdit" {
+  printf '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"%s"}}' \
+    "$REPO/nb.ipynb" >"$INPUT_FILE"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}
+
+@test "denies for a new file in a not-yet-created subdirectory" {
+  write_input "$REPO/newdir/sub/file.txt"
+  run bash "$GUARD" <"$INPUT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"deny"'* ]]
+}


### PR DESCRIPTION
## Summary
- require linked worktrees before feature-related writes, with a Claude edit-tool guard based on actual worktree topology
- automatically place blindspot, polish --fix, fresh verification, and change explanation around the existing Superpowers lifecycle
- keep Claude and Codex workflow guidance synchronized and cover the policy with regression tests

## Important behavior
- primary checkouts are denied even on feature branches or detached HEAD
- linked worktrees are allowed regardless of branch state
- blindspot pauses only for material high-impact decisions
- knowledge-check questions are limited to substantial changes

## Test plan
- [x] `make syntax lint validate`
- [x] `bats tests` (57 tests)
- [x] `git diff --check main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a worktree edit/write guard that blocks edits to the primary checkout for edit-related tool actions (with an allowlist and an escape-hatch to disable).
  - Introduced an “automatic feature workflow” overlay covering discovery → implementation → polish → verification → change explanation.
  - Codex installs now refresh the personal plugin automatically after setup.

- **Documentation**
  - Updated skill and workflow guidance to refine pause behavior and knowledge-check inclusion rules.
  - Added workflow automation plan and design spec.

- **Tests**
  - Added Bats coverage for the worktree guard, Codex plugin refresh, and workflow policy consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->