### PR TITLE
fix: exclude .claude/worktrees from dotfile symlink discovery

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -202,6 +202,7 @@ install_dotfiles() {
   done < <(find -H "$DOTFILES_ROOT" \
     -not -path '*/archived/*' \
     -not -path '*/.git/*' \
+    -not -path '*/.claude/worktrees/*' \
     -name '*.symlink' -print0)
 
   # Link config/ subdirectories to ~/.config/<name>

--- a/bin/relink
+++ b/bin/relink
@@ -72,6 +72,7 @@ while IFS= read -r -d '' src; do
 done < <(find -H "$DOTFILES_ROOT" \
   -not -path '*/archived/*' \
   -not -path '*/.git/*' \
+  -not -path '*/.claude/worktrees/*' \
   -name '*.symlink' -print0)
 
 # ── Step 3: Re-create config/ directory symlinks ──────────────────────────────


### PR DESCRIPTION
## Summary
- `bin/relink` and `bin/bootstrap` discovered `*.symlink` sources with a `find` that descended into `.claude/worktrees/*`. Every worktree carries its own copy of each source, and they all resolve to the same `$HOME` target, so the last one `find` visited won **nondeterministically**.
- This left links like `~/.git-hooks` pointing at a worktree that could later be deleted — silently disabling the global `commit-msg` coauthor-removal hook (the symptom that started this).
- Fix: add `-not -path '*/.claude/worktrees/*'` to the `find` in both scripts, so only canonical repo sources are linked.

## Impact
Symlink sources dropped from 72 (duplicate-ridden) to 13 canonical. Targets now deterministically resolve to the repo root.

## Test plan
- [x] `bash -n` syntax check on both scripts
- [x] Source-count comparison (72 → 13) confirms all worktree copies excluded
- [x] Patched relink produces worktree-free output; `~/.git-hooks`, `~/.gitconfig`, `~/.config/mise` all point at the real repo
- [x] End-to-end hook test: `Co-authored-by:` trailer stripped, other trailers preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded files within `.claude/worktrees` from dotfile symlink installation and recreation.
  * Prevented unintended symlinks from being generated from worktree directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->