### PR TITLE
Fix Vekil loading before deferred shell setup

### DIFF
--- a/core/shell/zshrc.symlink
+++ b/core/shell/zshrc.symlink
@@ -11,6 +11,10 @@ if [[ -r "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
 fi
 
 
+# Codex needs the Vekil wrapper before deferred customizations can run.
+[[ -r "${DOTFILES:-$HOME/.dotfiles}/ai/vekil/env.zsh" ]] && \
+  source "${DOTFILES:-$HOME/.dotfiles}/ai/vekil/env.zsh"
+
 # Load my customizations
 function load_custom() {
   source "${DOTFILES:-$HOME/.dotfiles}/core/shell/load-custom.zsh"

--- a/docs/superpowers/plans/2026-07-21-vekil-synchronous-shell-loading.md
+++ b/docs/superpowers/plans/2026-07-21-vekil-synchronous-shell-loading.md
@@ -1,0 +1,86 @@
+# Synchronous Vekil Shell Loading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure every initialized interactive zsh has the Vekil-managed `codex` function before deferred customizations run.
+
+**Architecture:** Source `ai/vekil/env.zsh` directly from `core/shell/zshrc.symlink` before `zsh-defer` queues `load_custom`. Retain the source in `load-custom.zsh` for direct callers and rely on the loader's existing idempotence.
+
+**Tech Stack:** zsh, zsh-defer, Bats
+
+---
+
+### Task 1: Load Vekil before deferred customizations
+
+**Files:**
+- Modify: `tests/shell_loading.bats`
+- Modify: `core/shell/zshrc.symlink`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add a Bats test that creates valid Vekil state, stubs a healthy readiness probe, and installs a `zsh-defer` stub that does not execute queued work:
+
+```bash
+@test "zshrc loads Vekil before deferred customizations run" {
+  local state_dir="$HOME/.local/state/vekil"
+  mkdir -p "$state_dir" "$HOME/.zsh-defer"
+  printf '127.0.0.1\n' >"$state_dir/proxy-host"
+  : >"$state_dir/proxy-ready"
+  chmod 0700 "$HOME/.local" "$HOME/.local/state" "$state_dir"
+  chmod 0600 "$state_dir/proxy-host" "$state_dir/proxy-ready"
+  stub_command curl 'exit 0'
+  cat >"$HOME/.zsh-defer/zsh-defer.plugin.zsh" <<'SCRIPT'
+zsh-defer() { :; }
+SCRIPT
+
+  run env HOME="$HOME" DOTFILES="$REPO_ROOT" PATH="$PATH" zsh -dfc '
+    source "$DOTFILES/core/shell/zshrc.symlink" || exit 1
+    print -r -- "VEKIL_CODEX_FUNCTION=${+functions[codex]}"
+  '
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VEKIL_CODEX_FUNCTION=1"* ]]
+}
+```
+
+- [ ] **Step 2: Verify the test fails for the missing synchronous source**
+
+Run: `bats tests/shell_loading.bats`
+
+Expected: the new test fails because `zsh-defer` does not execute `load_custom`, leaving `${+functions[codex]}` equal to `0`.
+
+- [ ] **Step 3: Add the minimal synchronous source**
+
+Before the `load_custom` definition in `core/shell/zshrc.symlink`, add:
+
+```zsh
+# Codex needs the Vekil wrapper before deferred customizations can run.
+[[ -r "${DOTFILES:-$HOME/.dotfiles}/ai/vekil/env.zsh" ]] && \
+  source "${DOTFILES:-$HOME/.dotfiles}/ai/vekil/env.zsh"
+```
+
+- [ ] **Step 4: Verify focused behavior**
+
+Run: `bats tests/shell_loading.bats`
+
+Expected: all shell-loading tests pass, including the new deferred-work regression.
+
+- [ ] **Step 5: Verify the repository**
+
+Run:
+
+```bash
+bats tests
+bash bin/validate-ai --verbose
+shellcheck -x -S warning tests/shell_loading.bats
+git diff --check
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add core/shell/zshrc.symlink tests/shell_loading.bats docs/superpowers/plans/2026-07-21-vekil-synchronous-shell-loading.md
+git commit -m "fix Vekil loading before deferred shell setup"
+```

--- a/docs/superpowers/specs/2026-07-21-vekil-synchronous-shell-loading-design.md
+++ b/docs/superpowers/specs/2026-07-21-vekil-synchronous-shell-loading-design.md
@@ -1,0 +1,25 @@
+# Synchronous Vekil Shell Loading
+
+## Problem
+
+`core/shell/zshrc.symlink` defers `load_custom`, which currently sources
+`ai/vekil/env.zsh`. A new interactive shell can therefore run the raw Codex
+binary before Vekil installs its managed `codex` function. If that shell
+inherits `OPENAI_API_KEY=dummy`, Codex sends the placeholder key directly to
+OpenAI.
+
+## Design
+
+Source `ai/vekil/env.zsh` synchronously in `zshrc.symlink` before scheduling
+`load_custom` with `zsh-defer`. Keep the existing source in `load-custom.zsh`
+as an idempotent fallback for callers that load customizations directly.
+
+All other shell customization remains deferred. No proxy lifecycle, Codex
+configuration, or devcontainer behavior changes.
+
+## Verification
+
+Add a shell-loading regression test whose `zsh-defer` stub queues but does not
+execute `load_custom`. After sourcing `zshrc.symlink`, the test requires the
+managed `codex` function to exist. Run the focused shell-loading tests and the
+full Bats suite.

--- a/tests/shell_loading.bats
+++ b/tests/shell_loading.bats
@@ -69,6 +69,27 @@ run_loader() {
   [[ "$output" == *"http://127.0.0.1:1337/v1|http://127.0.0.1:1337"* ]]
 }
 
+@test "zshrc loads Vekil before deferred customizations run" {
+  local state_dir="$HOME/.local/state/vekil"
+  mkdir -p "$state_dir" "$HOME/.zsh-defer"
+  printf '127.0.0.1\n' >"$state_dir/proxy-host"
+  : >"$state_dir/proxy-ready"
+  chmod 0700 "$HOME/.local" "$HOME/.local/state" "$state_dir"
+  chmod 0600 "$state_dir/proxy-host" "$state_dir/proxy-ready"
+  stub_command curl 'exit 0'
+  cat >"$HOME/.zsh-defer/zsh-defer.plugin.zsh" <<'SCRIPT'
+zsh-defer() { :; }
+SCRIPT
+
+  run env HOME="$HOME" DOTFILES="$REPO_ROOT" PATH="$PATH" zsh -dfc '
+    source "$DOTFILES/core/shell/zshrc.symlink" || exit 1
+    print -r -- "VEKIL_CODEX_FUNCTION=${+functions[codex]}"
+  '
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VEKIL_CODEX_FUNCTION=1"* ]]
+}
+
 @test "localrc endpoint overrides the managed Codex wrapper" {
   local state_dir="$HOME/.local/state/vekil"
   mkdir -p "$state_dir"


### PR DESCRIPTION
## Summary\n\n- source Vekil synchronously before zsh-defer queues the remaining shell customizations\n- preserve the existing load-custom fallback for direct callers\n- add a regression test proving the managed Codex wrapper exists before deferred work runs\n\n## Root cause\n\nA new shell could invoke the raw Codex binary before deferred customizations sourced ai/vekil/env.zsh. If it inherited OPENAI_API_KEY=dummy, Codex sent that placeholder directly to OpenAI.\n\n## Test plan\n\n- bats tests/shell_loading.bats (11 passed)\n- bats tests (86 passed)\n- bash bin/validate-ai --verbose\n- shellcheck -x -S warning tests/shell_loading.bats\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the managed Codex command is available immediately when starting a new interactive shell, before deferred customizations run.
  * Preserved compatibility for existing shell-loading workflows.

* **Tests**
  * Added regression coverage verifying synchronous Vekil shell loading.

* **Documentation**
  * Added design and implementation documentation for the shell-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->