### PR TITLE
Make SSH/gh opt-in and version the devcontainer seed

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -342,19 +342,21 @@ Report to the user:
   ```bash
   # Run grep INSIDE the container — a bare ~/.zshrc would expand on the host.
   docker compose exec <service> sh -c 'grep -Fq ai/vekil/env.zsh "$HOME/.zshrc"'          # hook present
-  docker compose exec <service> sh -c 'zsh -ec "source \"$HOME/.dotfiles/ai/vekil/env.zsh\""'  # target sources nonzero on failure
+  docker compose exec <service> sh -c 'zsh -n "$HOME/.dotfiles/ai/vekil/env.zsh"'          # target exists + parses; no /readyz probe
   docker compose exec <service> zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
   ```
   If the hook grep fails, the seed's always-run block never wrote it — the
   running container is likely executing a stale pre-hook `local-seed.sh`. A
   persisted named volume can keep an old versioned sentinel; confirm the on-disk
   seed matches the current template, then restart so the always-run block fires.
-  The `zsh -ec` line sources the hook *target* directly, so a missing or
-  malformed `~/.dotfiles/ai/vekil/env.zsh` exits nonzero even when later startup
-  commands would have masked it — fix that before blaming the proxy. Only once
-  the target sources cleanly does an empty endpoint variable point at Vekil's
-  `/readyz` probe. Empty endpoint variables or Codex resolving to the raw binary
-  otherwise mean the container-local zsh hook did not load.
+  The `zsh -n` line validates the hook *target* alone — nonzero if
+  `~/.dotfiles/ai/vekil/env.zsh` is missing (127) or malformed (1), without
+  executing it, so it does not touch the proxy. That keeps "is the hook
+  well-formed" separate from readiness; the `zsh -lic` line is the combined
+  hook-plus-readiness check, where an empty endpoint variable means the target
+  loaded but Vekil's `/readyz` probe failed. Empty endpoint variables or Codex
+  resolving to the raw binary otherwise mean the container-local zsh hook did
+  not load.
   Diagnose the local seed hook and proxy readiness. Never edit a Dockerfile or
   baked rc, source all dotfiles by glob, or add a shell-startup retry loop
   without reproducing a readiness race.

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: project-claude-setup
-description: Set up a project for Claude Code without leaking personal config into the project's git history. Creates a per-project overlay under ~/.dotfiles/projects/ (CLAUDE.md, agents/, settings.local.json), symlinks it into the project worktree, and — for compose-based devcontainers — writes a local seed-and-copy override for host SSH/gh/Claude/dotfiles. Also detects and repairs legacy writable or dual-home Claude mounts. Use when starting work on a new project, when an open-source project shouldn't carry your CLAUDE.md, when adding agent-teams support to an existing project, or when the user mentions "set up this project for Claude" / "bootstrap project Claude config" / "share host SSH/gh/dotfiles with the devcontainer".
+description: Set up a project for Claude Code without leaking personal config into the project's git history. Creates a per-project overlay under ~/.dotfiles/projects/ (CLAUDE.md, agents/, settings.local.json), symlinks it into the project worktree, and — for compose-based devcontainers — writes a local seed-and-copy override for host Claude/dotfiles (with SSH/gh identity sharing as an explicit opt-in). Also detects and repairs legacy writable or dual-home Claude mounts. Use when starting work on a new project, when an open-source project shouldn't carry your CLAUDE.md, when adding agent-teams support to an existing project, or when the user mentions "set up this project for Claude" / "bootstrap project Claude config" / "share host SSH/gh/dotfiles with the devcontainer".
 ---
 
 # Project Claude setup
 
-The user keeps personal per-project Claude config (CLAUDE.md, settings.local.json, agents/) in their dotfiles repo at `~/.dotfiles/projects/<project-name>/`, not in the project repo. This skill scaffolds that overlay, symlinks it into the project worktree (the global gitignore catches the symlinks), and — when the project has a compose-based devcontainer — wires the host mounts that let the container see the user's Claude/dotfiles/SSH/gh.
+The user keeps personal per-project Claude config (CLAUDE.md, settings.local.json, agents/) in their dotfiles repo at `~/.dotfiles/projects/<project-name>/`, not in the project repo. This skill scaffolds that overlay, symlinks it into the project worktree (the global gitignore catches the symlinks), and — when the project has a compose-based devcontainer — wires the host mounts that let the container see the user's Claude and dotfiles (with SSH/gh identity sharing available as an explicit opt-in).
 
 It replaces the old narrower `devcontainer-host-mounts` skill. The host-mounts logic is still in here, just as one section of a longer flow.
 
@@ -199,20 +199,21 @@ Never write to the project-shared `.claude/settings.json` from this skill — th
 
 ## Step 6 — Compose host mounts (case a only)
 
-Keep `~/.ssh` and `~/.config/gh` read-only at the container user's home. Mount `~/.claude` and `~/.dotfiles` read-only under `/host-seed`, then copy the authored Claude subset and dotfiles into container-local named volumes at the user's home with a gitignored `.devcontainer/local-seed.sh`. The named-volume targets also replace any inherited host binds with the same container targets during Compose merge. This lets Claude Code write runtime state without any write path back to the host. OpenCode is not seeded; the seed script links Codex through `ai/codex/install.sh`.
+Mount `~/.claude` and `~/.dotfiles` read-only under `/host-seed`, then copy the authored Claude subset and dotfiles into container-local named volumes at the user's home with a gitignored `.devcontainer/local-seed.sh`. The named-volume targets also replace any inherited host binds with the same container targets during Compose merge. This lets Claude Code write runtime state without any write path back to the host. Host SSH keys and `gh` auth are **not** shared by default — they are single global credentials that force the container onto the host's GitHub identity across projects; mount `~/.ssh` and `~/.config/gh` read-only only when the user explicitly opts in (see item 2). OpenCode is not seeded; the seed script links Codex through `ai/codex/install.sh`.
 
 Write or merge the gitignored `docker-compose.override.yml` directly. The override must:
 
 1. Target the actual devcontainer service and home directory found in Step 2.
-2. Mount `~/.ssh` and `~/.config/gh` read-only at the container home.
+2. Leave host SSH keys and `gh` auth unmounted by default. Ask the user once: "Share host SSH keys and gh auth with this container? (default: no)" — mounting them forces every container onto the same host GitHub identity and key set and can switch accounts unexpectedly. Only if the user opts in, mount `~/.ssh` and `~/.config/gh` read-only at the container home. Otherwise the container authenticates itself (`gh auth login` inside the container, a project-scoped `GH_TOKEN`, or its own key).
 3. Mount `~/.claude` at `/host-seed/.claude:ro,cached` and `~/.dotfiles` at `/host-seed/.dotfiles:ro,cached`.
 4. Mount project-scoped named volumes at the container user's `~/.claude` and `~/.dotfiles`. Because Compose volume entries merge by container target, these replace legacy host binds inherited from the base compose file.
 5. If the merged base still exposes host OpenCode config, shadow that target with an empty project-scoped named volume; do not seed or install OpenCode.
 6. Override `command` to run `.devcontainer/local-seed.sh`, then `exec` the base service's original foreground command.
 7. Preserve unrelated existing override keys and show the diff before writing.
 8. Back up an existing override to `<file>.backup-<timestamp>` before replacing legacy mounts.
-9. In the seed script, repair both named-volume trees' ownership before checking `.seeded`; the sentinel may skip copies and installers, never ownership recovery.
-10. Before checking `.seeded`, idempotently add a container-local `~/.zshrc` hook that sources `~/.dotfiles/ai/vekil/env.zsh`; this supplies both proxy endpoint variables and the managed `codex` function without modifying the host or running the full dotfiles installer.
+9. In the seed script, repair both named-volume trees' ownership before checking the sentinel; the sentinel may skip copies and installers, never ownership recovery.
+10. Before checking the sentinel, idempotently add a container-local `~/.zshrc` hook that sources `~/.dotfiles/ai/vekil/env.zsh`; this supplies both proxy endpoint variables and the managed `codex` function without modifying the host or running the full dotfiles installer.
+11. Make the sentinel version-aware: store a `SEED_VERSION` number in `~/.claude/.seeded` and re-run the gated copy/install steps whenever the on-disk version differs. A persisted named volume survives `--remove-existing-container`, so a bare touch-file sentinel would otherwise pin an evolving container to its first seed forever. The always-run block (ownership + Vekil hook) stays before the gate so those land on every start regardless of version.
 
 Do **not** use `claude-merge-compose-override` for this step until that helper emits the seed model; its current output contains writable and dual-home mounts.
 
@@ -339,10 +340,15 @@ Report to the user:
   `devcontainer up --remove-existing-container --workspace-folder .` or VS Code "Dev Containers: Rebuild Container"
 - For case (a): verify Vekil in a fresh interactive login shell:
   ```bash
+  docker compose exec <service> grep -Fq 'ai/vekil/env.zsh' ~/.zshrc   # hook present
   docker compose exec <service> zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
   ```
-  Empty endpoint variables or Codex resolving to the raw binary mean the
-  container-local zsh hook did not load or Vekil's `/readyz` probe failed.
+  If the hook grep fails, the seed's always-run block never wrote it — the
+  running container is likely executing a stale pre-hook `local-seed.sh`. A
+  persisted named volume can keep an old versioned sentinel; confirm the on-disk
+  seed matches the current template, then restart so the always-run block fires.
+  Empty endpoint variables *with* the hook present mean the
+  container-local zsh hook loaded but Vekil's `/readyz` probe failed.
   Diagnose the local seed hook and proxy readiness. Never edit a Dockerfile or
   baked rc, source all dotfiles by glob, or add a shell-startup retry loop
   without reproducing a readiness race.

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -213,7 +213,7 @@ Write or merge the gitignored `docker-compose.override.yml` directly. The overri
 8. Back up an existing override to `<file>.backup-<timestamp>` before replacing legacy mounts.
 9. In the seed script, repair both named-volume trees' ownership before checking the sentinel; the sentinel may skip copies and installers, never ownership recovery.
 10. Before checking the sentinel, idempotently add a container-local `~/.zshrc` hook that sources `~/.dotfiles/ai/vekil/env.zsh`; this supplies both proxy endpoint variables and the managed `codex` function without modifying the host or running the full dotfiles installer.
-11. Make the sentinel version-aware: store a `SEED_VERSION` number in `~/.claude/.seeded` and re-run the gated copy/install steps whenever the on-disk version differs. A persisted named volume survives `--remove-existing-container`, so a bare touch-file sentinel would otherwise pin an evolving container to its first seed forever. The always-run block (ownership + Vekil hook) stays before the gate so those land on every start regardless of version.
+11. Make the sentinel version-aware: store a `SEED_VERSION` number in `~/.claude/.seeded` and re-run the gated copy/install steps only when a *stamped* sentinel records a different version. A persisted named volume survives `--remove-existing-container`, so without a version bump an evolving template could not refresh those steps; a legacy bare (empty) sentinel is treated as current and left alone, so existing good volumes are not reseeded. The always-run block (ownership + Vekil hook) stays before the gate so those land on every start regardless of version.
 
 Do **not** use `claude-merge-compose-override` for this step until that helper emits the seed model; its current output contains writable and dual-home mounts.
 
@@ -340,15 +340,21 @@ Report to the user:
   `devcontainer up --remove-existing-container --workspace-folder .` or VS Code "Dev Containers: Rebuild Container"
 - For case (a): verify Vekil in a fresh interactive login shell:
   ```bash
-  docker compose exec <service> grep -Fq 'ai/vekil/env.zsh' ~/.zshrc   # hook present
+  # Run grep INSIDE the container — a bare ~/.zshrc would expand on the host.
+  docker compose exec <service> sh -c 'grep -Fq ai/vekil/env.zsh "$HOME/.zshrc"'   # hook present
+  docker compose exec <service> sh -c 'zsh -c "source \"$HOME/.zshrc\"" 2>&1'       # hook sources cleanly
   docker compose exec <service> zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
   ```
   If the hook grep fails, the seed's always-run block never wrote it — the
   running container is likely executing a stale pre-hook `local-seed.sh`. A
   persisted named volume can keep an old versioned sentinel; confirm the on-disk
   seed matches the current template, then restart so the always-run block fires.
-  Empty endpoint variables *with* the hook present mean the
-  container-local zsh hook loaded but Vekil's `/readyz` probe failed.
+  If the hook is present but the source line errors or prints warnings, the hook
+  target is missing or malformed (`~/.dotfiles/ai/vekil/env.zsh` absent, or the
+  dotfiles copy never landed) — fix that before blaming the proxy. Only once the
+  hook sources cleanly does an empty endpoint variable point at Vekil's
+  `/readyz` probe. Empty endpoint variables or Codex resolving to the raw binary
+  otherwise mean the container-local zsh hook did not load.
   Diagnose the local seed hook and proxy readiness. Never edit a Dockerfile or
   baked rc, source all dotfiles by glob, or add a shell-startup retry loop
   without reproducing a readiness race.

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -204,7 +204,7 @@ Mount `~/.claude` and `~/.dotfiles` read-only under `/host-seed`, then copy the 
 Write or merge the gitignored `docker-compose.override.yml` directly. The override must:
 
 1. Target the actual devcontainer service and home directory found in Step 2.
-2. Leave host SSH keys and `gh` auth unmounted by default. Ask the user once: "Share host SSH keys and gh auth with this container? (default: no)" — mounting them forces every container onto the same host GitHub identity and key set and can switch accounts unexpectedly. Only if the user opts in, mount `~/.ssh` and `~/.config/gh` read-only at the container home. Otherwise the container authenticates itself (`gh auth login` inside the container, a project-scoped `GH_TOKEN`, or its own key).
+2. Leave host SSH keys and `gh` auth unmounted by default. Ask the user once: "Share host SSH keys and gh auth with this container? (default: no)" — mounting them forces every container onto the same host GitHub identity and key set and can switch accounts unexpectedly. Only if the user opts in, mount `~/.ssh` and `~/.config/gh` read-only at the container home. Otherwise the container authenticates itself (`gh auth login` inside the container, a project-scoped `GH_TOKEN`, or its own key). If the merged base compose already binds host `~/.ssh` or `~/.config/gh` and the user declined, shadow each inherited target with an empty project-scoped named volume — declining must not leave an inherited host bind in place.
 3. Mount `~/.claude` at `/host-seed/.claude:ro,cached` and `~/.dotfiles` at `/host-seed/.dotfiles:ro,cached`.
 4. Mount project-scoped named volumes at the container user's `~/.claude` and `~/.dotfiles`. Because Compose volume entries merge by container target, these replace legacy host binds inherited from the base compose file.
 5. If the merged base still exposes host OpenCode config, shadow that target with an empty project-scoped named volume; do not seed or install OpenCode.
@@ -238,7 +238,7 @@ Remediation (confirm with user before each write):
 
 - Rewrite the override to read-only seed mounts, container-local named-volume targets, the `command` override, and `local-seed.sh` from Step 6. Back up the old override to `<file>.backup-<timestamp>`.
 - Remove the `${HOME}:${HOME}` dual-mount lines.
-- Inspect the fully merged Compose config, not only the override. Shadow any legacy base-file binds targeting the container user's `~/.claude`, `~/.dotfiles`, or OpenCode directory with project-scoped named volumes.
+- Inspect the fully merged Compose config, not only the override. Shadow any legacy base-file binds targeting the container user's `~/.claude`, `~/.dotfiles`, or OpenCode directory with project-scoped named volumes. Unless credential sharing was opted into, do the same for any inherited `~/.ssh` or `~/.config/gh` bind.
 - Optional host cleanup: rewrite `/home/<container-user>` to the host home in `~/.claude/plugins/{known_marketplaces,installed_plugins}.json`, and delete broken `~/.claude` symlinks whose target starts with `/home/<container-user>`. Show a diff or list first; never bulk-delete without confirmation.
 - Tell the user to rebuild the container to apply the repair.
 
@@ -341,18 +341,18 @@ Report to the user:
 - For case (a): verify Vekil in a fresh interactive login shell:
   ```bash
   # Run grep INSIDE the container — a bare ~/.zshrc would expand on the host.
-  docker compose exec <service> sh -c 'grep -Fq ai/vekil/env.zsh "$HOME/.zshrc"'   # hook present
-  docker compose exec <service> sh -c 'zsh -c "source \"$HOME/.zshrc\"" 2>&1'       # hook sources cleanly
+  docker compose exec <service> sh -c 'grep -Fq ai/vekil/env.zsh "$HOME/.zshrc"'          # hook present
+  docker compose exec <service> sh -c 'zsh -ec "source \"$HOME/.dotfiles/ai/vekil/env.zsh\""'  # target sources nonzero on failure
   docker compose exec <service> zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
   ```
   If the hook grep fails, the seed's always-run block never wrote it — the
   running container is likely executing a stale pre-hook `local-seed.sh`. A
   persisted named volume can keep an old versioned sentinel; confirm the on-disk
   seed matches the current template, then restart so the always-run block fires.
-  If the hook is present but the source line errors or prints warnings, the hook
-  target is missing or malformed (`~/.dotfiles/ai/vekil/env.zsh` absent, or the
-  dotfiles copy never landed) — fix that before blaming the proxy. Only once the
-  hook sources cleanly does an empty endpoint variable point at Vekil's
+  The `zsh -ec` line sources the hook *target* directly, so a missing or
+  malformed `~/.dotfiles/ai/vekil/env.zsh` exits nonzero even when later startup
+  commands would have masked it — fix that before blaming the proxy. Only once
+  the target sources cleanly does an empty endpoint variable point at Vekil's
   `/readyz` probe. Empty endpoint variables or Codex resolving to the raw binary
   otherwise mean the container-local zsh hook did not load.
   Diagnose the local seed hook and proxy readiness. Never edit a Dockerfile or

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
@@ -5,7 +5,9 @@
 > `my:project-claude-setup`. No YAML frontmatter — this is not a
 > separately loaded skill.
 
-Use a local `docker-compose.override.yml` to expose SSH and `gh` auth read-only, and expose Claude Code config and dotfiles as read-only seed sources under `/host-seed`. Project-scoped named volumes at the container user's `~/.claude` and `~/.dotfiles` replace inherited host binds with the same targets. A local `local-seed.sh` copies the authored subset into those container-local volumes and installs a container-local zsh hook for Vekil before the base foreground command starts. Claude Code can then write sessions, history, plugins, and other runtime state only inside the container.
+Use a local `docker-compose.override.yml` to expose Claude Code config and dotfiles as read-only seed sources under `/host-seed`. Project-scoped named volumes at the container user's `~/.claude` and `~/.dotfiles` replace inherited host binds with the same targets. A local `local-seed.sh` copies the authored subset into those container-local volumes and installs a container-local zsh hook for Vekil before the base foreground command starts. Claude Code can then write sessions, history, plugins, and other runtime state only inside the container.
+
+Host SSH keys (`~/.ssh`) and `gh` auth (`~/.config/gh`) are **not** shared by default. Both are single global host credentials: mounting them forces every container onto the same GitHub identity and key set, which breaks per-container credential isolation and can switch accounts unexpectedly between projects. The container should authenticate itself instead (`gh auth login` inside the container, a project-scoped `GH_TOKEN`, or its own key). Mount them only when the user explicitly opts in for a project that genuinely wants the host identity — see Step 3.
 
 Do not use `claude-merge-compose-override` for this model until that helper is updated: its current output creates writable and dual-home mounts. OpenCode is no longer bridged; the seed script links Codex with `ai/codex/install.sh`.
 
@@ -16,6 +18,8 @@ Trigger this skill when the user says things like:
 - "share my ssh keys / gh auth / Claude config / dotfiles with the container"
 - "bootstrap a new project's devcontainer the way I usually do"
 - starts working on a fresh project and the devcontainer comes up without their host tools
+
+Sharing host SSH keys and `gh` auth is an explicit opt-in, not automatic — the default mounts only the read-only Claude/dotfiles seed sources.
 
 If `.devcontainer/` doesn't exist yet, stop and tell the user this skill assumes a compose-based devcontainer is already in place — offer to help create one separately, but don't invent one as part of this task.
 
@@ -71,8 +75,6 @@ If you can't determine the user from any of these signals, ask. Do not guess bet
 The default set, in order:
 
 ```
-~/.ssh                  →  /home/{USER}/.ssh                 (ro)
-~/.config/gh            →  /home/{USER}/.config/gh           (ro)
 ~/.claude               →  /host-seed/.claude                (ro) seed source, never written
 ~/.dotfiles             →  /host-seed/.dotfiles              (ro) seed source
 ```
@@ -87,12 +89,11 @@ dotfiles-local-home     →  /home/{USER}/.dotfiles            named volume
 Compose merges service volumes by container target. These named-volume entries therefore replace legacy base-file binds targeting the same home paths instead of merely adding more mounts. If a base compose file binds host OpenCode config, add an empty `opencode-local-home` named volume at that target to shadow it; do not seed OpenCode.
 
 Why each one:
-- **`~/.ssh` (ro)**: lets the container `git push` over SSH and connect to remote hosts using the host's keys. Read-only because the container should never modify host keys.
-- **`~/.config/gh` (ro)**: shares the `gh` CLI's stored auth token so `gh pr create`, `gh api`, etc. work without a fresh login inside the container.
 - **`~/.claude` seed (ro)**: supplies only authored config to the seed script. The container never writes through this mount.
 - **`~/.dotfiles` seed (ro)**: supplies shell config and the marketplace/Codex installers. The script copies it container-local before running installers.
 
 Optional, ask before adding:
+- **`~/.ssh` (ro)** and **`~/.config/gh` (ro)** — host SSH keys and `gh` auth. **Off by default.** These are single global host credentials, so mounting them forces the container onto the host's GitHub identity and key set and can switch accounts unexpectedly across projects. Prefer having the container authenticate itself (`gh auth login` inside the container, a project-scoped `GH_TOKEN`, or its own key). Ask the user once: "Share host SSH keys and gh auth with this container? (default: no)". Only mount them if they say yes — SSH `ro` so the container can `git push`/reach remote hosts with the host keys; gh `ro` so `gh pr create`/`gh api` reuse the host token.
 - **`~/.pi`** — only used in some of the user's projects (e.g. `abyssalwatch`). Don't include by default.
 - **Project-specific dirs** — if the user mentions another tool's config they want shared, mount it the same way.
 
@@ -110,12 +111,15 @@ Use this template, filling in `{SERVICE}`, `{USER}`, `{WORKSPACE}`, and `{BASE_C
 services:
   {SERVICE}:
     volumes:
-      - ~/.ssh:/home/{USER}/.ssh:ro
-      - ~/.config/gh:/home/{USER}/.config/gh:ro
       - ~/.claude:/host-seed/.claude:ro,cached
       - ~/.dotfiles:/host-seed/.dotfiles:ro,cached
       - claude-local-home:/home/{USER}/.claude
       - dotfiles-local-home:/home/{USER}/.dotfiles
+      # Opt-in: share the host GitHub identity. Off by default — mounting these
+      # forces this container onto the host's gh account and SSH keys. Uncomment
+      # only if the user asked to share host credentials for this project.
+      # - ~/.ssh:/home/{USER}/.ssh:ro
+      # - ~/.config/gh:/home/{USER}/.config/gh:ro
     command: >-
       bash -c "bash {WORKSPACE}/.devcontainer/local-seed.sh; exec {BASE_COMMAND}"
     configs:
@@ -156,15 +160,25 @@ Write `{WORKSPACE}/.devcontainer/local-seed.sh` with:
 #!/usr/bin/env bash
 # Local-only devcontainer seed (gitignored). Copies the authored subset of the
 # host ~/.claude into a CONTAINER-LOCAL ~/.claude so nothing the container writes
-# can reach the host. Idempotent: guarded by ~/.claude/.seeded.
+# can reach the host. The expensive copy/install steps are guarded by a
+# versioned sentinel: bump SEED_VERSION whenever those steps change and existing
+# containers re-run them on next start without a manual volume wipe.
 set -euo pipefail
+
+# Bump this whenever the gated steps below (copies, installers) change so
+# already-seeded containers refresh instead of silently keeping stale state.
+SEED_VERSION=2
 
 SEED_CLAUDE="/host-seed/.claude"
 SEED_DOTFILES="/host-seed/.dotfiles"
 SENTINEL="$HOME/.claude/.seeded"
 
-# Named-volume mountpoints can start as root:root. Repair them on every launch,
-# even when the sentinel exists, so stale volumes remain recoverable.
+# --- Always-run block (before the sentinel) --------------------------------
+# Ownership repair and the Vekil shell hook run on EVERY launch, even when the
+# sentinel is current, so persisted named volumes stay recoverable and pick up
+# hook changes without a full reseed.
+
+# Named-volume mountpoints can start as root:root. Repair them every launch.
 echo "🌱 seed: repairing container-local volume ownership"
 if [ "$(id -u)" -ne 0 ]; then
   sudo chown -R "$(id -u):$(id -g)" "$HOME/.claude" "$HOME/.dotfiles"
@@ -181,10 +195,14 @@ if ! grep -Fqx "$VEKIL_ENV_HOOK" "$ZSHRC"; then
   echo "🌱 seed: configured Vekil shell integration"
 fi
 
-if [ -f "$SENTINEL" ]; then
-  echo "🌱 seed: already seeded ($SENTINEL) — skipping"
+# --- Versioned gate --------------------------------------------------------
+# Skip the gated steps only when the sentinel records the CURRENT version.
+# A bare legacy sentinel (no version) or an older version forces a refresh.
+if [ -f "$SENTINEL" ] && [ "$(cat "$SENTINEL" 2>/dev/null)" = "$SEED_VERSION" ]; then
+  echo "🌱 seed: already seeded (v$SEED_VERSION) — skipping copies/installers"
   exit 0
 fi
+echo "🌱 seed: seeding to v$SEED_VERSION"
 
 echo "🌱 seed: creating container-local ~/.claude"
 mkdir -p "$HOME/.claude"
@@ -222,10 +240,12 @@ if [ -x "$HOME/.dotfiles/ai/codex/install.sh" ]; then
   bash "$HOME/.dotfiles/ai/codex/install.sh" || echo "⚠️  seed: codex install failed (non-fatal)"
 fi
 
-# 5. Sentinel.
-touch "$SENTINEL"
-echo "🌱 seed: done"
+# 5. Stamp the sentinel with the current version.
+printf '%s\n' "$SEED_VERSION" >"$SENTINEL"
+echo "🌱 seed: done (v$SEED_VERSION)"
 ```
+
+The sentinel now stores a version number rather than being a bare touch-file. The always-run block (ownership + Vekil hook) executes before the gate, so hook changes land on the next container start; the gated copy/install steps re-run whenever `SEED_VERSION` is bumped, even on a persisted named volume that survives `--remove-existing-container`. A legacy bare sentinel (empty file) compares unequal to any version and triggers one refresh.
 
 Execute it with `bash`; an executable bit is optional. Keep both files untracked. If the project does not already ignore them, add the actual override path plus the seed script path to `.git/info/exclude`. For the common `.devcontainer/` layout:
 
@@ -270,11 +290,20 @@ Once written:
 ```bash
 docker compose exec {SERVICE} sh -c 'test "$(stat -c %u:%g /home/{USER}/.claude)" = "$(id -u):$(id -g)" && test "$(stat -c %u:%g /home/{USER}/.dotfiles)" = "$(id -u):$(id -g)"'
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/.seeded
+docker compose exec {SERVICE} grep -Fq 'ai/vekil/env.zsh' /home/{USER}/.zshrc   # Vekil hook present
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/settings.json
 docker compose exec {SERVICE} test -f /home/{USER}/.codex/config.toml
 docker compose exec {SERVICE} zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
 docker compose exec {SERVICE} sh -c 'touch /host-seed/.claude/.write-test' # must fail read-only
 ```
+
+The `grep` line asserts the seed actually wrote the Vekil hook into the
+container's `~/.zshrc`. An empty `OPENAI_BASE_URL` in the `zsh -lic` line with
+the hook present points at the readiness probe, not a missing hook. If the hook
+grep fails, the seed's always-run block didn't execute — check that the running
+container isn't holding a stale pre-hook `local-seed.sh` (a persisted named
+volume can keep an old sentinel; the versioned sentinel forces a refresh, but
+only once the on-disk seed script is the current template).
 
 Empty endpoint variables or Codex resolving to the raw binary mean the
 container-local zsh hook did not load or Vekil's `/readyz` probe failed.

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
@@ -196,10 +196,14 @@ if ! grep -Fqx "$VEKIL_ENV_HOOK" "$ZSHRC"; then
 fi
 
 # --- Versioned gate --------------------------------------------------------
-# Skip the gated steps only when the sentinel records the CURRENT version.
-# A bare legacy sentinel (no version) or an older version forces a refresh.
-if [ -f "$SENTINEL" ] && [ "$(cat "$SENTINEL" 2>/dev/null)" = "$SEED_VERSION" ]; then
-  echo "🌱 seed: already seeded (v$SEED_VERSION) — skipping copies/installers"
+# Skip the gated copy/install steps when the sentinel is current: either a
+# legacy bare sentinel (empty — the pre-versioning contract) or one that already
+# records this SEED_VERSION. Refresh only when a stamped version differs, so a
+# bump re-runs the steps on containers seeded by a newer template without
+# disturbing already-good legacy volumes. The Vekil hook above runs regardless.
+SEEN_VERSION="$(cat "$SENTINEL" 2>/dev/null || true)"
+if [ -f "$SENTINEL" ] && { [ -z "$SEEN_VERSION" ] || [ "$SEEN_VERSION" = "$SEED_VERSION" ]; }; then
+  echo "🌱 seed: already seeded (${SEEN_VERSION:-legacy}) — skipping copies/installers"
   exit 0
 fi
 echo "🌱 seed: seeding to v$SEED_VERSION"
@@ -245,7 +249,7 @@ printf '%s\n' "$SEED_VERSION" >"$SENTINEL"
 echo "🌱 seed: done (v$SEED_VERSION)"
 ```
 
-The sentinel now stores a version number rather than being a bare touch-file. The always-run block (ownership + Vekil hook) executes before the gate, so hook changes land on the next container start; the gated copy/install steps re-run whenever `SEED_VERSION` is bumped, even on a persisted named volume that survives `--remove-existing-container`. A legacy bare sentinel (empty file) compares unequal to any version and triggers one refresh.
+The sentinel now stores a version number rather than being a bare touch-file. The always-run block (ownership + Vekil hook) executes before the gate, so hook changes land on the next container start; the gated copy/install steps re-run whenever `SEED_VERSION` is bumped to a value different from what a *stamped* sentinel records, even on a persisted named volume that survives `--remove-existing-container`. A legacy bare sentinel (empty file) is treated as current and left alone — the always-run block still updates its hook — so existing good volumes are not needlessly reseeded.
 
 Execute it with `bash`; an executable bit is optional. Keep both files untracked. If the project does not already ignore them, add the actual override path plus the seed script path to `.git/info/exclude`. For the common `.devcontainer/` layout:
 
@@ -291,19 +295,23 @@ Once written:
 docker compose exec {SERVICE} sh -c 'test "$(stat -c %u:%g /home/{USER}/.claude)" = "$(id -u):$(id -g)" && test "$(stat -c %u:%g /home/{USER}/.dotfiles)" = "$(id -u):$(id -g)"'
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/.seeded
 docker compose exec {SERVICE} grep -Fq 'ai/vekil/env.zsh' /home/{USER}/.zshrc   # Vekil hook present
+docker compose exec {SERVICE} zsh -c 'source /home/{USER}/.zshrc' 2>&1           # hook sources cleanly
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/settings.json
 docker compose exec {SERVICE} test -f /home/{USER}/.codex/config.toml
 docker compose exec {SERVICE} zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
 docker compose exec {SERVICE} sh -c 'touch /host-seed/.claude/.write-test' # must fail read-only
 ```
 
-The `grep` line asserts the seed actually wrote the Vekil hook into the
-container's `~/.zshrc`. An empty `OPENAI_BASE_URL` in the `zsh -lic` line with
-the hook present points at the readiness probe, not a missing hook. If the hook
-grep fails, the seed's always-run block didn't execute — check that the running
-container isn't holding a stale pre-hook `local-seed.sh` (a persisted named
-volume can keep an old sentinel; the versioned sentinel forces a refresh, but
-only once the on-disk seed script is the current template).
+The `grep` line asserts the seed wrote the Vekil hook into the container's
+`~/.zshrc`; the `source` line asserts it actually loads — a present-but-broken
+hook (missing or malformed `~/.dotfiles/ai/vekil/env.zsh` target) prints errors
+here even though the grep passed. Only once the hook sources cleanly does an
+empty `OPENAI_BASE_URL` in the `zsh -lic` line point at the readiness probe
+rather than a missing or non-loading hook. If the grep fails, the seed's
+always-run block didn't execute — check that the running container isn't holding
+a stale pre-hook `local-seed.sh` (a persisted named volume can keep an old
+sentinel; a version bump refreshes the gated steps, but only once the on-disk
+seed script is the current template).
 
 Empty endpoint variables or Codex resolving to the raw binary mean the
 container-local zsh hook did not load or Vekil's `/readyz` probe failed.

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
@@ -313,7 +313,7 @@ Once written:
 docker compose exec {SERVICE} sh -c 'test "$(stat -c %u:%g /home/{USER}/.claude)" = "$(id -u):$(id -g)" && test "$(stat -c %u:%g /home/{USER}/.dotfiles)" = "$(id -u):$(id -g)"'
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/.seeded
 docker compose exec {SERVICE} grep -Fq 'ai/vekil/env.zsh' /home/{USER}/.zshrc   # Vekil hook present
-docker compose exec {SERVICE} zsh -ec 'source /home/{USER}/.dotfiles/ai/vekil/env.zsh'   # hook target sources nonzero on failure
+docker compose exec {SERVICE} zsh -n /home/{USER}/.dotfiles/ai/vekil/env.zsh   # hook target exists + parses; no /readyz probe
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/settings.json
 docker compose exec {SERVICE} test -f /home/{USER}/.codex/config.toml
 docker compose exec {SERVICE} zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
@@ -321,11 +321,12 @@ docker compose exec {SERVICE} sh -c 'touch /host-seed/.claude/.write-test' # mus
 ```
 
 The `grep` line asserts the seed wrote the Vekil hook into the container's
-`~/.zshrc`; the `source` line sources the hook *target* directly under `zsh -e`,
-so a missing or malformed `~/.dotfiles/ai/vekil/env.zsh` exits nonzero even
-though later `.zshrc` lines would have masked the error. Only once the target
-sources cleanly does an empty `OPENAI_BASE_URL` in the `zsh -lic` line point at
-the readiness probe rather than a missing or non-loading hook. If the grep
+`~/.zshrc`; the `zsh -n` line validates the hook *target* alone — it exits
+nonzero if `~/.dotfiles/ai/vekil/env.zsh` is missing (127) or malformed (1)
+**without executing it**, so it never triggers the `/readyz` probe. That keeps
+"is the hook well-formed" separate from "is the proxy up": the `zsh -lic` line
+below is the combined hook-plus-readiness check, where an empty `OPENAI_BASE_URL`
+means the target sourced but the readiness probe failed. If the grep
 fails, the seed's always-run block didn't execute — check that the running
 container isn't holding a stale pre-hook `local-seed.sh` (a persisted named
 volume can keep an old sentinel; a version bump refreshes the gated steps, but

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
@@ -88,6 +88,8 @@ dotfiles-local-home     →  /home/{USER}/.dotfiles            named volume
 
 Compose merges service volumes by container target. These named-volume entries therefore replace legacy base-file binds targeting the same home paths instead of merely adding more mounts. If a base compose file binds host OpenCode config, add an empty `opencode-local-home` named volume at that target to shadow it; do not seed OpenCode.
 
+**Inherited ssh/gh binds.** If the merged base compose already binds the host's `~/.ssh` or `~/.config/gh` into the container (some base images do), the opt-in decision below is not enough on its own — an inherited bind leaks the host identity even when the user declined. When sharing is declined, shadow each inherited target with an empty project-scoped named volume (`ssh-local-home` at `/home/{USER}/.ssh`, `gh-local-home` at `/home/{USER}/.config/gh`) so the container starts with no host credentials. The merged-config check in Step 5 must confirm neither target resolves to a host bind.
+
 Why each one:
 - **`~/.claude` seed (ro)**: supplies only authored config to the seed script. The container never writes through this mount.
 - **`~/.dotfiles` seed (ro)**: supplies shell config and the marketplace/Codex installers. The script copies it container-local before running installers.
@@ -152,6 +154,20 @@ volumes:
   opencode-local-home:
 ```
 
+If the base compose file binds host `~/.ssh` or `~/.config/gh` and the user declined credential sharing, shadow those targets the same way so no host identity leaks in:
+
+```yaml
+services:
+  {SERVICE}:
+    volumes:
+      - ssh-local-home:/home/{USER}/.ssh
+      - gh-local-home:/home/{USER}/.config/gh
+
+volumes:
+  ssh-local-home:
+  gh-local-home:
+```
+
 This does not bridge OpenCode; it replaces the inherited host bind with an empty project-local volume.
 
 Write `{WORKSPACE}/.devcontainer/local-seed.sh` with:
@@ -201,8 +217,10 @@ fi
 # records this SEED_VERSION. Refresh only when a stamped version differs, so a
 # bump re-runs the steps on containers seeded by a newer template without
 # disturbing already-good legacy volumes. The Vekil hook above runs regardless.
-SEEN_VERSION="$(cat "$SENTINEL" 2>/dev/null || true)"
-if [ -f "$SENTINEL" ] && { [ -z "$SEEN_VERSION" ] || [ "$SEEN_VERSION" = "$SEED_VERSION" ]; }; then
+# A read that FAILS (permission/IO) is not a legacy sentinel — fall through to
+# the reseed path so the later sentinel write surfaces the error.
+if [ -f "$SENTINEL" ] && SEEN_VERSION="$(cat "$SENTINEL")" 2>/dev/null \
+   && { [ -z "$SEEN_VERSION" ] || [ "$SEEN_VERSION" = "$SEED_VERSION" ]; }; then
   echo "🌱 seed: already seeded (${SEEN_VERSION:-legacy}) — skipping copies/installers"
   exit 0
 fi
@@ -286,7 +304,7 @@ Any signal means offer repair. Confirm each write, back up the override, remove 
 ## Step 5 — Verify
 
 Once written:
-1. Run `docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml config` from the project root. Compose will print the merged config or fail loudly on a typo. Check that the service name matches and that no host bind targets the container user's `~/.claude`, `~/.dotfiles`, or OpenCode directory.
+1. Run `docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml config` from the project root. Compose will print the merged config or fail loudly on a typo. Check that the service name matches and that no host bind targets the container user's `~/.claude`, `~/.dotfiles`, or OpenCode directory. Unless the user opted into credential sharing, also confirm no host bind targets `~/.ssh` or `~/.config/gh` — an inherited base-file bind there must be shadowed with an empty named volume (Step 3), not left in the merged config.
 2. Confirm the merged `command` contains `local-seed.sh` followed by the original foreground command.
 3. Run `git check-ignore .devcontainer/docker-compose.override.yml .devcontainer/local-seed.sh`, then compare `git status --short` with the initial snapshot. They must match; if a new tracked devcontainer modification appears, report it without staging or reverting it.
 4. After the user rebuilds, verify container-local files and read-only seed mounts:
@@ -295,7 +313,7 @@ Once written:
 docker compose exec {SERVICE} sh -c 'test "$(stat -c %u:%g /home/{USER}/.claude)" = "$(id -u):$(id -g)" && test "$(stat -c %u:%g /home/{USER}/.dotfiles)" = "$(id -u):$(id -g)"'
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/.seeded
 docker compose exec {SERVICE} grep -Fq 'ai/vekil/env.zsh' /home/{USER}/.zshrc   # Vekil hook present
-docker compose exec {SERVICE} zsh -c 'source /home/{USER}/.zshrc' 2>&1           # hook sources cleanly
+docker compose exec {SERVICE} zsh -ec 'source /home/{USER}/.dotfiles/ai/vekil/env.zsh'   # hook target sources nonzero on failure
 docker compose exec {SERVICE} test -f /home/{USER}/.claude/settings.json
 docker compose exec {SERVICE} test -f /home/{USER}/.codex/config.toml
 docker compose exec {SERVICE} zsh -lic 'print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; print "ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"; whence -v codex'
@@ -303,15 +321,15 @@ docker compose exec {SERVICE} sh -c 'touch /host-seed/.claude/.write-test' # mus
 ```
 
 The `grep` line asserts the seed wrote the Vekil hook into the container's
-`~/.zshrc`; the `source` line asserts it actually loads — a present-but-broken
-hook (missing or malformed `~/.dotfiles/ai/vekil/env.zsh` target) prints errors
-here even though the grep passed. Only once the hook sources cleanly does an
-empty `OPENAI_BASE_URL` in the `zsh -lic` line point at the readiness probe
-rather than a missing or non-loading hook. If the grep fails, the seed's
-always-run block didn't execute — check that the running container isn't holding
-a stale pre-hook `local-seed.sh` (a persisted named volume can keep an old
-sentinel; a version bump refreshes the gated steps, but only once the on-disk
-seed script is the current template).
+`~/.zshrc`; the `source` line sources the hook *target* directly under `zsh -e`,
+so a missing or malformed `~/.dotfiles/ai/vekil/env.zsh` exits nonzero even
+though later `.zshrc` lines would have masked the error. Only once the target
+sources cleanly does an empty `OPENAI_BASE_URL` in the `zsh -lic` line point at
+the readiness probe rather than a missing or non-loading hook. If the grep
+fails, the seed's always-run block didn't execute — check that the running
+container isn't holding a stale pre-hook `local-seed.sh` (a persisted named
+volume can keep an old sentinel; a version bump refreshes the gated steps, but
+only once the on-disk seed script is the current template).
 
 Empty endpoint variables or Codex resolving to the raw binary mean the
 container-local zsh hook did not load or Vekil's `/readyz` probe failed.


### PR DESCRIPTION
## Summary

Two related hardening changes to the `my:project-claude-setup` skill, driven by real friction:

- **SSH/gh sharing is now opt-in, off by default.** The skill used to mount host `~/.ssh` and `~/.config/gh` read-only into every compose devcontainer. Both are single global credentials, so this forced each container onto the same GitHub identity and could switch accounts unexpectedly across projects. Now the skill asks once ("Share host SSH keys and gh auth? (default: no)") and otherwise leaves the container to authenticate itself (`gh auth login`, a project-scoped `GH_TOKEN`, or its own key). The override template ships the two mounts commented out.

- **The devcontainer seed sentinel is now versioned.** A persisted named volume survives `--remove-existing-container`, so a bare touch-file `.seeded` pinned an evolving container to its very first seed forever. That's the concrete bug this fixes: a container seeded before the Vekil zsh hook existed never picked it up, so `OPENAI_BASE_URL` / the managed `codex` wrapper were silently absent until a manual `source`. The seed now stores `SEED_VERSION` and re-runs the gated copy/install steps when it changes, while ownership repair and the Vekil hook run in an always-run block before the gate. A legacy bare sentinel triggers one refresh.

- **Verification asserts the hook.** Both the SKILL.md and reference verification blocks now `grep` for the Vekil hook in `~/.zshrc` alongside the proxy-var check, and distinguish "hook missing → stale seed" from "hook present but var unset → readiness probe."

## Test plan

- [ ] `bash -n` and `shellcheck -S warning` on the regenerated seed script — pass (verified locally against a real project's generated copy).
- [ ] In an affected devcontainer: restart, then confirm `grep vekil ~/.zshrc` succeeds and `print "OPENAI_BASE_URL=$OPENAI_BASE_URL"; whence -v codex` shows the managed values.
- [ ] Fresh project run of `my:project-claude-setup` on a compose devcontainer: confirm ssh/gh are not mounted unless opted in, and the seed stamps `SEED_VERSION`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that SSH keys and GitHub CLI credentials are opt-in only, and added safeguards to prevent inherited compose mounts from persisting when credential sharing is declined.
  * Updated troubleshooting guidance for repairing/remounting credential-related paths to apply the new shadowing logic only when not opted in.
  * Strengthened devcontainer verification by directly sourcing the shell hook target to clearly distinguish hook/setup failures from readiness checks.
  * Improved local seeding behavior to re-seed when the existing sentinel can’t be read, ensuring container refreshes correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->