### PR TITLE
Start the Vekil proxy automatically via a systemd user service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,13 +22,14 @@ ai/
     install.sh
   vekil/                     # Shared Copilot model proxy for Claude Code + Codex
     env.zsh                  # Auto-selects host/devcontainer endpoint
+    vekil.service            # systemd user unit template (autostart at boot)
     install.sh               # Pinned install, managed auth, lifecycle startup
 ```
 
 Configuration is symlinked into `~/.claude/` and `~/.codex/` by the respective
 install scripts. Run `make ai` or individual `ai/*/install.sh` scripts.
 
-Vekil is installed and started only through `ai/vekil/install.sh` and `bin/vekil-proxy`. Its credentials and runtime state are machine-local under `~/.config/vekil/` and `~/.local/state/vekil/`, but their lifecycle is repository-managed. The proxy binds to the Docker bridge when available so devcontainers can use `host.docker.internal` without exposing it on every interface.
+Vekil is installed and started only through `ai/vekil/install.sh` and `bin/vekil-proxy`. Its credentials and runtime state are machine-local under `~/.config/vekil/` and `~/.local/state/vekil/`, but their lifecycle is repository-managed. On Linux the installer also enables a systemd user service (from `ai/vekil/vekil.service`) so the proxy starts at boot — `env.zsh` only reads the proxy's state and never starts it. The proxy binds to the Docker bridge when available so devcontainers can use `host.docker.internal` without exposing it on every interface.
 
 ## The `my` Plugin
 

--- a/ai/vekil/README.md
+++ b/ai/vekil/README.md
@@ -6,9 +6,47 @@ its installer (`install.sh`), lifecycle helper reference, and the shell
 integration (`env.zsh`) that points the clients at the proxy.
 
 - Proxy lifecycle script: `bin/vekil-proxy`
+- Autostart unit template: `ai/vekil/vekil.service`
 - Shell integration (sourced from `core/shell/load-custom.zsh`): `ai/vekil/env.zsh`
 - Codex config + auth installer: `ai/codex/install.sh`
 - Migration background: `VEKIL_MIGRATION_HANDOFF.md` (repo root)
+
+## Autostart
+
+`env.zsh` is deliberately read-only: it checks `/readyz` and, if the proxy is
+down, unsets the managed variables and returns. It never starts the proxy. So
+something else has to, or every shell after a reboot silently gets no
+`ANTHROPIC_BASE_URL` and Claude/Codex bypass the proxy.
+
+On Linux with a systemd user manager, `ai/vekil/install.sh` installs a user
+service from the `ai/vekil/vekil.service` template, substituting the repo path
+into `ExecStart`, then enables it and turns on lingering (so the user manager
+survives logout and starts at boot).
+
+```bash
+systemctl --user status vekil       # is it up?
+systemctl --user restart vekil      # after auth changes or a version bump
+journalctl --user -u vekil -n 50    # startup output (proxy's own log is bin/vekil-proxy logs)
+```
+
+Notes:
+
+- The unit is `Type=oneshot` + `RemainAfterExit=yes`. `vekil-proxy start`
+  daemonizes and returns once `/readyz` answers; the proxy stays in the unit's
+  cgroup, so `systemctl --user stop vekil` shuts it down properly.
+- `ExecStartPre` waits up to 30s for the Docker bridge. The proxy binds to that
+  bridge so devcontainers can reach it via `host.docker.internal`; without the
+  wait, a boot race binds it to loopback and container access breaks silently.
+- A terminal opened in the first second or two after boot can still lose the
+  race and start without the variables. Open a new shell.
+- If you set `VEKIL_PORT`, `VEKIL_BIN`, `VEKIL_STATE_DIR`, `VEKIL_TOKEN_DIR`, or
+  `VEKIL_INSTALL_DIR`, the installer skips the service and starts the proxy
+  directly — the unit runs with no environment and would otherwise manage a
+  different proxy than you asked for. Same fallback when there is no systemd
+  user manager (containers, CI, macOS): set `VEKIL_SKIP_SERVICE=1` to force it.
+- Lingering needs polkit permission. If the installer warns, run
+  `sudo loginctl enable-linger $USER`.
+
 
 ## How the two clients reach the proxy
 

--- a/ai/vekil/install.sh
+++ b/ai/vekil/install.sh
@@ -2,6 +2,19 @@
 
 set -euo pipefail
 
+# Snapshot caller-supplied overrides before the defaults below assign them.
+# The user service starts vekil-proxy with no environment, so it can only
+# manage the default port/paths; any override must take the direct path.
+VEKIL_ENV_OVERRIDDEN=0
+for _vekil_override in VEKIL_PORT VEKIL_BIN VEKIL_STATE_DIR VEKIL_TOKEN_DIR VEKIL_INSTALL_DIR; do
+  if [[ -n "${!_vekil_override+x}" ]]; then
+    VEKIL_ENV_OVERRIDDEN=1
+    VEKIL_ENV_OVERRIDE_NAME="$_vekil_override"
+    break
+  fi
+done
+unset _vekil_override
+
 source "$(dirname "${BASH_SOURCE[0]}")/../../bin/common.sh"
 
 DOTFILES_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
@@ -18,6 +31,11 @@ LIFECYCLE_BIN="$DOTFILES_ROOT/bin/vekil-proxy"
 LEGACY_LITELLM_DIR="${LITELLM_CONFIG_DIR:-$HOME/.config/litellm}"
 LEGACY_LITELLM_CONFIG="$LEGACY_LITELLM_DIR/config.yaml"
 LEGACY_STOP_TIMEOUT="${VEKIL_LEGACY_STOP_TIMEOUT:-15}"
+SERVICE_TEMPLATE="$DOTFILES_ROOT/ai/vekil/vekil.service"
+SYSTEMD_USER_DIR="${VEKIL_SYSTEMD_USER_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
+SERVICE_UNIT="$SYSTEMD_USER_DIR/vekil.service"
+STAGED_SERVICE=""
+SERVICE_INSTALLED=0
 DOWNLOAD_DIR=""
 STAGED_BIN=""
 STAGED_VERSION=""
@@ -30,6 +48,7 @@ cleanup() {
   [[ -z "$STAGED_BIN" ]] || rm -f "$STAGED_BIN"
   [[ -z "$STAGED_VERSION" ]] || rm -f "$STAGED_VERSION"
   [[ -z "$STAGED_RESTART_REQUIRED" ]] || rm -f "$STAGED_RESTART_REQUIRED"
+  [[ -z "$STAGED_SERVICE" ]] || rm -f "$STAGED_SERVICE"
 }
 
 trap cleanup EXIT
@@ -426,6 +445,72 @@ authenticate_vekil() {
   fi
 }
 
+systemd_user_available() {
+  [[ "$(uname -s)" == "Linux" ]] || return 1
+  [[ "${VEKIL_SKIP_SERVICE:-0}" != "1" ]] || return 1
+  command -v systemctl >/dev/null 2>&1 || return 1
+  # `systemctl --user` always acts on the invoking user's real manager, ignoring
+  # HOME. If HOME has been redirected (test harnesses, sandboxes), installing a
+  # unit would mutate state outside the sandbox -- refuse and start directly.
+  local real_home
+  real_home=$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6 || true)
+  [[ -n "$real_home" && "$HOME" == "$real_home" ]] || return 1
+  # A user manager only exists for a real login session (absent in containers,
+  # SSH ForceCommand, and CI). Without it, fall back to a direct start.
+  systemctl --user show-environment >/dev/null 2>&1 || return 1
+  [[ -f "$SERVICE_TEMPLATE" && ! -L "$SERVICE_TEMPLATE" ]] || return 1
+  # The unit invokes vekil-proxy with no environment, so it resolves the default
+  # port/paths. If this run overrides any of them, systemd would manage a
+  # different proxy than the caller asked for -- use the direct path instead.
+  if ((VEKIL_ENV_OVERRIDDEN)); then
+    log_warning "${VEKIL_ENV_OVERRIDE_NAME} is set; skipping the Vekil user service and starting the proxy directly."
+    return 1
+  fi
+}
+
+# Installs (or refreshes) the user unit that starts the proxy at login/boot.
+# The unit is generated from the repo template so DOTFILES_ROOT is baked in and
+# the file stays a plain regular file rather than a symlink into the repo --
+# systemd refuses to follow unit symlinks outside its search path predictably.
+install_service_unit() {
+  SERVICE_INSTALLED=0
+  systemd_user_available || return 0
+
+  prepare_destination_directory "$SYSTEMD_USER_DIR"
+  validate_regular_target "$SERVICE_UNIT"
+
+  STAGED_SERVICE=$(mktemp "$SYSTEMD_USER_DIR/.vekil.service.XXXXXX")
+  sed "s|@DOTFILES_ROOT@|$DOTFILES_ROOT|g" "$SERVICE_TEMPLATE" >"$STAGED_SERVICE"
+  chmod 0644 "$STAGED_SERVICE"
+
+  if [[ -f "$SERVICE_UNIT" ]] && cmp -s "$STAGED_SERVICE" "$SERVICE_UNIT"; then
+    rm -f "$STAGED_SERVICE"
+    STAGED_SERVICE=""
+  else
+    validate_regular_target "$SERVICE_UNIT"
+    command mv -f "$STAGED_SERVICE" "$SERVICE_UNIT"
+    STAGED_SERVICE=""
+    log_info "Installed Vekil user service at $SERVICE_UNIT."
+  fi
+
+  systemctl --user daemon-reload
+  systemctl --user enable vekil.service >/dev/null
+
+  # Without lingering, the user manager is torn down when the last session ends,
+  # so the proxy would not survive a reboot into a fresh WSL/SSH session.
+  if command -v loginctl >/dev/null 2>&1; then
+    if [[ "$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)" != "yes" ]]; then
+      if loginctl enable-linger "$USER" 2>/dev/null; then
+        log_info "Enabled systemd lingering for $USER."
+      else
+        log_warning "Could not enable systemd lingering; run: sudo loginctl enable-linger $USER"
+      fi
+    fi
+  fi
+
+  SERVICE_INSTALLED=1
+}
+
 start_vekil() {
   [[ "${VEKIL_SKIP_START:-0}" == "1" ]] && return 0
 
@@ -439,7 +524,19 @@ start_vekil() {
   validate_regular_target "$RESTART_REQUIRED_FILE"
   [[ "$VEKIL_CHANGED" == "0" && "$AUTH_CHANGED" == "0" && ! -f "$RESTART_REQUIRED_FILE" ]] || action="restart"
   [[ -z "${VEKIL_PORT+x}" ]] || lifecycle_env+=("VEKIL_PORT=$VEKIL_PORT")
-  command env "${lifecycle_env[@]}" "$LIFECYCLE_BIN" "$action"
+
+  if ((SERVICE_INSTALLED)); then
+    # Let systemd own the process so it is tracked and restarted on boot.
+    # ExecStart is idempotent: vekil-proxy start is a no-op when already ready.
+    if [[ "$action" == "restart" ]]; then
+      systemctl --user restart vekil.service
+    else
+      systemctl --user start vekil.service
+    fi
+  else
+    command env "${lifecycle_env[@]}" "$LIFECYCLE_BIN" "$action"
+  fi
+
   [[ "$action" != "restart" ]] || clear_restart_required
 }
 
@@ -453,6 +550,7 @@ main() {
     log_info "[dry-run] Would inspect $LEGACY_LITELLM_DIR/proxy.pid for legacy LiteLLM on port 4000"
     log_info "[dry-run] Would inspect $LEGACY_LITELLM_DIR/codex-proxy.pid for legacy LiteLLM on port 4001"
     log_info "[dry-run] Would authenticate Vekil using token directory $TOKEN_DIR and start it through bin/vekil-proxy"
+    log_info "[dry-run] Would install and enable the user service $SERVICE_UNIT from $SERVICE_TEMPLATE"
     return 0
   fi
 
@@ -461,6 +559,7 @@ main() {
   install_vekil
   cleanup_legacy_litellm
   authenticate_vekil
+  install_service_unit
   start_vekil
   log_success "Vekil setup complete."
 }

--- a/ai/vekil/install.sh
+++ b/ai/vekil/install.sh
@@ -480,7 +480,13 @@ install_service_unit() {
   validate_regular_target "$SERVICE_UNIT"
 
   STAGED_SERVICE=$(mktemp "$SYSTEMD_USER_DIR/.vekil.service.XXXXXX")
-  sed "s|@DOTFILES_ROOT@|$DOTFILES_ROOT|g" "$SERVICE_TEMPLATE" >"$STAGED_SERVICE"
+  # Escape the replacement so a repo path containing sed metacharacters (\, &,
+  # or the | delimiter) is substituted literally instead of corrupting the unit.
+  local escaped_root
+  escaped_root=${DOTFILES_ROOT//\\/\\\\}
+  escaped_root=${escaped_root//|/\\|}
+  escaped_root=${escaped_root//&/\\&}
+  sed "s|@DOTFILES_ROOT@|$escaped_root|g" "$SERVICE_TEMPLATE" >"$STAGED_SERVICE"
   chmod 0644 "$STAGED_SERVICE"
 
   if [[ -f "$SERVICE_UNIT" ]] && cmp -s "$STAGED_SERVICE" "$SERVICE_UNIT"; then

--- a/ai/vekil/vekil.service
+++ b/ai/vekil/vekil.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Vekil AI model proxy (Claude Code + Codex)
+Documentation=file://@DOTFILES_ROOT@/ai/vekil/README.md
+After=default.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# vekil-proxy binds to the Docker bridge so devcontainers can reach the proxy
+# via host.docker.internal. If Docker has not published the bridge yet, the
+# helper falls back to loopback-only and devcontainer access silently breaks.
+# Docker runs as a system service, so a user unit cannot order itself after it;
+# poll for the bridge instead, bounded, then start anyway on loopback.
+ExecStartPre=/usr/bin/env bash -c 'for _ in $(seq 1 30); do docker network inspect bridge >/dev/null 2>&1 && exit 0; sleep 1; done; exit 0'
+
+ExecStart=@DOTFILES_ROOT@/bin/vekil-proxy start
+ExecStop=@DOTFILES_ROOT@/bin/vekil-proxy stop
+
+# vekil-proxy waits for /readyz itself (VEKIL_START_TIMEOUT, default 90s).
+TimeoutStartSec=180
+
+[Install]
+WantedBy=default.target

--- a/tests/ai_installers.bats
+++ b/tests/ai_installers.bats
@@ -142,6 +142,57 @@ SCRIPT
   [ "$(cat "$HOME/action")" = "start" ]
 }
 
+@test "vekil installer does not touch systemd when HOME is redirected" {
+  # `systemctl --user` ignores HOME and targets the invoking user's real
+  # manager, so a sandboxed run must never install or enable the unit.
+  mkdir -p "$HOME/.local/bin" "$HOME/.local/state/vekil" "$HOME/.config/vekil"
+  printf 'v0.13.3\n' >"$HOME/.local/state/vekil/installed-version"
+  printf 'token\n' >"$HOME/.config/vekil/access-token"
+  chmod 0600 "$HOME/.config/vekil/access-token"
+  printf '#!/bin/bash\nexit 0\n' >"$HOME/.local/bin/vekil"
+  chmod +x "$HOME/.local/bin/vekil"
+
+  cat >"$STUB_BIN/systemctl" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' "$*" >>"$VEKIL_SYSTEMCTL_LOG"
+SCRIPT
+  chmod +x "$STUB_BIN/systemctl"
+  cat >"$STUB_BIN/env" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' "${*: -1}" >"$VEKIL_ACTION_FILE"
+SCRIPT
+  chmod +x "$STUB_BIN/env"
+
+  run /usr/bin/env \
+    HOME="$HOME" \
+    PATH="$PATH" \
+    VEKIL_SKIP_AUTH=1 \
+    VEKIL_SYSTEMCTL_LOG="$HOME/systemctl.log" \
+    VEKIL_ACTION_FILE="$HOME/action" \
+    bash "$REPO_ROOT/ai/vekil/install.sh"
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$HOME/systemctl.log" ]
+  [ ! -e "$HOME/.config/systemd/user/vekil.service" ]
+  # Falls back to starting the proxy through the lifecycle helper.
+  [ "$(cat "$HOME/action")" = "start" ]
+}
+
+@test "vekil service template renders an absolute repo path" {
+  local template="$REPO_ROOT/ai/vekil/vekil.service"
+  [ -f "$template" ]
+  grep -q '^ExecStart=@DOTFILES_ROOT@/bin/vekil-proxy start$' "$template"
+  grep -q '^ExecStop=@DOTFILES_ROOT@/bin/vekil-proxy stop$' "$template"
+  # oneshot + RemainAfterExit keeps the daemonized proxy in the unit cgroup so
+  # `systemctl --user stop` shuts it down instead of leaking the process.
+  grep -q '^Type=oneshot$' "$template"
+  grep -q '^RemainAfterExit=yes$' "$template"
+  grep -q '^WantedBy=default.target$' "$template"
+  # No placeholder may survive rendering.
+  run bash -c "sed 's|@DOTFILES_ROOT@|/repo|g' '$template' | grep -c '@DOTFILES_ROOT@' || true"
+  [ "$output" = "0" ]
+}
+
 @test "codex check mode changes no files" {
   assert_check_is_immutable ai/codex/install.sh
 }

--- a/tests/ai_installers.bats
+++ b/tests/ai_installers.bats
@@ -193,6 +193,22 @@ SCRIPT
   [ "$output" = "0" ]
 }
 
+@test "vekil service rendering escapes sed metacharacters in the repo path" {
+  # A repo path containing \, & or the | delimiter must be substituted
+  # literally; unescaped, sed silently corrupts the unit or errors out.
+  local template="$TEST_ROOT/tmpl.service"
+  printf 'ExecStart=@DOTFILES_ROOT@/bin/vekil-proxy start\n' >"$template"
+
+  local root='/home/a&b/c|d/e\f/dotfiles'
+  local escaped=${root//\\/\\\\}
+  escaped=${escaped//|/\\|}
+  escaped=${escaped//&/\\&}
+
+  run sed "s|@DOTFILES_ROOT@|$escaped|g" "$template"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ExecStart=$root/bin/vekil-proxy start" ]
+}
+
 @test "codex check mode changes no files" {
   assert_check_is_immutable ai/codex/install.sh
 }


### PR DESCRIPTION
## Problem

The proxy never started at boot. `env.zsh` *was* being sourced correctly from `.zshrc` — but it is deliberately read-only: it probes `/readyz` and, when the proxy is down, unsets the managed variables and returns. It never starts anything.

The only caller of `vekil-proxy start` was `ai/vekil/install.sh`, i.e. install time only. No systemd unit, no cron, no `.zprofile` hook. So after a reboot every new shell came up without `ANTHROPIC_BASE_URL`, and both Claude and Codex silently bypassed the proxy until the helper was started by hand.

Manually sourcing `env.zsh` appeared to fix it only because by then the proxy had already been started — the sourcing was never the problem.

## Change

`ai/vekil/vekil.service` is a repo-tracked unit template, so the setup travels to new machines. `install.sh` renders `DOTFILES_ROOT` into it, installs it under `~/.config/systemd/user`, enables it, and turns on lingering so the user manager survives logout and starts at boot.

Two non-obvious constraints drove the design:

- **Docker bridge race.** The proxy binds to the Docker bridge so devcontainers reach it via `host.docker.internal`. A *user* unit cannot order itself after Docker (a *system* service), so `ExecStartPre` polls up to 30s for the bridge. Without it, a boot race binds loopback-only and container access breaks with no error.
- **`systemctl --user` ignores `HOME`.** It always targets the invoking user's real manager. The bats suite runs with a redirected `HOME`, so the installer would have mutated live user state during tests. It now refuses to touch systemd unless `HOME` is the real one.

Falls back to starting the proxy directly when the service is not appropriate: no systemd user manager (containers, CI, macOS), `VEKIL_SKIP_SERVICE=1`, or any caller-supplied `VEKIL_PORT`/`BIN`/`STATE_DIR`/`TOKEN_DIR`/`INSTALL_DIR` override — the unit runs with no environment and would otherwise manage a different proxy than requested. The override snapshot is taken *before* `install.sh` assigns its own defaults.

## Verification

- Tested `Type=oneshot` cgroup behavior on an isolated port (1339) **first** — this was the main risk, since default `KillMode` could have killed the disowned process. The daemonized proxy survives `ExecStart` exiting and still stops cleanly via the unit.
- Full stop → cold start cycle on the real service: stops cleanly, restarts to ready.
- Starting the unit while the proxy was already running **adopted** it rather than restarting.
- Fresh `zsh -i` now gets `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL`, `OPENAI_BASE_URL`, and the `codex` wrapper function.
- `make check` passes; 2 regression tests added (20/20 in `ai_installers.bats`).

## Reviewer notes

- **One pre-existing failure**, unrelated to this change: `gitconfig uses the managed global hooks directory` fails in any linked worktree (verified — it fails identically with these changes stashed, and passes in the primary checkout). Appears to be a worktree-specific issue in `bin/relink`; left alone.
- **Known limitation:** a terminal opened within ~1–2s of boot can still beat the proxy to ready. Accepted deliberately over adding a startup stall to every shell; documented in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vekil can now start automatically at login or boot on supported Linux systems.
  * Installation waits for Docker networking and improves startup and shutdown handling.
  * Custom paths or ports use a direct startup fallback when system services are unavailable.

* **Documentation**
  * Added autostart, fallback, lingering, and troubleshooting guidance.

* **Tests**
  * Added coverage for custom environments and service configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->