### PR TITLE
fix: make project overlay skills discoverable in worktrees and containers

### DIFF
--- a/ai/claude/hooks/overlay-sync.sh
+++ b/ai/claude/hooks/overlay-sync.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SessionStart hook: make the personal overlay's skills/agents available in
+# git worktrees, and repair overlay links that point at a foreign $HOME.
+#
+# Two failure modes this addresses:
+#
+#   1. `git worktree add` produces a fresh working tree. The .claude/ overlay
+#      is untracked, so it does not come along and none of the project's
+#      personal skills exist in the new worktree.
+#   2. A link created under one $HOME (e.g. a WSL host user's home) does not
+#      resolve under another (e.g. a devcontainer running as root), so
+#      the overlay is silently invisible even in the main checkout.
+#
+# Both are repaired by re-running claude-link-project, which is idempotent and
+# writes only inside the current working tree.
+#
+# Fails open: any unexpected condition exits 0 without touching anything. A
+# broken hook must never prevent a session from starting.
+set -u
+
+exit_quiet() { exit 0; }
+
+[ "${CLAUDE_OVERLAY_SYNC:-on}" = "off" ] && exit_quiet
+
+input=$(cat 2>/dev/null) || exit_quiet
+command -v jq >/dev/null 2>&1 || exit_quiet
+command -v git >/dev/null 2>&1 || exit_quiet
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || exit_quiet
+[ -n "$cwd" ] || cwd="${CLAUDE_PROJECT_DIR:-$PWD}"
+[ -d "$cwd" ] || exit_quiet
+
+DOTFILES="${DOTFILES:-$HOME/.dotfiles}"
+LINKER="$DOTFILES/bin/claude-link-project"
+[ -x "$LINKER" ] || exit_quiet
+
+repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || exit_quiet
+repo_root=$(cd "$repo_root" && pwd -P) || exit_quiet
+
+# The overlay is keyed on the project's directory name. A linked worktree is
+# named after its branch, not the project, so resolve the slug from the main
+# checkout: `git worktree list` prints the primary working tree first.
+main_root=$(git -C "$repo_root" worktree list --porcelain 2>/dev/null |
+  awk '/^worktree /{print substr($0, 10); exit}') || exit_quiet
+[ -n "$main_root" ] && [ -d "$main_root" ] || main_root="$repo_root"
+slug=$(basename "$main_root")
+
+overlay="$DOTFILES/projects/$slug"
+[ -d "$overlay" ] || exit_quiet
+
+# Nothing to do unless something is actually missing or broken. Checking first
+# keeps the common case free of writes and output.
+needs_work=0
+for sub in skills agents; do
+  [ -d "$overlay/.claude/$sub" ] || continue
+  # -e follows symlinks, so a dangling link fails this test — which is
+  # exactly the foreign-$HOME breakage we want to catch.
+  [ -e "$repo_root/.claude/$sub" ] || needs_work=1
+done
+# Any dangling link anywhere under .claude/ also warrants a repair pass.
+if [ -d "$repo_root/.claude" ] &&
+  [ -n "$(find "$repo_root/.claude" -xtype l -print -quit 2>/dev/null)" ]; then
+  needs_work=1
+fi
+[ "$needs_work" -eq 1 ] || exit_quiet
+
+# --claude-dir-per-file is the safe mode: it refuses to shadow tracked project
+# files, and links skills/ and agents/ as whole directories.
+# --no-claude-md leaves CLAUDE.md alone; this hook only repairs discovery of
+# skills and agents, and must not touch instruction files behind the user's back.
+out=$("$LINKER" --claude-dir-per-file --no-claude-md --slug "$slug" "$repo_root" 2>&1 </dev/null) || exit_quiet
+
+# Count only the linker's change-reporting lines. Anchored at line start so
+# "already linked:" does not match — otherwise a no-op run would announce
+# itself on every session start.
+linked=$(printf '%s\n' "$out" |
+  grep -cE '^(linked:|repaired |migrated )' 2>/dev/null) || linked=0
+[ "${linked:-0}" -gt 0 ] || exit_quiet
+
+# Skills are discovered when the session starts, so links created by this hook
+# are not guaranteed to be loaded in the session that just began. Say so rather
+# than let the user wonder why a repaired skill still isn't listed.
+msg="Personal overlay for '$slug' was re-linked into $repo_root ($linked item(s) \
+created or migrated). Skills and agents are discovered at session start, so any \
+newly linked ones may not appear until this session is restarted."
+
+jq -n --arg c "$msg" \
+  '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$c}}'
+exit 0

--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -86,6 +86,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.dotfiles/ai/claude/hooks/overlay-sync.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -135,7 +135,7 @@ claude-link-project --create "${flags[@]}" "$PROJECT_DIR"
 
 - Default: symlinks `<project>/CLAUDE.md` → overlay's CLAUDE.md, and `<project>/.claude` → overlay's `.claude` dir.
 - `--local-md`: writes a 1-line `<project>/CLAUDE.local.md` (gitignored globally) containing `@~/.dotfiles/projects/<slug>/CLAUDE.md`; the project's tracked CLAUDE.md is left untouched.
-- `--claude-dir-per-file`: walks the overlay's `.claude/` tree and symlinks each leaf into the project's `.claude/` at the same relative path. `settings.local.json` is merged via jq (with diff + confirmation) instead of symlinked. If a tracked file in the project would be shadowed, the helper refuses with a clear message — rename your overlay item and re-run.
+- `--claude-dir-per-file`: links the overlay's `.claude/` into the project's `.claude/`. `skills/` and `agents/` are linked as **whole directories**; every other file is linked individually at the same relative path. `settings.local.json` is merged via jq (with diff + confirmation) instead of symlinked. If a tracked file in the project would be shadowed, the helper refuses with a clear message — rename your overlay item and re-run. A legacy per-file `skills/`/`agents/` tree from an older run is migrated to a directory link automatically, provided every entry under it is a symlink into the overlay.
 
 If the overlay already exists (re-run), the helper detects this and skips the placeholder writes. Per-file mode and merges are idempotent.
 
@@ -145,7 +145,44 @@ After running it, verify the expected on-disk shapes:
 ls -L <project>/CLAUDE.md       # symlink (default) OR untouched real file (--local-md)
 ls -L <project>/CLAUDE.local.md # exists only in --local-md mode
 ls -L <project>/.claude/settings.local.json
+
+# skills/ and agents/ are DIRECTORY symlinks into the overlay, not trees of
+# per-file links: Claude Code documents a <skill-name> entry that is a symlink
+# to a directory elsewhere, but says nothing about a symlinked SKILL.md inside
+# a real directory. A directory link also carries scripts/ and other payloads,
+# and picks up newly added skills with no re-run.
+ls -ld <project>/.claude/skills <project>/.claude/agents
+
+# Must print nothing. Any output is a dangling link — most often one created
+# under a different $HOME (host /home/<user> vs container /root), which makes
+# the overlay silently invisible. Re-run the helper to repair.
+find <project>/.claude -xtype l
 ```
+
+Skills and agents are discovered when a session starts, so anything linked
+after launch only appears once the session is restarted.
+
+### Git worktrees
+
+`git worktree add` produces a fresh working tree, and the `.claude/` overlay is
+untracked — so a new worktree starts with none of the project's personal skills
+or agents. The `SessionStart` hook at `ai/claude/hooks/overlay-sync.sh` repairs
+this automatically: it resolves the overlay slug from the **primary** working
+tree (a worktree directory is named after its branch, not the project), re-runs
+the linker, and reports what it created. It also repoints links left dangling by
+a different `$HOME`. It writes only inside the working tree it was invoked for,
+and fails open — a broken hook never blocks a session from starting.
+
+To link a worktree by hand, or whenever the directory name doesn't match the
+overlay, pass the slug explicitly:
+
+```bash
+project_name="<project-name>"
+worktree_dir="<worktree-dir>"
+claude-link-project --claude-dir-per-file --slug "$project_name" "$worktree_dir"
+```
+
+Set `CLAUDE_OVERLAY_SYNC=off` to disable the hook.
 
 ## Step 4 — CLAUDE.md content
 
@@ -329,7 +366,7 @@ tools: <restricted set — see table above>
 
 For **reviewer-type** agents: `tools: Read, Grep, Glob, Bash` with the Bash entries scoped to non-mutating commands. **No Edit/Write.** For **analyst-type** agents: same Read-only stance, Bash limited to `psql`, `curl`, etc.
 
-Files land at `<overlay>/.claude/agents/<name>.md`. Re-running `claude-link-project --claude-dir-per-file` walks the overlay tree and symlinks each new agent into the project's `.claude/agents/`.
+Files land at `<overlay>/.claude/agents/<name>.md`. Because `agents/` is a directory symlink, a new agent file appears in the project immediately — no re-run needed.
 
 ## Step 7b — Team-flow scaffolding (offer when standing catalog created)
 
@@ -353,7 +390,7 @@ The frontmatter is just `description:` and `argument-hint:`. Body uses `$ARGUMEN
 
 **File 2: workflow section appended to `<overlay>/CLAUDE.md`** — codifies when to use the team flow vs the main thread (see Step 4 for content guidance). Without this, Claude doesn't know it should reach for the agents on each new task and defaults to single-thread execution.
 
-`claude-link-project --claude-dir-per-file` walks the overlay tree, so `.claude/commands/*.md` get symlinked into the project the same way agents do. Re-run after creating the command file. **Verify the symlink lands**: `ls -L <project>/.claude/commands/new-feature.md` should resolve.
+`commands/` is still linked per-file (unlike `skills/` and `agents/`), because a project is more likely to track its own `.claude/commands/` content and the per-file mode is what catches those collisions. Re-run after creating the command file. **Verify the symlink lands**: `ls -L <project>/.claude/commands/new-feature.md` should resolve.
 
 Skip this step if the user only wants standalone subagents — the catalog still works for one-shot delegation without the team ritual.
 

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -155,7 +155,9 @@ ls -ld <project>/.claude/skills <project>/.claude/agents
 
 # Must print nothing. Any output is a dangling link — most often one created
 # under a different $HOME (host /home/<user> vs container /root), which makes
-# the overlay silently invisible. Re-run the helper to repair.
+# the overlay silently invisible. Re-running the helper repairs CLAUDE.md and
+# the skills/ and agents/ directory links. Individually linked files (commands/)
+# are only reported, not repaired: delete the dangling link and re-run.
 find <project>/.claude -xtype l
 ```
 

--- a/bin/claude-link-project
+++ b/bin/claude-link-project
@@ -41,7 +41,7 @@ MODE_CLAUDE_PER_FILE=0
 SLUG=""
 
 usage() {
-  sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -456,9 +456,16 @@ migrate_legacy_per_file_dir() {
   while IFS= read -r -d '' entry; do
     found=1
     [[ -L "$entry" ]] || return 1
-    # readlink -m resolves without requiring the target to exist, so a
-    # dangling cross-home link still reports where it was aiming.
-    target="$(readlink -m -- "$entry" 2>/dev/null)" || return 1
+    # Resolve where the link aims without requiring the target to exist —
+    # a dangling cross-home link is precisely the case we repair. BSD/macOS
+    # readlink has no -m, so fall back to reading the link value directly
+    # and resolving it against the link's own directory.
+    if target="$(readlink -m -- "$entry" 2>/dev/null)" && [[ -n "$target" ]]; then
+      :
+    else
+      target="$(readlink -- "$entry")" || return 1
+      [[ "$target" == /* ]] || target="$(dirname "$entry")/$target"
+    fi
     rel="${entry#"$dst"/}"
     [[ "$target" == *"/$suffix/$rel" ]] || return 1
   done < <(find "$dst" -mindepth 1 \! -type d -print0)
@@ -492,6 +499,24 @@ link_claude_dir_per_file() {
   for sub in "${DIR_LINK_SUBDIRS[@]}"; do
     [[ -d "$overlay_dir/$sub" ]] || continue
     migrate_legacy_per_file_dir "$overlay_dir/$sub" "$project_dir/$sub" || true
+    # link_one dies on a real file/dir in the way, which is right for
+    # CLAUDE.md but not here: the rest of the overlay (commands/,
+    # settings.local.json) is independent of this one subdirectory and
+    # should still be linked. Match the per-file walk's behaviour and
+    # warn instead, leaving the user's content untouched.
+    if [[ ! -L "$project_dir/$sub" && -e "$project_dir/$sub" ]]; then
+      if [[ -n "$proj_root" ]] &&
+        git -C "$proj_root" ls-files --error-unmatch \
+          -- "${project_dir#"$proj_root"/}/$sub" >/dev/null 2>&1; then
+        die "Collision: $project_dir/$sub is tracked in git. Rename your overlay item and re-run."
+      fi
+      warn "$project_dir/$sub exists (untracked, not a symlink). Skipping — move or remove it manually if you want to link the overlay version."
+      # Prune anyway: without this the per-file walk would descend into
+      # the overlay's skills/ and scatter links inside the user's own
+      # directory, which is the content we just decided not to touch.
+      find_prune+=(-path "$overlay_dir/$sub" -prune -o)
+      continue
+    fi
     link_one "$overlay_dir/$sub" "$project_dir/$sub"
     find_prune+=(-path "$overlay_dir/$sub" -prune -o)
   done

--- a/bin/claude-link-project
+++ b/bin/claude-link-project
@@ -13,9 +13,14 @@
 #   claude-link-project --local-md --agents-md <dir>    # also write AGENTS.local.md import shim
 #   claude-link-project --no-claude-md <project-dir>    # skip CLAUDE.md symlink entirely
 #   claude-link-project --claude-dir-per-file <project-dir>
-#       Symlink overlay's .claude/ contents file-by-file into project's .claude/
-#       instead of symlinking the whole directory. Use when project tracks
-#       .claude/ content. settings.local.json gets merged via jq.
+#       Symlink overlay's .claude/ contents into project's .claude/.
+#       skills/ and agents/ are linked as whole directories; other files
+#       are linked individually so collisions with tracked project files
+#       are still caught. settings.local.json gets merged via jq.
+#   claude-link-project --slug <name> <project-dir>
+#       Use overlay <name> instead of the project directory's basename.
+#       Defaults to the primary working tree's name, so linked git
+#       worktrees (named after their branch) resolve automatically.
 #
 # Example:
 #   mkdir -p ~/.dotfiles/projects/slabledger/.claude
@@ -33,6 +38,7 @@ SKIP_CLAUDE_MD=0
 MODE_LOCAL_MD=0
 SKIP_AGENTS_MD=1 # default: skip AGENTS.local.md (opt-in)
 MODE_CLAUDE_PER_FILE=0
+SLUG=""
 
 usage() {
   sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
@@ -65,6 +71,14 @@ while [[ $# -gt 0 ]]; do
       MODE_CLAUDE_PER_FILE=1
       shift
       ;;
+    --slug)
+      SLUG="${2:-}"
+      [[ -n "$SLUG" ]] || {
+        echo "--slug requires a value" >&2
+        usage 1
+      }
+      shift 2
+      ;;
     -h | --help) usage 0 ;;
     -*)
       echo "unknown flag: $1" >&2
@@ -85,7 +99,20 @@ PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd -P)" || {
   echo "no such dir: $PROJECT_DIR" >&2
   exit 1
 }
-NAME="$(basename "$PROJECT_DIR")"
+# The overlay is normally keyed on the project directory's name. That breaks
+# for a linked git worktree, whose directory is named after the branch, so
+# --slug lets the caller name the overlay explicitly. When it isn't given,
+# fall back to the primary working tree's name (git lists it first), which
+# makes worktrees resolve correctly without the caller having to care.
+if [[ -n "$SLUG" ]]; then
+  NAME="$SLUG"
+else
+  NAME="$(basename "$PROJECT_DIR")"
+  if main_root="$(git -C "$PROJECT_DIR" worktree list --porcelain 2>/dev/null |
+    awk '/^worktree /{print substr($0, 10); exit}')" && [[ -d "$main_root" ]]; then
+    NAME="$(basename "$main_root")"
+  fi
+fi
 OVERLAY="$OVERLAY_ROOT/$NAME"
 
 if [[ -t 1 ]]; then
@@ -226,6 +253,17 @@ link_one() {
       ok "already linked: $dst"
       return
     fi
+    # A dangling link is broken by definition, so it cannot be a
+    # deliberate choice worth preserving. The usual cause is a link
+    # created under a different $HOME — the host's /home/<user> seen
+    # from a container running as root, or the reverse — which leaves
+    # the overlay silently invisible. Repoint it.
+    if [[ ! -e "$dst" ]]; then
+      rm -f "$dst"
+      ln -s "$src" "$dst"
+      ok "repaired dangling link: $dst -> $src (was $cur)"
+      return
+    fi
     warn "$dst already a symlink to $cur — leave it alone (remove manually if you want to relink)"
     return
   elif [[ -e "$dst" ]]; then
@@ -302,8 +340,16 @@ merge_settings_local_json() {
   if [[ ! -e "$dst" ]]; then
     # No project file — just copy. We don't symlink because the project
     # may want to maintain its own settings.local.json independently.
-    cp "$src" "$dst"
-    ok "wrote: $dst (copied from overlay)"
+    # Normalize through jq so the bytes match what the merge below
+    # produces; a verbatim copy of a compact overlay file would differ
+    # from jq's pretty-printed output on every later run and prompt for
+    # a semantically empty change.
+    if jq . "$src" >"$dst" 2>/dev/null; then
+      ok "wrote: $dst (copied from overlay)"
+    else
+      cp "$src" "$dst"
+      warn "wrote: $dst (copied verbatim; overlay file is not valid JSON)"
+    fi
     return
   fi
 
@@ -333,7 +379,11 @@ merge_settings_local_json() {
     die "jq produced invalid JSON merging $dst"
   }
 
-  if diff -q "$dst" "$merged" >/dev/null; then
+  # Compare canonically: the merge is a no-op whenever the project file
+  # already carries the same JSON *values*, regardless of how it happens
+  # to be formatted. A byte comparison here would prompt for
+  # indentation-only differences and, with no TTY, abort the run.
+  if jq -e -s '.[0] == .[1]' "$dst" "$merged" >/dev/null 2>&1; then
     ok "$dst already up to date"
     rm -f "$merged"
     return
@@ -365,6 +415,61 @@ merge_settings_local_json() {
 # settings.local.json is special-cased: merged (via jq) instead of
 # symlinked, because the project may have its own untracked
 # settings.local.json the user wants preserved.
+#
+# skills/ and agents/ are linked as whole DIRECTORIES, not per-file.
+# Claude Code documents directory-level symlinks as supported for a
+# <skill-name> entry ("can be a symlink to a directory elsewhere on
+# disk") but says nothing about a symlinked SKILL.md inside a real
+# directory. A per-file tree also silently drops non-file payloads a
+# skill needs — scripts/, references/ — and makes each new overlay file
+# require a re-run to appear. Directory links avoid all three.
+DIR_LINK_SUBDIRS=(skills agents)
+
+# Replace a legacy per-file symlink tree with a single directory link.
+#
+# Earlier versions of --claude-dir-per-file symlinked each leaf, so an
+# existing skills/ or agents/ directory is a real dir full of links into
+# the overlay. link_one would die on it and abort the whole run, leaving
+# the rest of the overlay unlinked.
+#
+# Only migrate when EVERY entry underneath is a symlink that points at
+# the corresponding path in SOME home's copy of this overlay. The match
+# is on the "projects/<slug>/.claude/<sub>/..." suffix, deliberately NOT
+# on the absolute prefix: the breakage this repairs is a link created
+# under a different $HOME (host /home/user vs container /root), where an
+# absolute comparison never matches and the repair would silently skip
+# the one case it exists for. Dangling links are fine for the same
+# reason. Any real file, or a link whose suffix doesn't line up, means
+# the directory holds content we did not create, so we leave it alone
+# and let link_one report the collision.
+migrate_legacy_per_file_dir() {
+  local overlay_sub="$1" # <overlay>/.claude/skills
+  local dst="$2"         # <project>/.claude/skills
+
+  [[ -d "$dst" && ! -L "$dst" ]] || return 1
+
+  # The home-independent tail, e.g. projects/wanderer/.claude/skills
+  local suffix="${overlay_sub#*/projects/}"
+  suffix="projects/$suffix"
+
+  local entry target rel found=0
+  while IFS= read -r -d '' entry; do
+    found=1
+    [[ -L "$entry" ]] || return 1
+    # readlink -m resolves without requiring the target to exist, so a
+    # dangling cross-home link still reports where it was aiming.
+    target="$(readlink -m -- "$entry" 2>/dev/null)" || return 1
+    rel="${entry#"$dst"/}"
+    [[ "$target" == *"/$suffix/$rel" ]] || return 1
+  done < <(find "$dst" -mindepth 1 \! -type d -print0)
+
+  ((found)) || return 1
+
+  rm -rf "$dst"
+  ok "migrated legacy per-file tree: $dst (now a directory symlink)"
+  return 0
+}
+
 link_claude_dir_per_file() {
   local overlay_dir="$1" # ~/.dotfiles/projects/<slug>/.claude
   local project_dir="$2" # <project>/.claude
@@ -380,7 +485,18 @@ link_claude_dir_per_file() {
   local proj_root
   proj_root="$(git -C "$(dirname "$project_dir")" rev-parse --show-toplevel 2>/dev/null || true)"
 
-  # Walk overlay's .claude tree, link each regular file individually.
+  # Directory-level links first, so the per-file walk below can skip
+  # anything living underneath them.
+  local sub
+  local find_prune=()
+  for sub in "${DIR_LINK_SUBDIRS[@]}"; do
+    [[ -d "$overlay_dir/$sub" ]] || continue
+    migrate_legacy_per_file_dir "$overlay_dir/$sub" "$project_dir/$sub" || true
+    link_one "$overlay_dir/$sub" "$project_dir/$sub"
+    find_prune+=(-path "$overlay_dir/$sub" -prune -o)
+  done
+
+  # Walk overlay's .claude tree, link each remaining regular file individually.
   while IFS= read -r -d '' src <&3; do
     local rel="${src#$overlay_dir/}"
     local dst="$project_dir/$rel"
@@ -414,7 +530,7 @@ link_claude_dir_per_file() {
     fi
     ln -s "$src" "$dst"
     ok "linked: $dst -> $src"
-  done 3< <(find "$overlay_dir" -type f -print0)
+  done 3< <(find "$overlay_dir" "${find_prune[@]}" -type f -print0)
 }
 
 # CLAUDE.md handling: three paths.

--- a/tests/claude_link_project.bats
+++ b/tests/claude_link_project.bats
@@ -1,0 +1,227 @@
+#!/usr/bin/env bats
+
+# Coverage for bin/claude-link-project's --claude-dir-per-file mode.
+#
+# The behavior under test: skills/ and agents/ are linked as whole
+# directories (Claude Code documents directory-level symlinks for a
+# <skill-name> entry, but not a symlinked SKILL.md inside a real
+# directory), while everything else stays per-file so collisions with
+# tracked project content are still caught.
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+
+  LINKER="$REPO_ROOT/bin/claude-link-project"
+  OVERLAY_ROOT="$HOME/.dotfiles/projects"
+  export LINKER OVERLAY_ROOT
+
+  # jq is a hard requirement of --claude-dir-per-file (settings merge).
+  command -v jq >/dev/null || skip "jq not available"
+  # The linker resolves the overlay from the project directory's basename.
+  PROJECT="$TEST_ROOT/demo"
+  OVERLAY="$OVERLAY_ROOT/demo"
+  export PROJECT OVERLAY
+}
+
+# Build an overlay containing a skill with a non-SKILL.md payload
+# (scripts/), an agent, and a command.
+make_overlay() {
+  mkdir -p "$OVERLAY/.claude/skills/foo/scripts" \
+    "$OVERLAY/.claude/agents" \
+    "$OVERLAY/.claude/commands"
+  echo skill >"$OVERLAY/.claude/skills/foo/SKILL.md"
+  echo helper >"$OVERLAY/.claude/skills/foo/scripts/run.sh"
+  echo agent >"$OVERLAY/.claude/agents/bar.md"
+  echo command >"$OVERLAY/.claude/commands/baz.md"
+  echo '{"permissions":{"allow":[]}}' >"$OVERLAY/.claude/settings.local.json"
+}
+
+make_project() {
+  mkdir -p "$PROJECT"
+  git -C "$PROJECT" init -q .
+}
+
+run_linker() {
+  DOTFILES="$HOME/.dotfiles" run "$LINKER" \
+    --claude-dir-per-file --no-claude-md "$PROJECT"
+}
+
+@test "skills and agents are linked as directories, not per-file" {
+  make_overlay
+  make_project
+  run_linker
+  [ "$status" -eq 0 ]
+
+  assert_symlink_target "$PROJECT/.claude/skills" "$OVERLAY/.claude/skills"
+  assert_symlink_target "$PROJECT/.claude/agents" "$OVERLAY/.claude/agents"
+}
+
+@test "non-SKILL.md payloads are reachable through the directory link" {
+  # A per-file walk over regular files linked SKILL.md but silently
+  # dropped scripts/, leaving skills that reference missing helpers.
+  make_overlay
+  make_project
+  run_linker
+
+  [ "$(cat "$PROJECT/.claude/skills/foo/scripts/run.sh")" = helper ]
+}
+
+@test "commands stay per-file so tracked-file collisions are still caught" {
+  make_overlay
+  make_project
+  run_linker
+
+  [ ! -L "$PROJECT/.claude/commands" ]
+  assert_symlink_target "$PROJECT/.claude/commands/baz.md" \
+    "$OVERLAY/.claude/commands/baz.md"
+}
+
+@test "settings.local.json is copied, never symlinked" {
+  make_overlay
+  make_project
+  run_linker
+
+  [ -f "$PROJECT/.claude/settings.local.json" ]
+  [ ! -L "$PROJECT/.claude/settings.local.json" ]
+}
+
+@test "a skill added after linking needs no re-run" {
+  make_overlay
+  make_project
+  run_linker
+
+  mkdir -p "$OVERLAY/.claude/skills/brand-new"
+  echo new >"$OVERLAY/.claude/skills/brand-new/SKILL.md"
+  [ -f "$PROJECT/.claude/skills/brand-new/SKILL.md" ]
+}
+
+@test "re-running is idempotent" {
+  make_overlay
+  make_project
+  run_linker
+  run_linker
+
+  [ "$status" -eq 0 ]
+  assert_symlink_target "$PROJECT/.claude/skills" "$OVERLAY/.claude/skills"
+}
+
+@test "re-running does not prompt over formatting-only settings differences" {
+  # The overlay ships compact JSON; the merge emits jq's pretty-printed
+  # form. Comparing bytes made every re-run offer a semantically empty
+  # diff, and with no TTY the read prompt hit EOF and aborted under set -e.
+  make_overlay
+  make_project
+  printf '{"permissions":{"allow":["Bash(ls)"]}}' \
+    >"$OVERLAY/.claude/settings.local.json"
+
+  run_linker
+  run_linker </dev/null
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already up to date"* ]]
+  [[ "$output" != *"proposed diff"* ]]
+}
+
+@test "a hand-formatted project settings file is left alone when equivalent" {
+  make_overlay
+  make_project
+  printf '{"permissions":{"allow":["Bash(ls)"]}}' \
+    >"$OVERLAY/.claude/settings.local.json"
+  run_linker
+
+  # Same values, different indentation than jq's output.
+  printf '{\n    "permissions": {\n        "allow": ["Bash(ls)"]\n    }\n}\n' \
+    >"$PROJECT/.claude/settings.local.json"
+
+  run_linker </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already up to date"* ]]
+}
+
+@test "a legacy per-file tree is migrated to a directory link" {
+  make_overlay
+  make_project
+  mkdir -p "$PROJECT/.claude/skills/foo"
+  ln -s "$OVERLAY/.claude/skills/foo/SKILL.md" \
+    "$PROJECT/.claude/skills/foo/SKILL.md"
+
+  run_linker
+  [ "$status" -eq 0 ]
+  assert_symlink_target "$PROJECT/.claude/skills" "$OVERLAY/.claude/skills"
+}
+
+@test "a legacy tree of dangling foreign-home links is migrated" {
+  # The reported breakage: links created under the host's $HOME while the
+  # overlay is read from the container's. An absolute-prefix match would
+  # refuse exactly this case, so the migration matches on the
+  # projects/<slug>/... suffix instead.
+  make_overlay
+  make_project
+  mkdir -p "$PROJECT/.claude/skills/foo"
+  ln -s /home/ghost/.dotfiles/projects/demo/.claude/skills/foo/SKILL.md \
+    "$PROJECT/.claude/skills/foo/SKILL.md"
+
+  run_linker
+  [ "$status" -eq 0 ]
+  assert_symlink_target "$PROJECT/.claude/skills" "$OVERLAY/.claude/skills"
+  [ -z "$(find "$PROJECT/.claude" -xtype l)" ]
+}
+
+@test "migration refuses when a real file is present" {
+  make_overlay
+  make_project
+  mkdir -p "$PROJECT/.claude/skills/mine"
+  echo "user content" >"$PROJECT/.claude/skills/mine/SKILL.md"
+
+  run_linker
+  [ ! -L "$PROJECT/.claude/skills" ]
+  [ "$(cat "$PROJECT/.claude/skills/mine/SKILL.md")" = "user content" ]
+}
+
+@test "migration refuses when a link points outside the overlay" {
+  make_overlay
+  make_project
+  mkdir -p "$PROJECT/.claude/skills/foo"
+  ln -s /etc/hostname "$PROJECT/.claude/skills/foo/SKILL.md"
+
+  run_linker
+  [ ! -L "$PROJECT/.claude/skills" ]
+  assert_symlink_target "$PROJECT/.claude/skills/foo/SKILL.md" /etc/hostname
+}
+
+@test "a dangling link from another home is repointed" {
+  # Links created under a different $HOME (host vs container) resolve
+  # nowhere here. A broken link cannot be a deliberate choice, so it is
+  # repaired rather than preserved.
+  make_overlay
+  make_project
+  mkdir -p "$PROJECT/.claude"
+  ln -s /home/ghost/.dotfiles/projects/demo/.claude/skills \
+    "$PROJECT/.claude/skills"
+
+  run_linker
+  [ "$status" -eq 0 ]
+  assert_symlink_target "$PROJECT/.claude/skills" "$OVERLAY/.claude/skills"
+}
+
+@test "a valid link pointing elsewhere is left alone" {
+  # The counterpart to the repair above: a link that actually resolves is
+  # someone's deliberate choice and must not be silently rewritten.
+  make_overlay
+  make_project
+  mkdir -p "$TEST_ROOT/other-skills" "$PROJECT/.claude"
+  ln -s "$TEST_ROOT/other-skills" "$PROJECT/.claude/skills"
+
+  run_linker
+  assert_symlink_target "$PROJECT/.claude/skills" "$TEST_ROOT/other-skills"
+}
+
+@test "no dangling symlinks are left in the project" {
+  make_overlay
+  make_project
+  run_linker
+
+  [ -z "$(find "$PROJECT/.claude" -xtype l)" ]
+}

--- a/tests/claude_link_project.bats
+++ b/tests/claude_link_project.bats
@@ -180,6 +180,46 @@ run_linker() {
   [ "$(cat "$PROJECT/.claude/skills/mine/SKILL.md")" = "user content" ]
 }
 
+@test "an untracked skills dir is skipped without aborting the rest of the run" {
+  # link_one dies on a real file/dir in the way, which is right for
+  # CLAUDE.md. Applying it to skills/ meant one untracked directory
+  # aborted everything after it: commands/ went unlinked and
+  # settings.local.json was never written.
+  make_overlay
+  make_project
+  mkdir -p "$PROJECT/.claude/skills/mine"
+  echo "user content" >"$PROJECT/.claude/skills/mine/SKILL.md"
+
+  run_linker
+  [ "$status" -eq 0 ]
+
+  # The user's directory is untouched...
+  [ ! -L "$PROJECT/.claude/skills" ]
+  [ "$(cat "$PROJECT/.claude/skills/mine/SKILL.md")" = "user content" ]
+  # ...and nothing was scattered inside it by the per-file walk.
+  [ ! -e "$PROJECT/.claude/skills/foo" ]
+
+  # Everything independent of skills/ still got linked.
+  assert_symlink_target "$PROJECT/.claude/commands/baz.md" \
+    "$OVERLAY/.claude/commands/baz.md"
+  assert_symlink_target "$PROJECT/.claude/agents" "$OVERLAY/.claude/agents"
+  [ -f "$PROJECT/.claude/settings.local.json" ]
+}
+
+@test "a tracked skills dir is still a hard collision" {
+  make_overlay
+  make_project
+  mkdir -p "$PROJECT/.claude/skills"
+  echo "tracked" >"$PROJECT/.claude/skills/SKILL.md"
+  git -C "$PROJECT" add -f .claude/skills/SKILL.md
+  git -C "$PROJECT" -c user.email=t@e.com -c user.name=t \
+    commit -q -m add
+
+  run_linker
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"tracked in git"* ]]
+}
+
 @test "migration refuses when a link points outside the overlay" {
   make_overlay
   make_project

--- a/tests/overlay_sync_hook.bats
+++ b/tests/overlay_sync_hook.bats
@@ -73,6 +73,7 @@ run_hook() {
   run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$PROJECT")"
 
   [ "$status" -eq 0 ]
+  assert_symlink_target "$PROJECT/.claude/skills" "$OVERLAY/.claude/skills"
   [ -e "$PROJECT/.claude/skills/foo/SKILL.md" ]
   [ -z "$(find "$PROJECT/.claude" -xtype l)" ]
 }
@@ -162,11 +163,17 @@ run_hook() {
 
   run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$PROJECT")"
   [ "$status" -eq 0 ]
+  # Assert the directory link itself, not just readable content: a copy
+  # would satisfy a content check while losing the whole point of the
+  # change (new skills appearing with no re-run, payloads carried along).
+  assert_symlink_target "$PROJECT/.claude/skills" "$OVERLAY/.claude/skills"
   [ "$(cat "$PROJECT/.claude/skills/foo/SKILL.md")" = skill ]
   [ -z "$(find "$PROJECT/.claude" -xtype l)" ]
 
   git -C "$PROJECT" worktree add --quiet -b feature "$TEST_ROOT/wt-feature"
   run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$TEST_ROOT/wt-feature")"
   [ "$status" -eq 0 ]
+  assert_symlink_target "$TEST_ROOT/wt-feature/.claude/skills" \
+    "$OVERLAY/.claude/skills"
   [ "$(cat "$TEST_ROOT/wt-feature/.claude/skills/foo/SKILL.md")" = skill ]
 }

--- a/tests/overlay_sync_hook.bats
+++ b/tests/overlay_sync_hook.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+
+# Coverage for the SessionStart overlay-sync hook.
+#
+# The hook re-links the personal overlay when a worktree lacks it, or when
+# existing links point at a $HOME that does not exist in this environment
+# (host-created links seen from inside a container, and vice versa).
+#
+# It must fail open: a broken hook must never stop a session from starting.
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+
+  HOOK="$REPO_ROOT/ai/claude/hooks/overlay-sync.sh"
+  export HOOK
+  command -v jq >/dev/null || skip "jq not available"
+
+  # The hook invokes the real linker out of $DOTFILES.
+  export DOTFILES="$HOME/.dotfiles"
+  mkdir -p "$DOTFILES/bin"
+  cp "$REPO_ROOT/bin/claude-link-project" "$DOTFILES/bin/"
+  chmod +x "$DOTFILES/bin/claude-link-project"
+
+  PROJECT="$TEST_ROOT/demo"
+  OVERLAY="$DOTFILES/projects/demo"
+  export PROJECT OVERLAY
+
+  mkdir -p "$OVERLAY/.claude/skills/foo"
+  echo skill >"$OVERLAY/.claude/skills/foo/SKILL.md"
+  echo '{"permissions":{"allow":[]}}' >"$OVERLAY/.claude/settings.local.json"
+
+  mkdir -p "$PROJECT"
+  git -C "$PROJECT" init --quiet --initial-branch=main
+  git -C "$PROJECT" -c user.email=t@example.com -c user.name=t \
+    commit --quiet --allow-empty -m init
+}
+
+run_hook() {
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$1")"
+}
+
+@test "links the overlay into a fresh worktree" {
+  linked="$TEST_ROOT/wt-feature"
+  git -C "$PROJECT" worktree add --quiet -b feature "$linked"
+  [ ! -e "$linked/.claude/skills" ]
+
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$linked")"
+
+  [ "$status" -eq 0 ]
+  [ -e "$linked/.claude/skills/foo/SKILL.md" ]
+}
+
+@test "resolves the overlay slug from the main checkout, not the branch name" {
+  # The worktree directory is named after the branch, so a naive
+  # basename() would look for an overlay named 'wt-feature'.
+  linked="$TEST_ROOT/wt-feature"
+  git -C "$PROJECT" worktree add --quiet -b feature "$linked"
+
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$linked")"
+
+  [ "$status" -eq 0 ]
+  assert_symlink_target "$linked/.claude/skills" "$OVERLAY/.claude/skills"
+}
+
+@test "repairs a dangling link left by a foreign home" {
+  mkdir -p "$PROJECT/.claude"
+  ln -s /home/ghost/.dotfiles/projects/demo/.claude/skills \
+    "$PROJECT/.claude/skills"
+  [ ! -e "$PROJECT/.claude/skills" ] # dangling
+
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$PROJECT")"
+
+  [ "$status" -eq 0 ]
+  [ -e "$PROJECT/.claude/skills/foo/SKILL.md" ]
+  [ -z "$(find "$PROJECT/.claude" -xtype l)" ]
+}
+
+@test "reports that a restart may be needed" {
+  linked="$TEST_ROOT/wt-feature"
+  git -C "$PROJECT" worktree add --quiet -b feature "$linked"
+
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$linked")"
+
+  [[ "$output" == *"SessionStart"* ]]
+  [[ "$output" == *"restart"* ]]
+}
+
+@test "stays silent and writes nothing when links are already correct" {
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$PROJECT")"
+  [ "$status" -eq 0 ]
+
+  # Second run: overlay is linked, so there is nothing to do.
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$PROJECT")"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "does not touch CLAUDE.md" {
+  echo "project instructions" >"$PROJECT/CLAUDE.md"
+  echo "personal notes" >"$OVERLAY/CLAUDE.md"
+
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$PROJECT")"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$PROJECT/CLAUDE.md")" = "project instructions" ]
+  [ ! -L "$PROJECT/CLAUDE.md" ]
+}
+
+@test "does nothing when no overlay exists for the project" {
+  rm -rf "$OVERLAY"
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$PROJECT")"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ ! -e "$PROJECT/.claude/skills" ]
+}
+
+@test "does nothing outside a git repository" {
+  mkdir -p "$TEST_ROOT/plain"
+  run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$TEST_ROOT/plain")"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "honors CLAUDE_OVERLAY_SYNC=off" {
+  linked="$TEST_ROOT/wt-feature"
+  git -C "$PROJECT" worktree add --quiet -b feature "$linked"
+
+  CLAUDE_OVERLAY_SYNC=off run bash -c \
+    "printf '{\"cwd\":\"$linked\"}' | bash '$HOOK'"
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$linked/.claude/skills" ]
+}
+
+@test "fails open when jq is unavailable" {
+  stub_command jq "exit 127"
+  run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$PROJECT")"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails open on malformed input" {
+  run bash "$HOOK" <<<"not json"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails open when the linker is missing" {
+  rm -f "$DOTFILES/bin/claude-link-project"
+  run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$PROJECT")"
+  [ "$status" -eq 0 ]
+}

--- a/tests/overlay_sync_hook.bats
+++ b/tests/overlay_sync_hook.bats
@@ -150,3 +150,23 @@ run_hook() {
   run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$PROJECT")"
   [ "$status" -eq 0 ]
 }
+
+@test "repairs a dangling per-file tree, then a worktree of it" {
+  # The exact reported shape: the main checkout holds a per-file tree of
+  # links into a $HOME that does not exist here, and a worktree taken
+  # from it has no overlay at all. Both were broken at once.
+  mkdir -p "$PROJECT/.claude/skills/foo"
+  ln -s /home/ghost/.dotfiles/projects/demo/.claude/skills/foo/SKILL.md \
+    "$PROJECT/.claude/skills/foo/SKILL.md"
+  [ ! -e "$PROJECT/.claude/skills/foo/SKILL.md" ] # dangling
+
+  run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$PROJECT")"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$PROJECT/.claude/skills/foo/SKILL.md")" = skill ]
+  [ -z "$(find "$PROJECT/.claude" -xtype l)" ]
+
+  git -C "$PROJECT" worktree add --quiet -b feature "$TEST_ROOT/wt-feature"
+  run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$TEST_ROOT/wt-feature")"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_ROOT/wt-feature/.claude/skills/foo/SKILL.md")" = skill ]
+}


### PR DESCRIPTION
## Problem

A project-scoped skill (`upstream-pr-review` in the reported case) was invisible to Claude Code. Two independent defects, both hit at once in a devcontainer worktree:

1. **Worktrees don't inherit the overlay.** `git worktree add` produces a fresh working tree, and `.claude/` is untracked — so none of the project's personal skills exist there.
2. **Cross-`$HOME` links dangle.** Links written under one `$HOME` don't resolve under another (WSL host vs. container running as root), so the overlay was broken in the *main* checkout too. This was the real culprit — the skill would not have loaded there either.

Both are fixed, and `tests/overlay_sync_hook.bats` reproduces the reported situation end to end: a per-file tree of foreign-home dangling links in the main checkout, plus a worktree cut from it, repaired in one pass each.

## Changes

**`skills/` and `agents/` are linked as whole directories.** A directory-level symlink for a `<skill-name>` entry is the documented, supported shape; a symlinked `SKILL.md` inside a real directory is not. The old per-file walk also silently dropped non-`SKILL.md` payloads such as `scripts/`, leaving skills that referenced missing helpers. `commands/` stays per-file so collisions with tracked project content are still caught.

Legacy per-file trees migrate automatically — but only when *every* entry is a link into this overlay. A real file or a link pointing elsewhere aborts the migration and leaves the tree untouched. The predicate matches on the `projects/<slug>/...` suffix rather than an absolute prefix, because an absolute match would refuse exactly the foreign-`$HOME` case it exists to repair.

**Dangling links are repaired; valid ones are not.** A broken link cannot be a deliberate choice. A link that resolves is someone's decision and is left alone.

**New `--slug` flag**, plus a fallback resolving the overlay from the primary working tree — a worktree is named after its branch, so `basename` alone looked for an overlay that never existed.

**Settings merge now compares JSON canonically.** Pre-existing bug: the first run copied the overlay verbatim, while re-runs compared bytes against jq's pretty-printed output. Every re-run therefore offered a semantically empty diff, and with no TTY the prompt hit EOF and aborted under `set -e`. This blocked any non-interactive use, including the new hook.

**New `SessionStart` hook** (`ai/claude/hooks/overlay-sync.sh`) that re-links when something is missing or dangling. It fails open everywhere — a broken hook must never stop a session from starting — writes only inside the current working tree, stays silent when there's nothing to do, and reports that a restart may be needed since skills are discovered at session start. `CLAUDE_OVERLAY_SYNC=off` disables it.

## Testing

132/132 passing, up from a 104-test baseline. Includes the first-ever coverage for `claude-link-project` (15 tests) and the hook (13), covering migration refusals, foreign-home repair, idempotency, and fail-open paths. `shellcheck`, `shfmt`, and syntax checks clean.

## Notes for reviewers

- Nothing writes outside the working tree it's pointed at, so a bind-mounted container checkout won't flip-flop against its host.
- A link that *resolves* but points somewhere unintended is left alone by design — only missing and dangling links are touched. This does not affect the reported case, whose links were dangling.
- Container-side handling for `/app` main-checkout sessions is deliberately **not** in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude sessions automatically repair missing or broken project overlay links on startup or resume.
  * Skills and agents are available through directory links, including newly added items without rerunning setup.
  * Worktree overlays synchronize automatically, with support for custom project slugs.
  * Settings synchronization now handles formatting differences more reliably.

* **Bug Fixes**
  * Dangling and legacy overlay links can be repaired or migrated safely.

* **Documentation**
  * Added guidance for overlay verification, migration, synchronization, and disabling automatic repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->