### PR TITLE
nvim fun

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -322,7 +322,7 @@ Detect the old pattern before converting. Signals (any one → offer repair):
 2. parallel dual-mount lines:
    `grep -rn '${HOME}:${HOME}' .devcontainer/ 2>/dev/null || grep -rnE '\$\{HOME\}/\.claude:\$\{HOME\}/\.claude' .devcontainer/`
 3. container-user paths written back into HOST config:
-   `grep -rl '/home/vscode\|/home/node' ~/.claude/plugins/*.json 2>/dev/null`
+   `grep -rl '/home/vscode\|/home/node\|/root' ~/.claude/plugins/*.json 2>/dev/null`
 4. foreign home symlinks the shim created:
    `ls -l /home/*/ 2>/dev/null | grep -- '-> /home/'` (inside a container only)
 5. **stale gated config copy** (the clause-2 bug in item 15) — an existing
@@ -378,6 +378,47 @@ Detect the old pattern before converting. Signals (any one → offer repair):
    Repair: replace the guard with the unconditional `rsync -a --delete` mirror
    from item 15 and restart. Tell the user their container-local `~/.dotfiles`
    edits will be reverted from now on.
+
+7. **stale home paths in the CONTAINER plugin registry** — presents to the user
+   as every plugin failing at once with `Failed to load marketplace "<name>":
+   cache-miss`, which reads like the marketplace was never downloaded. It was:
+   the payloads are present and correctly owned, but the registry records
+   ABSOLUTE paths, and they still name the home of a *previous* container user.
+   This is signal 3 in the opposite direction — 3 is container paths leaking
+   into host config, 7 is a dead container home stranded in container config —
+   so check both; neither grep finds the other.
+   Trigger: the container user changed (commonly root → `vscode`/`node`/
+   `developer`) while `~/.claude` lived in a **persisted named volume**. No
+   rebuild clears it, because the volume is precisely what rebuilds preserve.
+   The removed home-symlink shim used to mask this by making the old path
+   resolve, so it typically surfaces right after that shim is cleaned up.
+   ```bash
+   # inside the container: any output => registry points at a dead home
+   docker exec -u "$REMOTE_USER" "$CID" sh -c \
+     'grep -l "\(/root\|/home/[^/\"]*\)/\.\(claude\|dotfiles\)" ~/.claude/plugins/*.json 2>/dev/null \
+      | grep -v "$HOME"'
+   ```
+   Distinguish from a genuinely absent marketplace before repairing — same error
+   string, unrelated cause: a marketplace referenced by `settings.json`'s
+   `enabledPlugins` but missing from `known_marketplaces.json` was never
+   registered in this container at all. The authored `~/.claude` allowlist
+   deliberately excludes `plugins/` (hundreds of MB), so it cannot arrive by
+   copy; it has to be re-registered with `claude plugin marketplace add <repo>`.
+   The registry key comes from the marketplace manifest, not the repo path
+   (`techwolf-ai/ai-first-toolkit` → `techwolf-ai-first`), so an
+   already-registered guard must list the key explicitly or it re-adds forever.
+   Repair, in the seed and **above** the version gate — the source is container
+   runtime state, so `SEED_VERSION` cannot observe the poisoning and gating it
+   latches the break:
+   ```bash
+   sed -E "s#(/root|/home/[^\"/]+)(/\.(claude|dotfiles))#${HOME}\2#g"
+   ```
+   Anchor on the `/.claude|/.dotfiles` suffix, not a bare `/root` — the official
+   catalog contains `//rootly.com` and `/Rootly-AI-Labs` URLs that a loose
+   pattern silently corrupts. Also delete `~/.claude` symlinks left dangling at
+   the old home. Rewriting is non-destructive and preserves the cache; wiping
+   the volume also works but costs re-auth (`.credentials.json` lives there),
+   re-download, and container-local history.
 
 Anything scaffolded before the two-clause rule existed will trip signals 5 and 6,
 so run both during **any** repair pass, not just rw-mount conversions. Signal 6

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
@@ -626,6 +626,55 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# PLUGIN REGISTRY HOME-PATH REPAIR — always-run, deliberately ABOVE the gate.
+# The registry records ABSOLUTE paths. When the container user changes (root →
+# vscode/node/developer), every recorded path still names the OLD home while the
+# payloads live under the new one, and Claude reports `cache-miss` for every
+# plugin — the marketplace looks un-downloaded when nothing is actually missing.
+# This lives in the persisted volume, so no rebuild clears it.
+#
+# NOT gated: the source is container runtime state, which SEED_VERSION cannot
+# observe, so gating latches the break the way any state-blind guard does.
+# The rewrite is a no-op once paths are correct, so running it always is free.
+#
+# The /.claude|/.dotfiles suffix is a load-bearing anchor: a bare /root also
+# matches the //rootly.com and /Rootly-AI-Labs URLs in the official catalog.
+# ---------------------------------------------------------------------------
+plugin_home_repair() {
+  local dir="$CLAUDE_HOME/plugins"
+  [ -d "$dir" ] || return 0
+  local repaired="" f tmp
+  for f in "$dir/known_marketplaces.json" "$dir/installed_plugins.json"; do
+    [ -f "$f" ] || continue
+    tmp="$f.seed.$$"
+    # No as_user on sed: the redirect is performed by THIS shell, so as_user
+    # would not affect the temp file's owner anyway. The `cat > "$f"` below
+    # writes through the existing inode, which is what preserves owner + mode.
+    sed -E "s#(/root|/home/[^\"/]+)(/\.(claude|dotfiles))#${SEED_HOME}\2#g" \
+      "$f" >"$tmp" 2>/dev/null || { rm -f "$tmp"; continue; }
+    if cmp -s "$f" "$tmp"; then
+      rm -f "$tmp"
+    else
+      cat "$tmp" >"$f" && repaired="$repaired $(basename "$f")"
+      rm -f "$tmp"
+    fi
+  done
+  # Same fallout: ~/.claude symlinks aimed at the dead home. Use `if`, not a
+  # trailing && chain — under `set -e` a loop body ending false kills the script,
+  # and on a fresh volume nothing matches, so that is the NORMAL path.
+  local link
+  for link in "$CLAUDE_HOME"/*; do
+    if [ -L "$link" ] && [ ! -e "$link" ]; then
+      rm -f "$link"
+      repaired="$repaired $(basename "$link")"
+    fi
+  done
+  [ -n "$repaired" ] && echo "🌱 seed: repaired stale home paths in plugin registry:$repaired"
+  return 0
+}
+plugin_home_repair
+
+# ---------------------------------------------------------------------------
 # DRIFT CHECK — runs on BOTH the gated-skip and reseed paths.
 # Compares CONTENT against the host mount rather than trusting the sentinel, so
 # it reports staleness no matter the cause — including a seed still running the
@@ -714,6 +763,33 @@ if [ -x "$DOTFILES_HOME/ai/marketplace/install.sh" ]; then
     MARKETPLACE_OK=0
     echo "⚠️  seed: marketplace install failed — NOT stamping sentinel; next launch retries"
   }
+fi
+
+# Register the GitHub-hosted marketplaces that settings.json's `enabledPlugins`
+# refers to. A marketplace that is enabled but never registered fails with the
+# SAME `cache-miss` string as a stale path (signal 7) for an unrelated reason,
+# so fix both or the errors only half clear. The authored ~/.claude allowlist
+# deliberately excludes plugins/ (hundreds of MB), so this cannot arrive by copy.
+#
+# Correctly gated: target persists in the volume, source is this template.
+# List "registry-name repo" pairs explicitly — the key comes from the
+# marketplace MANIFEST, not the repo path (techwolf-ai/ai-first-toolkit
+# registers as `techwolf-ai-first`), so it cannot be derived, and a guard that
+# guesses it never matches and re-adds on every single seed.
+if command -v claude >/dev/null 2>&1; then
+  while read -r mp_name mp_repo; do
+    [ -n "$mp_name" ] || continue
+    if grep -q "\"${mp_name}\"" "$CLAUDE_HOME/plugins/known_marketplaces.json" 2>/dev/null; then
+      continue
+    fi
+    echo "🌱 seed: registering marketplace $mp_name ($mp_repo)"
+    as_user claude plugin marketplace add "$mp_repo" >/dev/null 2>&1 || {
+      MARKETPLACE_OK=0
+      echo "⚠️  seed: could not register $mp_repo (needs network) — NOT stamping sentinel"
+    }
+  done <<'MARKETPLACES'
+claude-plugins-official anthropics/claude-plugins-official
+MARKETPLACES
 fi
 
 # 3. Stamp the sentinel with the current version, but only on a clean run.

--- a/config/versions.env
+++ b/config/versions.env
@@ -26,3 +26,10 @@ NERD_FONT_CASCADIA_MONO_SHA256=95dc4ace16f5a45734fc584925b9ef24c23f46d54a3b66082
 NERD_FONT_HACK_SHA256=8ca33a60c791392d872b80d26c42f2bfa914a480f9eb2d7516d9f84373c36897
 NERD_FONT_MESLO_SHA256=13b502ac8c2bd9d3161018064560e23cd42b175bb730780a270975265a19ad57
 CODEX_VERSION=0.146.0
+# Neovim: the OS package layer supplies this on a normal host, but containers
+# get these dotfiles without it, and Debian bookworm's apt candidate is 0.7.2 —
+# too old for config/nvim (it uses vim.uv and lazy.nvim). Pinned + checksummed
+# because upstream publishes no checksum file with the release assets.
+NVIM_VERSION=0.12.4
+NVIM_SHA256_X86_64=012bf3fcac5ade43914df3f174668bf64d05e049a4f032a388c027b1ebd78628
+NVIM_SHA256_ARM64=ceb7e88c6b681f0515d135dcdfad54f5eb4373b25ce6172197cd9a69c758063f

--- a/core/aliases.zsh
+++ b/core/aliases.zsh
@@ -1,1 +1,3 @@
-alias vi='nvim'
+# Only alias when nvim exists; otherwise `vi` would shadow the real vi/vim with
+# a command-not-found. See the EDITOR fallback in core/env.zsh.
+(( $+commands[nvim] )) && alias vi='nvim'

--- a/core/env.zsh
+++ b/core/env.zsh
@@ -1,3 +1,13 @@
-export EDITOR='nvim'
+# Fall back when nvim is absent. Containers and minimal hosts get these dotfiles
+# without the OS package layer that supplies the binary, and an EDITOR pointing
+# at a missing command breaks `git commit`, `git rebase -i`, and every tool that
+# shells out to $EDITOR — with a confusing error that names git, not the editor.
+if (( $+commands[nvim] )); then
+  export EDITOR='nvim'
+elif (( $+commands[vim] )); then
+  export EDITOR='vim'
+else
+  export EDITOR='vi'
+fi
 export GPG_TTY=$(tty)
 export CLICOLOR=1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude plugin setup by repairing stale home-directory paths and removing broken home-directory links during launch.
  - Automatically retries marketplace registration when setup fails.
  - Prevented `vi` and editor settings from selecting unavailable Neovim installations.

- **Improvements**
  - Added pinned Neovim 0.12.4 configuration with architecture-specific checksums.
  - Editor selection now falls back from Neovim to Vim or Vi when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->