### PR TITLE
fix(devcontainer): install tree-sitter CLI and stop global LFS hooks breaking clones

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/SKILL.md
@@ -648,11 +648,22 @@ Report to the user:
   ```bash
   docker ps --format '{{.ID}}\t{{.Names}}\t{{.Label "devcontainer.local_folder"}}'
   ```
+- For case (a): **check this one first — it decides whether any later check means anything.** Confirm the running container actually has the seed mounts, rather than assuming the config on disk is what it was built from:
+  ```bash
+  docker exec "$CID" sh -c 'test -d /host-seed && echo "/host-seed mounted"'
+  docker inspect "$CID" --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}'
+  ```
+  A missing `/host-seed`, or a `config_files` list without `docker-compose.override.yml`, means the container predates the `dockerComposeFile` edit. **Editing `devcontainer.json` does not touch an existing container, and neither does restarting it** — Compose keeps the file list, mounts, and `command:` recorded at creation, so the seed has simply never run and every check below will fail with a misleading symptom (no `nvim`, no `claude`, no dotfiles). The fix is a **rebuild**, not a restart: *Dev Containers: Rebuild Container* in VS Code. Do not `docker compose up` it by hand — the devcontainer CLI injects generated compose files for features and the build, and recreating without them silently drops those layers.
 - For case (a): verify the `claude` CLI binary is installed AND on PATH — this is the check that catches the "claude isn't installed in the devcontainer" failure:
   ```bash
   docker exec -u "$REMOTE_USER" "$CID" zsh -lic 'whence -v claude; claude --version'
   ```
   If `claude` doesn't resolve, either the seed's CLI-install step didn't run (override not loaded — re-check `dockerComposeFile`, Section 6c) or `~/.local/bin` isn't on PATH (the always-run PATH hook didn't fire — check the seed log for `added ~/.local/bin to PATH`).
+- For case (a): verify the `tree-sitter` CLI resolves — without it every nvim-treesitter parser fails to build at first launch, since `config/nvim` pins the `main` branch and its installer shells out to `tree-sitter build` with no bare-`cc` fallback:
+  ```bash
+  docker exec -u "$REMOTE_USER" "$CID" zsh -lic 'whence -v tree-sitter; tree-sitter --version'
+  ```
+  If it doesn't resolve, the seed's tree-sitter step didn't run (check the seed log for `tree-sitter ready`); on a container predating that step, catch the seed up per `catch-up-local-seed.md`. The symptom is a wall of `Error during "tree-sitter build": ... ENOENT ... (cmd): 'tree-sitter'` on opening any file.
 - For case (a): confirm zsh is the **default** shell and the proxy env reaches it — this catches "claude isn't picking up the vekil proxy" when everything else looks fine but the terminal opens bash:
   ```bash
   docker exec -u "$REMOTE_USER" "$CID" sh -c 'test "$(getent passwd $(id -un) | cut -d: -f7)" = "$(command -v zsh)" && echo "default shell = zsh"'

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -37,8 +37,8 @@ From the project directory:
 f=.devcontainer/local-seed.sh
 printf 'SEED_VERSION=%s\n' "$(sed -n 's/^SEED_VERSION=//p' "$f")"
 for k in 'STABLE_LINK_ROOT' 'ensure_stable_link_root' 'NVIM_VERSION' \
-         'load-custom.zsh' 'core.hooksPath' 'core.excludesFile' \
-         'local/bin/codex' 'config/nvim'; do
+         'TREE_SITTER_VERSION' 'load-custom.zsh' 'core.hooksPath' \
+         'core.excludesFile' 'local/bin/codex' 'config/nvim'; do
   grep -q "$k" "$f" && printf '  %-24s present\n' "$k" || printf '  %-24s MISSING\n' "$k"
 done
 grep -o "lname '[^']*'" "$f" || echo "  overlay-gitignore matcher MISSING"

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -79,6 +79,7 @@ one below the gate means a container that is already stamped will never run it.
 | `core.hooksPath` | `core.hooksPath` | Same reason, for the dotfiles git hooks. |
 | neovim install | `NVIM_VERSION` | The dotfiles set `EDITOR=nvim` but nothing in them installs the binary — on a host it arrives via the package lists, which no devcontainer image runs. An `EDITOR` naming a missing command breaks `git commit` with an error that blames git. Pinned and sha256-verified from `config/versions.env`; non-fatal. |
 | `~/.config/nvim` link | `config/nvim` | Without it the binary starts bare and none of `config/nvim` applies. Must not clobber a real directory. |
+| tree-sitter CLI | `TREE_SITTER_VERSION` | `config/nvim` pins nvim-treesitter to `main`, whose installer shells out to `tree-sitter build` per parser with no fallback to a bare `cc`. A container with gcc but no CLI still fails every parser at first launch (`ENOENT ... (cmd): 'tree-sitter'`). On a host it comes from mise, which the seed never runs. Pinned and sha256-verified from `config/versions.env`; non-fatal. |
 | `load-custom.zsh` loader | `DOTFILES_LOAD_HOOK` | The supported entry point for the shell tree. Append it **before** the Vekil hook — `ai/vekil/env.zsh` exports `ANTHROPIC_MODEL`, which outranks `settings.json`, so it has to get the last word. |
 | codex guard | `local/bin/codex` | Guard the reinstall on the **binary**, not `~/.codex/config.toml`. The installer writes config even when it fails to produce a binary, so a config-based guard latches shut and codex never reinstalls. |
 
@@ -146,6 +147,9 @@ find .claude -xtype l                       # must print nothing
 git status --porcelain | grep -i claude     # must print nothing
 nvim --version | head -1
 zsh -lic 'whence -v nvim; print $EDITOR'
+tree-sitter --version                       # must print a version, not "not found"
+# Compiles the bootstrap parser set — must end with no "tree-sitter build" errors
+nvim --headless -c 'lua require("nvim-treesitter").install({"lua"}):wait(120000)' -c q
 git config --global core.hooksPath
 git config --global core.excludesFile
 ```

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
@@ -814,10 +814,18 @@ fi
 # missing and be re-downloaded (26MB) each launch. The path test is the
 # PATH-independent guard for what this block installed; the `command -v` probe
 # only catches a CLI the image itself supplies somewhere else on PATH.
+#
+# Both guards confirm by RUNNING --version, for the same reason the install path
+# below does: `test -x` and `command -v` are satisfied by a binary that dies at
+# exec time (glibc release binary on a musl base) and by a shim whose tool was
+# never installed. Either one would latch this block shut — the seed would report
+# "already present" on every start while nvim-treesitter kept failing every
+# parser. Confirming by execution instead makes the guard self-healing: an
+# unusable CLI is simply replaced on the next start.
 if as_user test -f "$SEED_HOME/.local/bin/tree-sitter" \
-  && as_user test -x "$SEED_HOME/.local/bin/tree-sitter"; then
+  && as_user "$SEED_HOME/.local/bin/tree-sitter" --version >/dev/null 2>&1; then
   echo "🌱 seed: tree-sitter already present"
-elif as_user sh -c 'command -v tree-sitter >/dev/null 2>&1'; then
+elif as_user sh -c 'command -v tree-sitter >/dev/null 2>&1 && tree-sitter --version >/dev/null 2>&1'; then
   echo "🌱 seed: tree-sitter already present (image-provided)"
 elif [ -r "$DOTFILES_HOME/config/versions.env" ]; then
   # shellcheck source=/dev/null

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/devcontainer-host-mounts.md
@@ -791,6 +791,83 @@ if [ -d "$DOTFILES_HOME/config/nvim" ]; then
   fi
 fi
 
+# tree-sitter CLI (ephemeral target ~/.local/bin). config/nvim pins
+# nvim-treesitter to its `main` branch, whose installer shells out to
+# `tree-sitter build` for EVERY parser — there is no fallback to a bare `cc`, so
+# a container with gcc but no CLI still fails every parser with
+# `Error during "tree-sitter build": ... ENOENT ... (cmd): 'tree-sitter'`, on the
+# bootstrap set (bash, c, lua, markdown, vimdoc, ...) at the first nvim launch.
+# On a host the CLI arrives from mise (`npm:tree-sitter-cli` in
+# config/mise/config.toml); the seed never runs mise, so it is supplied here as a
+# pinned release binary. Keep TREE_SITTER_VERSION in step with the mise pin.
+#
+# Always-run for the same reason as nvim: ~/.local/bin is the ephemeral writable
+# layer, so a version-gated step would be skipped as "already seeded" and the
+# binary would be gone after every rebuild.
+#
+# Non-fatal throughout, like nvim: treesitter highlighting is a nicety, and an
+# editor that opens without it beats a container that will not start.
+#
+# Two guards, in this order, and the order matters. `command -v` alone is NOT
+# enough: the seed runs as a container `command:`, whose PATH does not include
+# ~/.local/bin, so on every warm start our own installed binary would look
+# missing and be re-downloaded (26MB) each launch. The path test is the
+# PATH-independent guard for what this block installed; the `command -v` probe
+# only catches a CLI the image itself supplies somewhere else on PATH.
+if as_user test -f "$SEED_HOME/.local/bin/tree-sitter" \
+  && as_user test -x "$SEED_HOME/.local/bin/tree-sitter"; then
+  echo "🌱 seed: tree-sitter already present"
+elif as_user sh -c 'command -v tree-sitter >/dev/null 2>&1'; then
+  echo "🌱 seed: tree-sitter already present (image-provided)"
+elif [ -r "$DOTFILES_HOME/config/versions.env" ]; then
+  # shellcheck source=/dev/null
+  . "$DOTFILES_HOME/config/versions.env"
+  case "$(uname -m)" in
+    x86_64) TS_ARCH=linux-x64 TS_SHA="${TREE_SITTER_SHA256_X86_64:-}" ;;
+    aarch64 | arm64) TS_ARCH=linux-arm64 TS_SHA="${TREE_SITTER_SHA256_ARM64:-}" ;;
+    *) TS_ARCH="" TS_SHA="" ;;
+  esac
+  # TS_SHA is checked here, not left to the verify step: an unpinned checksum
+  # would otherwise cost a 26MB download before failing, every single start.
+  if [ -z "$TS_ARCH" ] || [ -z "$TS_SHA" ] || [ -z "${TREE_SITTER_VERSION:-}" ]; then
+    echo "⚠️  seed: no pinned tree-sitter build for $(uname -m) — skipping (treesitter parsers will not compile)"
+  else
+    echo "🌱 seed: installing tree-sitter $TREE_SITTER_VERSION ($TS_ARCH)"
+    TS_TMP="$(mktemp -d)"
+    TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+    # The release asset is a single gzipped binary (.gz), NOT a tarball — there
+    # is no directory to extract and no runtime tree to place beside it.
+    #
+    # Staged as tree-sitter.new on the destination filesystem and validated by
+    # actually RUNNING it before the final mv. `test -x` is not enough: these are
+    # dynamically linked against glibc, so on a musl base image the file is
+    # executable and still dies with "not found" at exec time — which would
+    # surface later as the same confusing treesitter build failure this block
+    # exists to fix, only now with a binary sitting in place looking installed.
+    #
+    # Bounded curl timeouts for the same reason as nvim: the default is no
+    # timeout at all, so a blackholed CDN would hang container start forever.
+    if curl -fsSL --connect-timeout 10 --max-time 300 \
+      -o "$TS_TMP/tree-sitter.gz" "https://github.com/tree-sitter/tree-sitter/releases/download/v${TREE_SITTER_VERSION}/tree-sitter-${TS_ARCH}.gz" \
+      && echo "$TS_SHA  $TS_TMP/tree-sitter.gz" | sha256sum -c - >/dev/null 2>&1 \
+      && gunzip -c "$TS_TMP/tree-sitter.gz" > "$TS_TMP/tree-sitter" \
+      && as_user mkdir -p "$SEED_HOME/.local/bin" \
+      && rm -f "$TS_BIN.new" \
+      && cp "$TS_TMP/tree-sitter" "$TS_BIN.new" \
+      && chmod 0755 "$TS_BIN.new" \
+      && { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null \
+        || [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } \
+      && as_user "$TS_BIN.new" --version >/dev/null 2>&1 \
+      && as_user mv "$TS_BIN.new" "$TS_BIN"; then
+      echo "🌱 seed: tree-sitter ready"
+    else
+      echo "⚠️  seed: tree-sitter install failed (non-fatal; treesitter parsers will not compile)"
+    fi
+    rm -f "$TS_BIN.new"
+    rm -rf "$TS_TMP"
+  fi
+fi
+
 # --- Versioned gate --------------------------------------------------------
 # ---------------------------------------------------------------------------
 # AUTHORED ~/.claude COPY — ALWAYS-RUN, deliberately ABOVE the version gate.

--- a/config/versions.env
+++ b/config/versions.env
@@ -33,3 +33,14 @@ CODEX_VERSION=0.146.0
 NVIM_VERSION=0.12.4
 NVIM_SHA256_X86_64=012bf3fcac5ade43914df3f174668bf64d05e049a4f032a388c027b1ebd78628
 NVIM_SHA256_ARM64=ceb7e88c6b681f0515d135dcdfad54f5eb4373b25ce6172197cd9a69c758063f
+# tree-sitter CLI: config/nvim pins nvim-treesitter to its `main` branch, which
+# shells out to `tree-sitter build` for every parser — there is no fallback to a
+# bare `cc`, so without this binary every parser fails with
+# `ENOENT ... (cmd): 'tree-sitter'`. On a host it arrives via mise
+# (npm:tree-sitter-cli in config/mise/config.toml); containers never run mise,
+# hence the pinned release binary here. Keep the version in step with the mise
+# pin. The assets are single gzipped binaries (.gz, not tarballs) and upstream
+# publishes no checksum file, so these are computed from the release downloads.
+TREE_SITTER_VERSION=0.26.11
+TREE_SITTER_SHA256_X86_64=8dac3c89bb632eece700ea7a261ad963b251f2228c4aef3b58458ebea8dbe4eb
+TREE_SITTER_SHA256_ARM64=e47dd59bf2f21ad7c15771546a724464ee3c008a60fbb61c6860bd19a44b3060

--- a/core/git/git-hooks.symlink/post-checkout
+++ b/core/git/git-hooks.symlink/post-checkout
@@ -1,3 +1,15 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+# Stock git-lfs hook, adapted for a GLOBAL core.hooksPath. git-lfs writes these
+# per-repo, where a missing binary really is an error worth `exit 2`. The
+# dotfiles point core.hooksPath here for EVERY repo, so that exit code turns any
+# machine without git-lfs into one where clone and checkout fail outright —
+# including the repos that never touched LFS. Devcontainer images are the common
+# case: it breaks lazy.nvim's plugin clones with an error naming LFS, not the
+# container. Warn and step aside instead. A genuine LFS repo still checks out,
+# just with pointer files, which is the best available outcome without the
+# binary — and far better than no checkout at all.
+command -v git-lfs >/dev/null 2>&1 || {
+  printf >&2 '%s\n' "git-lfs not found - skipping 'git lfs post-checkout'; any LFS files are left as pointers."
+  exit 0
+}
 git lfs post-checkout "$@"

--- a/core/git/git-hooks.symlink/post-commit
+++ b/core/git/git-hooks.symlink/post-commit
@@ -1,3 +1,15 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+# Stock git-lfs hook, adapted for a GLOBAL core.hooksPath. git-lfs writes these
+# per-repo, where a missing binary really is an error worth `exit 2`. The
+# dotfiles point core.hooksPath here for EVERY repo, so that exit code turns any
+# machine without git-lfs into one where clone and checkout fail outright —
+# including the repos that never touched LFS. Devcontainer images are the common
+# case: it breaks lazy.nvim's plugin clones with an error naming LFS, not the
+# container. Warn and step aside instead. A genuine LFS repo still checks out,
+# just with pointer files, which is the best available outcome without the
+# binary — and far better than no checkout at all.
+command -v git-lfs >/dev/null 2>&1 || {
+  printf >&2 '%s\n' "git-lfs not found - skipping 'git lfs post-commit'; any LFS files are left as pointers."
+  exit 0
+}
 git lfs post-commit "$@"

--- a/core/git/git-hooks.symlink/post-merge
+++ b/core/git/git-hooks.symlink/post-merge
@@ -1,3 +1,15 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+# Stock git-lfs hook, adapted for a GLOBAL core.hooksPath. git-lfs writes these
+# per-repo, where a missing binary really is an error worth `exit 2`. The
+# dotfiles point core.hooksPath here for EVERY repo, so that exit code turns any
+# machine without git-lfs into one where clone and checkout fail outright —
+# including the repos that never touched LFS. Devcontainer images are the common
+# case: it breaks lazy.nvim's plugin clones with an error naming LFS, not the
+# container. Warn and step aside instead. A genuine LFS repo still checks out,
+# just with pointer files, which is the best available outcome without the
+# binary — and far better than no checkout at all.
+command -v git-lfs >/dev/null 2>&1 || {
+  printf >&2 '%s\n' "git-lfs not found - skipping 'git lfs post-merge'; any LFS files are left as pointers."
+  exit 0
+}
 git lfs post-merge "$@"

--- a/core/git/git-hooks.symlink/pre-push
+++ b/core/git/git-hooks.symlink/pre-push
@@ -1,3 +1,15 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+# Stock git-lfs hook, adapted for a GLOBAL core.hooksPath. git-lfs writes these
+# per-repo, where a missing binary really is an error worth `exit 2`. The
+# dotfiles point core.hooksPath here for EVERY repo, so that exit code turns any
+# machine without git-lfs into one where clone and checkout fail outright —
+# including the repos that never touched LFS. Devcontainer images are the common
+# case: it breaks lazy.nvim's plugin clones with an error naming LFS, not the
+# container. Warn and step aside instead. A genuine LFS repo still checks out,
+# just with pointer files, which is the best available outcome without the
+# binary — and far better than no checkout at all.
+command -v git-lfs >/dev/null 2>&1 || {
+  printf >&2 '%s\n' "git-lfs not found - skipping 'git lfs pre-push'; any LFS files are left as pointers."
+  exit 0
+}
 git lfs pre-push "$@"

--- a/tests/git_lfs_hooks.bats
+++ b/tests/git_lfs_hooks.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+#
+# These four hooks ship straight from `git lfs install`, but the dotfiles wire
+# them up through a GLOBAL core.hooksPath rather than per-repo. That changes what
+# "git-lfs is missing" means: stock behaviour (`exit 2`) is right for a repo that
+# opted into LFS, and wrong for every other repo on a machine without the binary
+# — which is every devcontainer built from a stock language image.
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  HOOK_DIR="$REPO_ROOT/core/git/git-hooks.symlink"
+}
+
+# The default test PATH keeps /usr/bin, where the host's own git-lfs lives, so
+# absence has to be staged per-invocation. Scoping it to the hook process rather
+# than the test shell keeps bats' own teardown (which needs /usr/bin) working.
+run_without_git_lfs() {
+  run env PATH="$STUB_BIN" "$@"
+}
+
+lfs_hooks() {
+  echo post-checkout post-commit post-merge pre-push
+}
+
+@test "the lfs hooks step aside instead of failing when git-lfs is missing" {
+  for hook in $(lfs_hooks); do
+    run_without_git_lfs "$HOOK_DIR/$hook"
+
+    # exit 2 here is what broke lazy.nvim's plugin clones: git reports the
+    # checkout as failed and the caller sees an error naming LFS.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"git-lfs not found"* ]]
+    # The message has to name the hook, or a failing clone gives no clue which
+    # of the four fired.
+    [[ "$output" == *"$hook"* ]]
+  done
+}
+
+@test "the lfs hooks still delegate to git-lfs when it is installed" {
+  # `git lfs <hook>` is reached via the `git` on PATH, so stubbing git is enough
+  # to observe delegation without installing git-lfs.
+  stub_command git-lfs 'exit 0'
+  stub_command git 'echo "git $*"'
+
+  for hook in $(lfs_hooks); do
+    run "$HOOK_DIR/$hook" arg1 arg2
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "git lfs $hook arg1 arg2" ]
+  done
+}

--- a/tests/project_claude_setup_seed.bats
+++ b/tests/project_claude_setup_seed.bats
@@ -638,6 +638,142 @@ extract_seed_script() {
   [ "$(cat "$HOME/.config/nvim/init.lua")" = mine ]
 }
 
+# --- tree-sitter CLI -------------------------------------------------------
+# config/nvim pins nvim-treesitter to its `main` branch, whose installer shells
+# out to `tree-sitter build` for every parser with no fallback to a bare `cc`.
+# A container with gcc but no CLI still fails every parser at first launch.
+
+# Stages a gzipped fake tree-sitter, points a curl stub at it, and writes a
+# versions.env whose checksum matches. Both arch SHAs get the same value so the
+# suite passes on x86_64 and arm64 runners alike.
+stage_tree_sitter_download() {
+  local body="$1"
+  mkdir -p "$TEST_ROOT/host-seed/.dotfiles/config" "$HOME/.local/bin"
+
+  printf '#!/usr/bin/env bash\n%s\n' "$body" >"$TEST_ROOT/ts-bin"
+  # -n suppresses the mtime header, so the checksum is reproducible.
+  gzip -n -c "$TEST_ROOT/ts-bin" >"$TEST_ROOT/ts.gz"
+  TS_FIXTURE="$TEST_ROOT/ts.gz"
+  export TS_FIXTURE
+
+  local sha
+  sha="$(sha256sum "$TS_FIXTURE" | cut -d' ' -f1)"
+  cat >"$TEST_ROOT/host-seed/.dotfiles/config/versions.env" <<EOF
+TREE_SITTER_VERSION=0.26.11
+TREE_SITTER_SHA256_X86_64=$sha
+TREE_SITTER_SHA256_ARM64=$sha
+EOF
+
+  # The nvim block shares this curl stub, so keep it out of the way by
+  # presenting an already-installed binary — this test is about tree-sitter.
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$HOME/.local/bin/nvim"
+  chmod +x "$HOME/.local/bin/nvim"
+
+  stub_command curl '
+set -euo pipefail
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$out" ] || exit 1
+cp "$TS_FIXTURE" "$out"
+'
+}
+
+@test "the seed installs the tree-sitter CLI nvim-treesitter needs" {
+  stage_tree_sitter_download 'exit 0'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter ready"* ]]
+  [ -x "$HOME/.local/bin/tree-sitter" ]
+  # The staging file must never survive a successful install.
+  [ ! -e "$HOME/.local/bin/tree-sitter.new" ]
+}
+
+@test "an existing tree-sitter is left alone" {
+  stage_tree_sitter_download 'exit 0'
+  stub_command tree-sitter 'exit 0'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter already present"* ]]
+  [ ! -e "$HOME/.local/bin/tree-sitter" ]
+}
+
+@test "a warm restart reuses the installed tree-sitter instead of re-downloading" {
+  # The seed runs as a container `command:`, whose PATH does not include
+  # ~/.local/bin — so a `command -v` guard alone would miss the binary this block
+  # installed and pull 26MB again on every single container start. The guard has
+  # to test the path.
+  stage_tree_sitter_download 'exit 0'
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$HOME/.local/bin/tree-sitter"
+  chmod +x "$HOME/.local/bin/tree-sitter"
+  # Any download attempt is a failure of this test, so make one impossible.
+  stub_command curl 'exit 1'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter already present"* ]]
+  [[ "$output" != *"installing tree-sitter"* ]]
+}
+
+@test "an unpinned checksum skips tree-sitter before spending a download" {
+  stage_tree_sitter_download 'exit 0'
+  sed -i 's/^TREE_SITTER_SHA256_\(.*\)=.*/TREE_SITTER_SHA256_\1=/' \
+    "$TEST_ROOT/host-seed/.dotfiles/config/versions.env"
+  stub_command curl 'exit 1'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no pinned tree-sitter build"* ]]
+  [[ "$output" != *"installing tree-sitter"* ]]
+  [ ! -e "$HOME/.local/bin/tree-sitter" ]
+}
+
+@test "a tree-sitter that cannot execute is not installed" {
+  # The release binaries are dynamically linked against glibc, so on a musl base
+  # image the file is executable and still dies at exec time. `test -x` would
+  # accept it and leave a binary that looks installed while nvim-treesitter keeps
+  # failing — so the seed validates by actually running --version.
+  stage_tree_sitter_download 'exit 127'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter install failed"* ]]
+  [ ! -e "$HOME/.local/bin/tree-sitter" ]
+  [ ! -e "$HOME/.local/bin/tree-sitter.new" ]
+}
+
+@test "a checksum mismatch never lands a tree-sitter binary" {
+  stage_tree_sitter_download 'exit 0'
+  sed -i 's/^TREE_SITTER_SHA256_\(.*\)=.*/TREE_SITTER_SHA256_\1=deadbeef/' \
+    "$TEST_ROOT/host-seed/.dotfiles/config/versions.env"
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter install failed"* ]]
+  [ ! -e "$HOME/.local/bin/tree-sitter" ]
+}
+
+@test "a missing versions.env skips tree-sitter without aborting the seed" {
+  # Non-fatal throughout: treesitter highlighting is a nicety, and an editor that
+  # opens without it beats a container that will not start.
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"tree-sitter ready"* ]]
+}
+
 @test "the dotfiles shell loader is installed exactly once" {
   # load-custom.zsh is the supported entry point. Globbing **/*.zsh instead also
   # matches load-custom.zsh itself, so the whole tree loads twice — aliases

--- a/tests/project_claude_setup_seed.bats
+++ b/tests/project_claude_setup_seed.bats
@@ -738,6 +738,34 @@ cp "$TS_FIXTURE" "$out"
   [ ! -e "$HOME/.local/bin/tree-sitter" ]
 }
 
+@test "a tree-sitter on PATH that cannot run is replaced, not trusted" {
+  # `command -v` is satisfied by a shim whose tool was never installed, and by a
+  # glibc binary on a musl base that dies at exec time. Trusting either latches
+  # the block shut: "already present" every start, parsers failing every start.
+  stage_tree_sitter_download 'exit 0'
+  stub_command tree-sitter 'exit 127'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter ready"* ]]
+  [ -x "$HOME/.local/bin/tree-sitter" ]
+}
+
+@test "an installed tree-sitter that stops running is reinstalled" {
+  stage_tree_sitter_download 'exit 0'
+  # Executable, on the expected path, and broken — the shape a base-image change
+  # leaves behind. The guard must not accept it on the strength of `test -x`.
+  printf '#!/usr/bin/env bash\nexit 127\n' >"$HOME/.local/bin/tree-sitter"
+  chmod +x "$HOME/.local/bin/tree-sitter"
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter ready"* ]]
+  "$HOME/.local/bin/tree-sitter"
+}
+
 @test "a tree-sitter that cannot execute is not installed" {
   # The release binaries are dynamically linked against glibc, so on a musl base
   # image the file is executable and still dies at exec time. `test -x` would

--- a/tests/project_claude_setup_seed.bats
+++ b/tests/project_claude_setup_seed.bats
@@ -749,7 +749,10 @@ cp "$TS_FIXTURE" "$out"
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"tree-sitter ready"* ]]
-  [ -x "$HOME/.local/bin/tree-sitter" ]
+  # Asserted the way the seed's own guard asserts it: the bit says nothing about
+  # whether the file can actually run, which is the whole point of this test.
+  run "$HOME/.local/bin/tree-sitter" --version
+  [ "$status" -eq 0 ]
 }
 
 @test "an installed tree-sitter that stops running is reinstalled" {
@@ -763,7 +766,8 @@ cp "$TS_FIXTURE" "$out"
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"tree-sitter ready"* ]]
-  "$HOME/.local/bin/tree-sitter"
+  run "$HOME/.local/bin/tree-sitter" --version
+  [ "$status" -eq 0 ]
 }
 
 @test "a tree-sitter that cannot execute is not installed" {


### PR DESCRIPTION
Three failures that all surfaced as a broken nvim inside devcontainers seeded by the `project-claude-setup` skill.

## 1. Missing `tree-sitter` CLI — the reported bug

`config/nvim` pins nvim-treesitter to its `main` branch, whose installer shells out to `tree-sitter build` for **every** parser with no fallback to a bare `cc`. On a host the CLI arrives via mise (`npm:tree-sitter-cli`); the seed never runs mise, so every container failed each parser at first launch:

```
Error during "tree-sitter build": vim/_core/system:324: ENOENT: no such file or directory (cmd): 'tree-sitter'
```

- `config/versions.env` gains `TREE_SITTER_VERSION` + per-arch SHA256 (kept in step with the mise pin).
- The seed downloads the pinned release binary, verifies the checksum, and validates by **running** `--version` — `test -x` would accept a glibc-linked binary on a musl base image that dies at exec time.
- Lives in the **always-run** block: `~/.local/bin` is the ephemeral writable layer, so a version-gated step would be skipped as "already seeded" and the binary would vanish on every rebuild.
- Guarded on the binary's **path** before `command -v`: the seed runs as a container `command:` whose PATH excludes `~/.local/bin`, so a PATH-only guard would re-download 26MB on every container start.
- Non-fatal throughout, matching the neighbouring nvim block.

## 2. Global git-lfs hooks broke every clone

The dotfiles point `core.hooksPath` at git-lfs's stock hooks **globally**. Those hooks `exit 2` when git-lfs is missing — correct for a repo that opted into LFS, wrong for every repo on a machine without the binary, which is every devcontainer built from a stock language image. `git clone` exits 2, so lazy.nvim could not fetch a single plugin and reported an error naming LFS rather than the container.

They now warn and step aside. A genuine LFS repo still checks out, with pointer files — strictly better than no checkout at all. Host behaviour is unchanged (git-lfs is present, so the guard never fires).

## 3. Stale containers silently skip the seed

A container created *before* `docker-compose.override.yml` was wired into `dockerComposeFile` keeps the mounts and `command:` recorded at creation. Neither a restart nor editing `devcontainer.json` changes that, so the seed never runs — no `/host-seed`, no nvim, no `claude`, no dotfiles, with symptoms that point everywhere except the real cause. `SKILL.md` gains a first-line verification step that checks `/host-seed` is actually mounted and calls for a **rebuild**, not a restart.

## Verification

- `make check`: **260 tests, 0 failures**, 0 errors, 0 warnings.
- 9 new tests — tree-sitter install/reuse/warm-restart/checksum-mismatch/exec-failure/unpinned-skip, plus both git-lfs hook paths across all four hooks.
- Live in the wanderer-notifier container: `git clone` exit **2 → 0** with the patched hook, and `nvim --headless +Lazy! sync` now installs **20 plugins** cleanly.
- Live in the slabledger container: `tree-sitter 0.26.11` installed and the previously-failing parser build completed with zero errors.

## Follow-up (not in this PR)

`wanderer-kills`' container predates its `dockerComposeFile` edit and has no `/host-seed` mount at all — it needs a **Rebuild Container** once this merges. Rebuilding before merge would be wasted, since the seed reads `TREE_SITTER_*` from the mirrored `main`-branch `config/versions.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Development containers now automatically configure the Tree-sitter CLI when supported, improving editor parsing and language tooling.
  - Setup verification now checks host mounts, Compose configuration, Tree-sitter availability, and parser installation.
- **Bug Fixes**
  - Git operations now continue successfully when Git LFS is unavailable, with a concise warning; LFS files remain as pointers.
  - Tree-sitter setup failures no longer prevent the development environment from starting.
- **Tests**
  - Added coverage for Git LFS behavior and Tree-sitter installation, reuse, validation, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->