### PR TITLE
fix(nvim): skip treesitter installs when the tree-sitter CLI cannot run

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -596,17 +596,31 @@ elif [ -r "$DOTFILES_HOME/config/versions.env" ]; then
       as_user "$TS_BIN.new" --version >/dev/null 2>&1 &&
       as_user mv "$TS_BIN.new" "$TS_BIN"; then
       echo "🌱 seed: tree-sitter ready"
-    elif [ -f "$TS_BIN.new" ] && ! as_user "$TS_BIN.new" --version >/dev/null 2>&1; then
-      # Distinguished from a generic failure because it is not fixable here and
-      # reads as a seed bug otherwise. Upstream's Linux binaries are dynamically
-      # linked against a recent glibc — every 0.26.x needs 2.39, while Debian
-      # bookworm ships 2.36 — and nvim-treesitter's `main` branch refuses a CLI
-      # older than 0.26.1, so on such an image no published build can work. The
-      # nvim config skips parser installs when the CLI cannot run, so this costs
-      # treesitter highlighting and nothing else. Fixing it means a newer base
-      # image (trixie and up are fine); naming the local glibc makes that call
-      # possible from the log alone.
-      echo "⚠️  seed: tree-sitter $TREE_SITTER_VERSION needs a newer glibc than this image has ($(ldd --version 2>&1 | head -1)) — skipping (nvim falls back to regex highlighting)"
+    elif [ -f "$TS_BIN.new" ] && ! TS_ERR="$(as_user "$TS_BIN.new" --version 2>&1 >/dev/null)"; then
+      # The download and checksum passed, so this is the binary upstream
+      # published — it just will not run here. WHICH reason matters: a loader
+      # failure is a property of the image that no retry can fix, while any
+      # other nonzero exit is an ordinary install failure worth reporting as
+      # one. Blaming glibc for every failure sends the reader to rebuild on a
+      # newer base image for a problem that was never about the base image.
+      case "$TS_ERR" in
+        *GLIBC_* | *"cannot open shared object"* | *"No such file or directory"* | *"Exec format error"*)
+          # Upstream's Linux binaries are dynamically linked against a recent
+          # glibc — every 0.26.x needs 2.39, while Debian bookworm ships 2.36 —
+          # and nvim-treesitter's `main` branch refuses a CLI older than 0.26.1,
+          # so on such an image no published build can work. The same shape
+          # covers a musl image, where the ELF interpreter is simply absent; the
+          # embedded ldd banner tells the two apart. The nvim config skips parser
+          # installs when the CLI cannot run, so this costs treesitter
+          # highlighting and nothing else. Fixing it means a newer base image
+          # (trixie and up are fine), and naming the local libc makes that call
+          # possible from the log alone.
+          echo "⚠️  seed: tree-sitter $TREE_SITTER_VERSION needs a newer glibc than this image has ($(ldd --version 2>&1 | head -1)) — skipping (nvim falls back to regex highlighting)"
+          ;;
+        *)
+          echo "⚠️  seed: tree-sitter install failed — the downloaded binary exits nonzero: ${TS_ERR:-no output on stderr} (non-fatal; treesitter parsers will not compile)"
+          ;;
+      esac
     else
       echo "⚠️  seed: tree-sitter install failed (non-fatal; treesitter parsers will not compile)"
     fi

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -596,6 +596,17 @@ elif [ -r "$DOTFILES_HOME/config/versions.env" ]; then
       as_user "$TS_BIN.new" --version >/dev/null 2>&1 &&
       as_user mv "$TS_BIN.new" "$TS_BIN"; then
       echo "🌱 seed: tree-sitter ready"
+    elif [ -f "$TS_BIN.new" ] && ! as_user "$TS_BIN.new" --version >/dev/null 2>&1; then
+      # Distinguished from a generic failure because it is not fixable here and
+      # reads as a seed bug otherwise. Upstream's Linux binaries are dynamically
+      # linked against a recent glibc — every 0.26.x needs 2.39, while Debian
+      # bookworm ships 2.36 — and nvim-treesitter's `main` branch refuses a CLI
+      # older than 0.26.1, so on such an image no published build can work. The
+      # nvim config skips parser installs when the CLI cannot run, so this costs
+      # treesitter highlighting and nothing else. Fixing it means a newer base
+      # image (trixie and up are fine); naming the local glibc makes that call
+      # possible from the log alone.
+      echo "⚠️  seed: tree-sitter $TREE_SITTER_VERSION needs a newer glibc than this image has ($(ldd --version 2>&1 | head -1)) — skipping (nvim falls back to regex highlighting)"
     else
       echo "⚠️  seed: tree-sitter install failed (non-fatal; treesitter parsers will not compile)"
     fi

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -897,9 +897,34 @@ require('lazy').setup({
       -- Without one, degrade to regex syntax highlighting rather than erroring.
       -- `:checkhealth nvim-treesitter` reports the missing CLI and the version
       -- it wants, so this stays diagnosable without spamming startup.
+      --
+      -- A working CLI is not enough — it must be new enough. This branch pins
+      -- TREE_SITTER_MIN_VER = 0.26.1 in its health check and fails every build
+      -- below it, and Debian still ships 0.20.x as `tree-sitter-cli`, so an
+      -- exit-code check alone would wave through a CLI that reproduces exactly
+      -- the error wall this guard exists to prevent.
+      local ts_min = { 0, 26, 1 }
+
       local function tree_sitter_cli_works()
-        return vim.fn.executable('tree-sitter') == 1
-          and vim.system({ 'tree-sitter', '--version' }):wait().code == 0
+        if vim.fn.executable('tree-sitter') ~= 1 then return false end
+
+        -- pcall and a bounded wait, because this runs on the startup path:
+        -- vim.system throws outright if the binary vanishes between the
+        -- executable() check above and the spawn, and an unbounded wait() would
+        -- hang nvim forever on a binary that never exits. Neither may cost a
+        -- usable editor when the fallback is merely worse highlighting.
+        local ok, res = pcall(function()
+          return vim.system({ 'tree-sitter', '--version' }, { text = true }):wait(2000)
+        end)
+        if not ok or type(res) ~= 'table' or res.code ~= 0 then return false end
+
+        local have = { tostring(res.stdout or ''):match('(%d+)%.(%d+)%.(%d+)') }
+        if #have < 3 then return false end
+        for i = 1, 3 do
+          local n = tonumber(have[i])
+          if n ~= ts_min[i] then return n > ts_min[i] end
+        end
+        return true
       end
 
       if tree_sitter_cli_works() then require('nvim-treesitter').install(parsers) end

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -882,7 +882,27 @@ require('lazy').setup({
     config = function()
       -- ensure basic parser are installed
       local parsers = { 'bash', 'c', 'diff', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' }
-      require('nvim-treesitter').install(parsers)
+
+      -- This branch shells out to the `tree-sitter` CLI for every parser build,
+      -- with no fallback to a bare `cc`. Calling install() without a working CLI
+      -- does not fail quietly — it emits one `Error during "tree-sitter build":
+      -- ... ENOENT ... (cmd): 'tree-sitter'` per parser, on every single
+      -- startup, so opening any file buries the buffer under a wall of errors.
+      --
+      -- Running it is the check, not `executable()`. The CLI's official Linux
+      -- builds are dynamically linked against a recent glibc, so on an older
+      -- base image (Debian bookworm ships 2.36; the binaries want 2.39) the file
+      -- is present and executable and still dies at exec time.
+      --
+      -- Without one, degrade to regex syntax highlighting rather than erroring.
+      -- `:checkhealth nvim-treesitter` reports the missing CLI and the version
+      -- it wants, so this stays diagnosable without spamming startup.
+      local function tree_sitter_cli_works()
+        return vim.fn.executable('tree-sitter') == 1
+          and vim.system({ 'tree-sitter', '--version' }):wait().code == 0
+      end
+
+      if tree_sitter_cli_works() then require('nvim-treesitter').install(parsers) end
 
       ---@param buf integer
       ---@param language string

--- a/tests/project_claude_setup_seed.bats
+++ b/tests/project_claude_setup_seed.bats
@@ -909,7 +909,11 @@ cp "$TS_FIXTURE" "$out"
   # base image the file is executable and still dies at exec time. `test -x`
   # would accept it and leave a binary that looks installed while
   # nvim-treesitter keeps failing — so the seed validates by running --version.
-  stage_tree_sitter_download 'exit 127'
+  #
+  # The fixture reproduces the loader's own wording, because that string is
+  # what the seed keys on. A bare `exit 127` would pass this test while the
+  # seed silently misfiled every glibc case as a generic failure.
+  stage_tree_sitter_download 'printf "%s\n" "tree-sitter: /lib/x86_64-linux-gnu/libc.so.6: version \`GLIBC_2.39'"'"' not found" >&2; exit 1'
 
   run bash "$SEED_SCRIPT"
 
@@ -919,6 +923,26 @@ cp "$TS_FIXTURE" "$out"
   # know a retry cannot help and a newer base image is the only fix.
   [[ "$output" == *"needs a newer glibc"* ]]
   [[ "$output" == *"regex highlighting"* ]]
+  [ ! -e "$HOME/.local/bin/tree-sitter" ]
+  [ ! -e "$HOME/.local/bin/tree-sitter.new" ]
+}
+
+@test "a tree-sitter that fails for a non-loader reason is not blamed on glibc" {
+  # Same observable symptom — the binary will not run — but a different cause
+  # and a different remedy. Sending the reader off to rebuild on a newer base
+  # image for a failure that was never about the base image wastes the one
+  # signal this block exists to give them, so the diagnostic must follow the
+  # actual stderr rather than the failure alone.
+  stage_tree_sitter_download 'printf "%s\n" "error: unexpected argument" >&2; exit 2'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tree-sitter install failed"* ]]
+  [[ "$output" != *"needs a newer glibc"* ]]
+  # The captured stderr is carried through: without it the message says only
+  # that something failed, which is where the original bug hunt started.
+  [[ "$output" == *"unexpected argument"* ]]
   [ ! -e "$HOME/.local/bin/tree-sitter" ]
   [ ! -e "$HOME/.local/bin/tree-sitter.new" ]
 }

--- a/tests/project_claude_setup_seed.bats
+++ b/tests/project_claude_setup_seed.bats
@@ -905,16 +905,20 @@ cp "$TS_FIXTURE" "$out"
 }
 
 @test "a tree-sitter that cannot execute is not installed" {
-  # The release binaries are dynamically linked against glibc, so on a musl base
-  # image the file is executable and still dies at exec time. `test -x` would
-  # accept it and leave a binary that looks installed while nvim-treesitter keeps
-  # failing — so the seed validates by actually running --version.
+  # The release binaries are dynamically linked against glibc, so on an older
+  # base image the file is executable and still dies at exec time. `test -x`
+  # would accept it and leave a binary that looks installed while
+  # nvim-treesitter keeps failing — so the seed validates by running --version.
   stage_tree_sitter_download 'exit 127'
 
   run bash "$SEED_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"tree-sitter install failed"* ]]
+  # Reported as the environment limit it is, not as a generic failure: no
+  # published 0.26.x build runs on a glibc this old, so the operator needs to
+  # know a retry cannot help and a newer base image is the only fix.
+  [[ "$output" == *"needs a newer glibc"* ]]
+  [[ "$output" == *"regex highlighting"* ]]
   [ ! -e "$HOME/.local/bin/tree-sitter" ]
   [ ! -e "$HOME/.local/bin/tree-sitter.new" ]
 }


### PR DESCRIPTION
## Problem

PR #37 made the devcontainer seed install a pinned `tree-sitter` CLI, which fixed containers that had none. The nvim error persisted in wanderer after a full rebuild.

The seed was working. The binary cannot run:

```
/home/developer/.local/bin/tree-sitter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

Every published tree-sitter **0.26.x** Linux binary is dynamically linked against `GLIBC_2.39`. Debian **bookworm ships 2.36**; trixie ships 2.41. Checked and ruled out:

- no musl asset is published
- the `.zip` asset is the identical binary
- the npm package has no per-platform optionalDependencies — it downloads the same binary
- downgrading is capped: `TREE_SITTER_MIN_VER = { 0, 26, 1 }` in nvim-treesitter's `health.lua`, and 0.26.1/0.26.5/0.26.8/0.26.11 all want 2.39

So on a bookworm base image **no published build can work**. slabledger (trixie) prints `tree-sitter 0.26.11` and is unaffected.

## Changes

**`config/nvim/init.lua`** — guard `require('nvim-treesitter').install(parsers)`. The check runs the CLI rather than calling `executable()`, because the file is present and executable and still dies at exec time. Without a working CLI, degrade to regex highlighting instead of emitting one `Error during "tree-sitter build"` per parser on every startup. `:checkhealth nvim-treesitter` still reports the missing CLI, so this stays diagnosable.

**`templates/local-seed.sh`** — the seed reports the glibc case specifically, embedding `$(ldd --version | head -1)`, so the log alone shows that a retry cannot help and a base-image bump is the fix. The generic failure message is unchanged for every other cause.

**`tests/project_claude_setup_seed.bats`** — the existing "cannot execute" test asserts the new message.

The equivalent seed message was applied to all five local `local-seed.sh` files (gitignored); `sh -n` clean on each.

## Rebased onto #34

The original branch edited the seed block inside `devcontainer-host-mounts.md`. #34 moved the executable seed out of that prose reference and into `templates/local-seed.sh`, so this is re-applied against the new source of truth rather than merged — the reference no longer carries a copy to keep in sync.

## Verification

- `make check` — 312 passing, 0 failing (post-rebase, on top of #34)
- `shellcheck -S warning -e SC1091` and `shfmt -d -i 2 -ci` clean on the seed template
- Live in `wanderer_devcontainer-wanderer-1`, same container, same nvim:
  - pre-change `init.lua` → `Downloading tree-sitter-lua...` etc., then build errors
  - guarded `init.lua` → no output, exit 0

## Follow-up, not in this PR

The real fix for bookworm containers is a base image with glibc ≥ 2.39. That means editing project Dockerfiles, which the skill's scope explicitly forbids — so it stays a per-project decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tree-sitter compatibility checks during setup and startup.
  * Prevented repeated parser installation errors when Tree-sitter is unavailable, incompatible, or cannot start reliably.
  * Added clearer diagnostics for binaries requiring a newer glibc version or other missing runtime libraries.
  * Automatically skips incompatible Tree-sitter setup while preserving fallback syntax highlighting.
  * Improved error reporting by including relevant command output for non-compatibility failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->