### PR TITLE
fix(overlay-sync): recover the project slug when the mount path hides it

### DIFF
--- a/ai/claude/hooks/overlay-sync.sh
+++ b/ai/claude/hooks/overlay-sync.sh
@@ -45,6 +45,31 @@ main_root=$(git -C "$repo_root" worktree list --porcelain 2>/dev/null |
 [ -n "$main_root" ] && [ -d "$main_root" ] || main_root="$repo_root"
 slug=$(basename "$main_root")
 
+# The directory name is not always the project name. A devcontainer bind-mounts
+# the repo at whatever path its compose file picked — /app, /workspace, /src —
+# so the same checkout that is `wanderer` on the host is `app` inside the
+# container, and this hook would look for a projects/app that does not exist and
+# fail open on every worktree. Recover the real slug from an overlay link the
+# main checkout already carries: those are created with an explicit slug, and
+# readlink reads the target text without resolving it, so a link left dangling
+# by the foreign-$HOME breakage above still names its project correctly.
+if [ ! -d "$DOTFILES/projects/$slug" ]; then
+  for link in "$main_root"/.claude/* "$main_root"/*; do
+    [ -L "$link" ] || continue
+    target=$(readlink "$link" 2>/dev/null) || continue
+    case "$target" in
+      */projects/*) ;;
+      *) continue ;;
+    esac
+    candidate=${target#*/projects/}
+    candidate=${candidate%%/*}
+    if [ -n "$candidate" ] && [ -d "$DOTFILES/projects/$candidate" ]; then
+      slug="$candidate"
+      break
+    fi
+  done
+fi
+
 overlay="$DOTFILES/projects/$slug"
 [ -d "$overlay" ] || exit_quiet
 

--- a/ai/claude/hooks/overlay-sync.sh
+++ b/ai/claude/hooks/overlay-sync.sh
@@ -63,7 +63,15 @@ if [ ! -d "$DOTFILES/projects/$slug" ]; then
     esac
     candidate=${target#*/projects/}
     candidate=${candidate%%/*}
-    if [ -n "$candidate" ] && [ -d "$DOTFILES/projects/$candidate" ]; then
+    # A slug is one path component, so "." and ".." are never valid ones — and
+    # the -d test below cannot reject them, since both resolve to directories
+    # that exist. ".." is the one that bites: it escapes projects/ entirely, so
+    # the linker would be handed --slug .. and would link $DOTFILES/.claude,
+    # the global agent config, into the project as if it were an overlay.
+    case "$candidate" in
+      "" | "." | "..") continue ;;
+    esac
+    if [ -d "$DOTFILES/projects/$candidate" ]; then
       slug="$candidate"
       break
     fi

--- a/tests/overlay_sync_hook.bats
+++ b/tests/overlay_sync_hook.bats
@@ -121,6 +121,61 @@ run_hook() {
   [ ! -e "$PROJECT/.claude/skills" ]
 }
 
+@test "recovers the slug when the checkout directory is not the project name" {
+  # A devcontainer bind-mounts the repo wherever its compose file says — /app,
+  # /workspace — so the checkout that is 'demo' on the host is 'app' inside the
+  # container, and basename() looks for a projects/app that will never exist.
+  # The main checkout's own links name the real project; use them.
+  mounted="$TEST_ROOT/app"
+  git clone --quiet "$PROJECT" "$mounted"
+  mkdir -p "$mounted/.claude"
+  ln -s "$OVERLAY/.claude/skills" "$mounted/.claude/skills"
+  linked="$TEST_ROOT/wt-mounted"
+  git -C "$mounted" worktree add --quiet -b feature "$linked"
+  [ ! -e "$linked/.claude/skills" ]
+
+  run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$linked")"
+
+  [ "$status" -eq 0 ]
+  assert_symlink_target "$linked/.claude/skills" "$OVERLAY/.claude/skills"
+}
+
+@test "recovers the slug from a link that dangles in this environment" {
+  # Both breakages at once: the mount path hides the project name AND the
+  # links were made under a $HOME that does not exist here. readlink reads the
+  # target text without resolving it, so the slug is still recoverable — which
+  # is the only reason a container can repair host-made links at all.
+  mounted="$TEST_ROOT/app"
+  git clone --quiet "$PROJECT" "$mounted"
+  mkdir -p "$mounted/.claude"
+  ln -s /home/ghost/.dotfiles/projects/demo/.claude/skills \
+    "$mounted/.claude/skills"
+
+  run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$mounted")"
+
+  [ "$status" -eq 0 ]
+  assert_symlink_target "$mounted/.claude/skills" "$OVERLAY/.claude/skills"
+  [ -z "$(find "$mounted/.claude" -xtype l)" ]
+}
+
+@test "does not adopt a slug with no overlay behind it" {
+  # Recovery must confirm the projects/ directory exists. Trusting the link
+  # text alone would hand the linker a slug for an overlay that is not there,
+  # turning a silent no-op into a failing linker run on every session start.
+  mounted="$TEST_ROOT/app"
+  git clone --quiet "$PROJECT" "$mounted"
+  mkdir -p "$mounted/.claude"
+  ln -s /home/ghost/.dotfiles/projects/gone/.claude/skills \
+    "$mounted/.claude/skills"
+
+  run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$mounted")"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ "$(readlink "$mounted/.claude/skills")" = \
+    /home/ghost/.dotfiles/projects/gone/.claude/skills ]
+}
+
 @test "does nothing outside a git repository" {
   mkdir -p "$TEST_ROOT/plain"
   run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$TEST_ROOT/plain")"

--- a/tests/overlay_sync_hook.bats
+++ b/tests/overlay_sync_hook.bats
@@ -176,6 +176,34 @@ run_hook() {
     /home/ghost/.dotfiles/projects/gone/.claude/skills ]
 }
 
+@test "does not adopt a path-navigation slug from a link target" {
+  # The -d test cannot reject "." or ".." — both name directories that exist.
+  # ".." is the one that bites: $DOTFILES/projects/.. is $DOTFILES itself, so
+  # an unvalidated candidate hands the linker --slug .. and links the global
+  # $DOTFILES/.claude into the project as if it were this project's overlay.
+  # Give that escape something real to land on, so dropping the guard fails
+  # this test loudly instead of passing because there was nothing to link.
+  mkdir -p "$DOTFILES/.claude/skills/global"
+  echo global >"$DOTFILES/.claude/skills/global/SKILL.md"
+
+  n=0
+  for nav in .. .; do
+    n=$((n + 1))
+    mounted="$TEST_ROOT/app$n"
+    git clone --quiet "$PROJECT" "$mounted"
+    mkdir -p "$mounted/.claude"
+    target="/home/ghost/.dotfiles/projects/$nav/.claude/skills"
+    ln -s "$target" "$mounted/.claude/skills"
+
+    run bash "$HOOK" <<<"$(printf '{"cwd":"%s"}' "$mounted")"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ "$(readlink "$mounted/.claude/skills")" = "$target" ]
+    [ ! -e "$mounted/.claude/skills/global/SKILL.md" ]
+  done
+}
+
 @test "does nothing outside a git repository" {
   mkdir -p "$TEST_ROOT/plain"
   run bash "$HOOK" <<<"$(printf '{"hook_event_name":"SessionStart","cwd":"%s"}' "$TEST_ROOT/plain")"


### PR DESCRIPTION
## Problem

Reported as: worktrees in the wanderer devcontainer have no access to the `~/.dotfiles/projects/wanderer` skills. Reproduced — worktrees created inside the container get a `.claude/` holding only `settings.local.json`, no `skills`, `agents`, or `references`. On the host the same repo is fine.

`overlay-sync.sh` keys the overlay on the main checkout's **directory name**. That name is not stable across environments:

```
bind /home/tng/workspace/wanderer -> /app
```

So inside the container the slug resolves to `app`, `~/.dotfiles/projects/app` does not exist, and the hook takes its fail-open path — silently, which is correct behaviour for a SessionStart hook and exactly why this went unnoticed.

Confirmed directly:

```
$ main_root=$(git -C "$w" worktree list --porcelain | awk '/^worktree /{print substr($0,10); exit}')
main_root=/app
slug=app
ls: cannot access '/home/developer/.dotfiles/projects/app': No such file or directory
```

The main checkout's own links were right all along (`skills -> /opt/dotfiles/projects/wanderer/.claude/skills`) — they were created with an explicit slug. Only the hook's inference was wrong.

## Change

When the directory name yields no overlay, recover the slug from an overlay link the main checkout already carries.

- `readlink` reads the target text **without resolving it**, so a link left dangling by the foreign-`$HOME` breakage this hook already repairs still names its project correctly. That is what lets a container repair host-made links at all.
- The recovered slug is adopted only after confirming `projects/<slug>/` exists. Trusting link text alone would hand the linker a slug for a missing overlay, turning a silent no-op into a failing linker run on every session start.
- Host behaviour is unchanged: the directory name already resolves there, so the recovery block never runs.

## Tests

Three added to `tests/overlay_sync_hook.bats`:

| Test | Covers |
|---|---|
| recovers the slug when the checkout directory is not the project name | the reported bug |
| recovers the slug from a link that dangles in this environment | mount-path *and* foreign-`$HOME` broken at once |
| does not adopt a slug with no overlay behind it | the confirm-before-adopt guard |

The first two **fail against the pre-fix hook** (verified by checking out `origin/main`'s copy and re-running); the third is a guard that must hold either way.

## Verification

- `make check` — 315 passing, 0 failing (post-rebase onto #34; +3 new)
- `shellcheck -S warning` and `shfmt -d -i 2 -ci` clean
- Live in `wanderer_devcontainer-wanderer-1`, on a real container-created worktree:
  - before: `.claude/` had only `settings.local.json`
  - after: `agents`, `references`, `skills` linked; `ls .claude/skills` lists the four wanderer skills; `git status --porcelain` still clean (the container `~/.gitignore` patterns are path-generic, so new links need no reseed)

## Note

The container's installed hook lives in the `dotfiles-local-home` volume, seeded from `/host-seed`. Existing containers pick this up on their next seed run after merge; the already-created worktrees repair themselves on the next session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay synchronization for repositories mounted under alternate directories.
  * Recovers valid project links when the expected project directory is unavailable.
  * Preserves invalid links and prevents unsafe path navigation.
  * Safely ignores missing or nonexistent overlays without producing errors.

* **Tests**
  * Added coverage for mounted repositories, dangling links, invalid overlay slugs, and silent hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->