### PR TITLE
fix(work): stop configuring the azure-cli APT repo twice

### DIFF
--- a/work/install.sh
+++ b/work/install.sh
@@ -36,9 +36,13 @@ setup_kubernetes_repository() {
 
 setup_microsoft_repositories() {
   download_apt_key https://packages.microsoft.com/keys/microsoft.asc /etc/apt/keyrings/microsoft.gpg || return
-  printf 'deb [arch=%s signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ %s main\n' \
-    "$(dpkg --print-architecture)" "$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")" |
-    sudo tee /etc/apt/sources.list.d/azure-cli.list >/dev/null || return
+  # The azure-cli installer ships a deb822 azure-cli.sources. Write the same
+  # file rather than a legacy .list so the two cannot describe the same repo at
+  # once, which makes apt warn about duplicate targets on every update.
+  printf 'Types: deb\nURIs: https://packages.microsoft.com/repos/azure-cli/\nSuites: %s\nComponents: main\nArchitectures: %s\nSigned-By: /etc/apt/keyrings/microsoft.gpg\n' \
+    "$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")" "$(dpkg --print-architecture)" |
+    sudo tee /etc/apt/sources.list.d/azure-cli.sources >/dev/null || return
+  sudo rm -f /etc/apt/sources.list.d/azure-cli.list || return
   printf '%s\n' 'deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/code stable main' |
     sudo tee /etc/apt/sources.list.d/vscode.list >/dev/null
 }


### PR DESCRIPTION
## Problem

Every `apt update` on the work machine emitted seven duplicate-target warnings:

```
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in
   /etc/apt/sources.list.d/azure-cli.list:1 and /etc/apt/sources.list.d/azure-cli.sources:1
```
(…and the same for `binary-all`, Translations, two DEP-11 targets, and two CNF targets.)

The `az` installer ships a deb822 `azure-cli.sources`, while `setup_microsoft_repositories`
wrote a legacy `azure-cli.list` pointing at the same repo, suite, and component. Neither
file is dpkg-owned (`dpkg -S` finds no owner for either), so nothing was ever going to
reconcile them — and re-running the bootstrap re-created the duplicate after any manual
cleanup.

## Change

Write the deb822 `.sources` file directly and remove any stale `.list`. The bootstrap now
converges with the installer's own layout rather than competing with it, so both orderings
(installer-then-bootstrap, bootstrap-then-installer) settle on one file.

Suite and architecture stay dynamic, as before. The rendered output is byte-identical to
the file the installer produces on this machine:

```
Types: deb
URIs: https://packages.microsoft.com/repos/azure-cli/
Suites: noble
Components: main
Architectures: amd64
Signed-By: /etc/apt/keyrings/microsoft.gpg
```

## Verification

- `bats tests/linux_packages.bats tests/portability.bats tests/repository_hygiene.bats` — 29/29 pass
- `bash -n work/install.sh` — clean
- `shellcheck work/install.sh` — only pre-existing SC1091 info notices, the same ones already reported for the untouched docker block
- Compared the rendered `printf` output against the live `azure-cli.sources` — identical

## Notes for reviewers

Not addressed here, because neither is a dotfiles issue:

- The `NO_PUBKEY 35B8ACA44FD9CA9F` warning in the same `apt update` output is unrelated —
  AquaSecurity rotated the trivy signing key. Trivy isn't installed by this repo, so it's a
  one-time keyring refresh on the machine.
- `google-chrome.list` and `google-chrome.sources` also coexist, but they point at different
  URIs (`chrome/deb` vs `chrome-stable/deb`), so apt doesn't treat them as duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure CLI repository configuration to use the modern `.sources` format.
  * Removed the legacy repository configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->