### PR TITLE
Keep the private overlay repo's .git out of devcontainers

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -288,6 +288,11 @@ fi
 # named volume persists across rebuilds, so without --delete a deleted path
 # lingers until a manual wipe). Fall back to cp -a where rsync is absent.
 if [ -d "$SEED_DOTFILES" ]; then
+  # Status is captured rather than left to `set -e` so the prune below still runs
+  # when the transfer fails: a partial rsync/cp can already have written
+  # projects/.git into the volume, and the volume outlives this container. The
+  # original status is re-raised after the prune, so a failed seed still fails.
+  sync_status=0
   if command -v rsync >/dev/null 2>&1; then
     # -c checksums instead of the default size+mtime quick check. The quick
     # check compares mtime at 1-second resolution, so a same-size edit made
@@ -301,16 +306,22 @@ if [ -d "$SEED_DOTFILES" ]; then
     # from it. The pattern is anchored (leading /) so it means the mirror root
     # and not some other projects/.git deeper in the tree, and carries no
     # trailing / so it matches whether .git is a directory or a gitfile.
-    as_user rsync -ac --delete --exclude='/projects/.git' \
-      "$SEED_DOTFILES/" "$DOTFILES_HOME/"
-    echo "🌱 seed: mirrored ~/.dotfiles via rsync ($(du -sh "$DOTFILES_HOME" | cut -f1))"
+    if as_user rsync -ac --delete --exclude='/projects/.git' \
+      "$SEED_DOTFILES/" "$DOTFILES_HOME/"; then
+      echo "🌱 seed: mirrored ~/.dotfiles via rsync ($(du -sh "$DOTFILES_HOME" | cut -f1))"
+    else
+      sync_status=$?
+    fi
   else
     # No non-pruning fallback. DOTFILES_HOME persists across rebuilds and the
     # always-run installers below EXECUTE files from it, so a stale installer
     # deleted upstream would keep running. Wipe-then-copy prunes equivalently.
-    as_user find "$DOTFILES_HOME" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-    as_user cp -a "$SEED_DOTFILES/." "$DOTFILES_HOME/"
-    echo "🌱 seed: rebuilt ~/.dotfiles via wipe+cp (no rsync) ($(du -sh "$DOTFILES_HOME" | cut -f1))"
+    if as_user find "$DOTFILES_HOME" -mindepth 1 -maxdepth 1 -exec rm -rf {} + &&
+      as_user cp -a "$SEED_DOTFILES/." "$DOTFILES_HOME/"; then
+      echo "🌱 seed: rebuilt ~/.dotfiles via wipe+cp (no rsync) ($(du -sh "$DOTFILES_HOME" | cut -f1))"
+    else
+      sync_status=$?
+    fi
   fi
   # Unconditional, and not folded into the rsync exclude alone, for two reasons:
   # cp -a has no exclusion mechanism, and rsync PROTECTS an excluded path on the
@@ -318,7 +329,13 @@ if [ -d "$SEED_DOTFILES" ]; then
   # exclusion would keep its copy forever. Losing it costs nothing -- this tree
   # is a copy, and container writes never reach the host, so committing here was
   # never a way to save overlay edits.
-  as_user rm -rf "$DOTFILES_HOME/projects/.git"
+  #
+  # rm -rf on an absent path succeeds, so this is idempotent. A failure here is
+  # reported but not fatal: it must not mask the sync status re-raised below.
+  if ! as_user rm -rf "$DOTFILES_HOME/projects/.git"; then
+    echo "⚠️  seed: could not remove $DOTFILES_HOME/projects/.git" >&2
+  fi
+  [ "$sync_status" -eq 0 ] || exit "$sync_status"
 fi
 
 # Stable link root: /opt/dotfiles -> this container's dotfiles checkout.

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -294,7 +294,15 @@ if [ -d "$SEED_DOTFILES" ]; then
     # within a second of the previous sync is skipped -- silently, and this
     # tree decides the model. 40M of unchanged files hashes fast enough that
     # correctness is the better trade here.
-    as_user rsync -ac --delete "$SEED_DOTFILES/" "$DOTFILES_HOME/"
+    #
+    # projects/ is a nested PRIVATE repository. Its overlay files are payload and
+    # must mirror; its .git is history plus a remote URL naming the repo, in a
+    # named volume that outlives the container and ships with any image built
+    # from it. The pattern is anchored (leading /) so it means the mirror root
+    # and not some other projects/.git deeper in the tree, and carries no
+    # trailing / so it matches whether .git is a directory or a gitfile.
+    as_user rsync -ac --delete --exclude='/projects/.git' \
+      "$SEED_DOTFILES/" "$DOTFILES_HOME/"
     echo "🌱 seed: mirrored ~/.dotfiles via rsync ($(du -sh "$DOTFILES_HOME" | cut -f1))"
   else
     # No non-pruning fallback. DOTFILES_HOME persists across rebuilds and the
@@ -304,6 +312,13 @@ if [ -d "$SEED_DOTFILES" ]; then
     as_user cp -a "$SEED_DOTFILES/." "$DOTFILES_HOME/"
     echo "🌱 seed: rebuilt ~/.dotfiles via wipe+cp (no rsync) ($(du -sh "$DOTFILES_HOME" | cut -f1))"
   fi
+  # Unconditional, and not folded into the rsync exclude alone, for two reasons:
+  # cp -a has no exclusion mechanism, and rsync PROTECTS an excluded path on the
+  # receiver from --delete, so a volume seeded by a template predating the
+  # exclusion would keep its copy forever. Losing it costs nothing -- this tree
+  # is a copy, and container writes never reach the host, so committing here was
+  # never a way to save overlay edits.
+  as_user rm -rf "$DOTFILES_HOME/projects/.git"
 fi
 
 # Stable link root: /opt/dotfiles -> this container's dotfiles checkout.

--- a/tests/dependency_pins.bats
+++ b/tests/dependency_pins.bats
@@ -19,7 +19,7 @@ setup() {
   run bash "$REPO_ROOT/bin/versions" list
   [ "$status" -eq 0 ]
   [[ "$output" == *"mise go 1.25.12"* ]]
-  [[ "$output" == *"git prezto 9739c8bdc9c288ffc134c209225543180e32ff69"* ]]
+  [[ "$output" == *"git prezto $PREZTO_REF"* ]]
   [[ "$output" == *"git zsh-defer $ZSH_DEFER_REF"* ]]
   [[ "$output" == *"channel kubernetes v1.28"* ]]
   [[ "$output" == *"artifact mise v2026.7.18"* ]]

--- a/tests/project_claude_setup_seed.bats
+++ b/tests/project_claude_setup_seed.bats
@@ -353,6 +353,44 @@ extract_seed_script() {
   [ -f "$HOME/.dotfiles/projects/myrepo/CLAUDE.md" ]
 }
 
+@test "the overlay git directory never reaches the destination during the transfer" {
+  # The two final-state assertions above cannot tell exclusion from pruning: with
+  # the prune in place they pass even if --exclude is dropped, and rsync would
+  # then write the private repo's history into the volume first. Record the
+  # transfer's own arguments so the exclusion is verified where it happens.
+  local real_rsync
+  if ! real_rsync="$(command -v rsync)"; then
+    skip "rsync not installed; the seed takes the wipe+cp path"
+  fi
+  cat >"$STUB_BIN/rsync" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$TEST_ROOT/rsync.args"
+exec "$real_rsync" "\$@"
+EOF
+  chmod +x "$STUB_BIN/rsync"
+  mkdir -p "$TEST_ROOT/host-seed/.dotfiles/projects/.git"
+  printf 'host\n' >"$TEST_ROOT/host-seed/.dotfiles/projects/.git/config"
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  grep -Fq -- "--exclude=/projects/.git" "$TEST_ROOT/rsync.args"
+}
+
+@test "a failed mirror still prunes the overlay git directory and reports the failure" {
+  # A partial transfer can already have written projects/.git into the named
+  # volume, which outlives the container, so the prune must not be skipped when
+  # the sync aborts -- and the seed must still fail rather than swallow it.
+  mkdir -p "$HOME/.dotfiles/projects/.git"
+  printf 'stale\n' >"$HOME/.dotfiles/projects/.git/config"
+  stub_command rsync 'exit 23'
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 23 ]
+  [ ! -e "$HOME/.dotfiles/projects/.git" ]
+}
+
 @test "config removed from the host is pruned from the persisted volume" {
   # The destination lives in the persisted claude-local-home named volume, so a
   # source the host DELETED must be cleared on the next gated reseed. Pruning

--- a/tests/project_claude_setup_seed.bats
+++ b/tests/project_claude_setup_seed.bats
@@ -313,6 +313,46 @@ extract_seed_script() {
   [ ! -e "$HOME/.dotfiles/ai/marketplace/doomed.sh" ]
 }
 
+@test "the overlay repo's git directory is not mirrored into the container" {
+  # ~/.dotfiles/projects is a nested PRIVATE repository, so the mirror would
+  # otherwise copy its .git -- full history plus a remote URL naming the repo --
+  # into a named volume that outlives the container and ships with any image
+  # built from it. The overlay FILES are the payload and must still arrive; only
+  # the git directory is dropped. Committing from inside the container was never
+  # useful anyway: this tree is a copy, and container writes never reach the host.
+  mkdir -p "$TEST_ROOT/host-seed/.dotfiles/projects/myrepo/.claude" \
+    "$TEST_ROOT/host-seed/.dotfiles/projects/.git/refs"
+  printf '# myrepo\n' >"$TEST_ROOT/host-seed/.dotfiles/projects/myrepo/CLAUDE.md"
+  printf '[remote "origin"]\n\turl = git@example.com:private/overlays.git\n' \
+    >"$TEST_ROOT/host-seed/.dotfiles/projects/.git/config"
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$HOME/.dotfiles/projects/myrepo/CLAUDE.md")" = "# myrepo" ]
+  [ ! -e "$HOME/.dotfiles/projects/.git" ]
+}
+
+@test "an overlay git directory from an earlier seed is pruned" {
+  # Volumes seeded by a template predating the exclusion already hold the copy,
+  # and the named volume survives --remove-existing-container. The host keeps its
+  # own .git here, as in production: rsync PROTECTS an excluded path on the
+  # receiver from --delete, so excluding it from the transfer does not remove the
+  # copy already there. The prune therefore runs unconditionally.
+  mkdir -p "$TEST_ROOT/host-seed/.dotfiles/projects/myrepo" \
+    "$TEST_ROOT/host-seed/.dotfiles/projects/.git" \
+    "$HOME/.dotfiles/projects/.git"
+  printf '# myrepo\n' >"$TEST_ROOT/host-seed/.dotfiles/projects/myrepo/CLAUDE.md"
+  printf 'host\n' >"$TEST_ROOT/host-seed/.dotfiles/projects/.git/config"
+  printf 'stale-from-an-earlier-seed\n' >"$HOME/.dotfiles/projects/.git/config"
+
+  run bash "$SEED_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$HOME/.dotfiles/projects/.git" ]
+  [ -f "$HOME/.dotfiles/projects/myrepo/CLAUDE.md" ]
+}
+
 @test "config removed from the host is pruned from the persisted volume" {
   # The destination lives in the persisted claude-local-home named volume, so a
   # source the host DELETED must be cleared on the next gated reseed. Pruning


### PR DESCRIPTION
Since #41, `~/.dotfiles/projects` is a nested **private** repository rather than a directory of this one. The devcontainer seed mirrors the host tree with a plain filesystem copy (`rsync -ac --delete`, or wipe + `cp -a` where rsync is absent), which has no git awareness — so the overlay files arrive correctly, but so did `projects/.git`.

That directory carries the overlay repo's full history and a remote URL naming it, and it lands in a named volume that outlives the container and ships with any image built from it. Before the split there was no private repo to expose, so this is new exposure introduced by #41 rather than a pre-existing bug.

## What changed

- `--exclude='/projects/.git'` on the rsync. Anchored with a leading `/` so it means the mirror root and not some other `projects/.git` deeper in the tree; no trailing `/` so it matches whether `.git` is a directory or a gitfile.
- An unconditional `rm -rf "$DOTFILES_HOME/projects/.git"` after the branch. This is not redundant with the exclude — it does two things the exclude cannot:
  - `cp -a` has no exclusion mechanism, so the fallback path needs it.
  - **rsync protects an excluded path on the receiver from `--delete`.** A volume seeded by a template predating this change would otherwise keep its copy indefinitely, and the named volume survives `--remove-existing-container`.

Nothing is lost by dropping it: the container tree is a copy whose writes never reach the host, so committing overlay edits there was never a way to save them.

## No `SEED_VERSION` bump

The contract at `templates/local-seed.sh:15` scopes bumps to the *gated* steps (the expensive copies and installers). This lives in the always-run block above the sentinel, so it takes effect on the next launch. Bumping would force every container to re-run the installers for nothing.

## Tests

Two cases in `tests/project_claude_setup_seed.bats`, both confirmed failing before the fix:

- overlay files mirror but `.git` does not;
- a `.git` left by an earlier seed is pruned. This one is the reason the unconditional `rm -rf` exists — the first draft of it passed *before* the fix, because with no `.git` on the host side `--delete` removed it anyway. It now keeps the host `.git` present, as in production, which is the case that distinguishes exclude-only from exclude-plus-prune.

Full suite 332/332, `make check` PASSED, no new shellcheck findings (the template is not in the enforced lint set and its whole-file `shfmt` disagreement predates this change — hunk count is 20 before and after).

## Reviewer focus

The rsync `--delete` / `--exclude` interaction is the load-bearing subtlety; if that reading is wrong, the second test is the one that would catch it.

## Follow-up, not in this PR

The mirror block is **not** in the anchor table in `catch-up-local-seed.md`, so `bin/seed-drift` (in progress on another branch) will not detect this block going stale. Adding a tenth anchor row would fix that, but it would add `BEHIND` lines to that branch's acceptance expectation, so it is left as a deliberate decision rather than folded in here.

Existing seeds in project working trees keep the old block until regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented nested project repository metadata from appearing in synchronized dotfiles.
  * Removed stale repository metadata during synchronization or reset operations.
  * Preserved project overlay files while cleaning up repository metadata.
  * Ensured synchronization failures remain accurately reported even when cleanup is performed.

* **Tests**
  * Added coverage for metadata exclusion, stale repository cleanup, overlay file preservation, and failed synchronization handling.
  * Updated dependency-pin validation to use the configured Prezto reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->