### PR TITLE
Add bin/seed-drift: block-granular drift detection for devcontainer local seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ bin/seed-drift ~/workspace/myproject # named candidates only
 ```
 
 It is strictly read-only with respect to the seeds it inspects. Exit codes:
-`0` clean, `1` drift found, `2` usage / template / doc / extraction error.
+`0` clean, `1` drift found, `2` usage / template / doc / extraction error, or no
+projects discovered.
 
 `AHEAD` is a **promotion candidate**, not an error — the seed has something the
 template does not, and the seed is the hand-owned file, so the fix direction is

--- a/README.md
+++ b/README.md
@@ -238,6 +238,28 @@ The personal plugin is the single source of truth for commands and skills. See
   and the deliberately-invoked `blindspot-pass`, `implementation-plan`,
   `change-explainer`.
 
+### Devcontainer seed drift
+
+`bin/seed-drift` reports, per project and per documented block, whether a
+project's `.devcontainer/local-seed.sh` has fallen behind the
+`project-claude-setup` template, run ahead of it, or diverged from it.
+
+```bash
+bin/seed-drift                       # every project under ~/workspace
+bin/seed-drift ~/workspace/myproject # named candidates only
+```
+
+It is strictly read-only with respect to the seeds it inspects. Exit codes:
+`0` clean, `1` drift found, `2` usage / template / doc / extraction error.
+
+`AHEAD` is a **promotion candidate**, not an error — the seed has something the
+template does not, and the seed is the hand-owned file, so the fix direction is
+to port it up rather than overwrite it.
+
+The blocks it compares come from the Step 1 table in
+`ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md`;
+that table is the tool's input, so adding a row there extends the detector.
+
 ### Global working agreement
 
 `ai/claude/CLAUDE.md` and `ai/codex/AGENTS.md` hold always-loaded default guidance

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -73,9 +73,9 @@ one below the gate means a container that is already stamped will never run it.
 
 > **This table is executable input, not just prose.** `bin/seed-drift` parses it
 > to decide which blocks to compare, so editing it changes what the detector
-> checks for **every** project. A row must be a four-cell Markdown table row —
-> `| Block name | ` + backticked anchor + ` | why |` — with the anchor wrapped in
-> backticks; a row whose anchor is not backticked is silently skipped, and a row
+> checks for **every** project. A row must be a four-cell Markdown table row of
+> the shape ``| Block name | `anchor` | why |`` — a row whose anchor is not
+> wrapped in backticks is silently skipped, and a row
 > whose anchor does not appear in the template's **code** (a match inside a
 > comment does not count, and neither does a typo) aborts the whole run with
 > exit 2 for every project, not just a per-block error. Adding a row is how you

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -71,6 +71,16 @@ Each entry gives the grep anchor to find it in the template. All of these live
 in the **always-run block, above the sentinel gate** — keep them there. Moving
 one below the gate means a container that is already stamped will never run it.
 
+> **This table is executable input, not just prose.** `bin/seed-drift` parses it
+> to decide which blocks to compare, so editing it changes what the detector
+> checks for **every** project. A row must be a four-cell Markdown table row —
+> `| Block name | ` + backticked anchor + ` | why |` — with the anchor wrapped in
+> backticks; a row whose anchor is not backticked is silently skipped, and a row
+> whose anchor does not appear in the template's **code** (a match inside a
+> comment does not count, and neither does a typo) aborts the whole run with
+> exit 2 for every project, not just a per-block error. Adding a row is how you
+> extend the detector; check `bin/seed-drift` still exits 0 or 1 afterwards.
+
 | Block | Anchor in template | Why it matters |
 |---|---|---|
 | Stable link root | `ensure_stable_link_root` | Publishes `/opt/dotfiles`. Without it every personal overlay symlink dangles in the container — `.claude/skills`, `agents`, `references`, **and `CLAUDE.md`**, so the project instructions never load either. |

--- a/bin/list-check-files
+++ b/bin/list-check-files
@@ -60,7 +60,7 @@ is_repository_zsh() {
       if is_direct_bin_shell "$path" || is_repository_sh "$path"; then printf '%s\0' "$path"; fi
       ;;
     shfmt)
-      if is_direct_bin_shell "$path" || is_repository_sh "$path" || [[ "$path" == tests/test_helper.bash ]]; then printf '%s\0' "$path"; fi
+      if is_direct_bin_shell "$path" || is_repository_sh "$path" || [[ "$path" == tests/test_helper.bash ]] || [[ "$path" == tests/*.bats ]]; then printf '%s\0' "$path"; fi
       ;;
   esac
 done

--- a/bin/list-check-files
+++ b/bin/list-check-files
@@ -60,6 +60,10 @@ is_repository_zsh() {
       if is_direct_bin_shell "$path" || is_repository_sh "$path"; then printf '%s\0' "$path"; fi
       ;;
     shfmt)
+      # tests/*.bats is shfmt-only: `bash -n` and shellcheck cannot parse the
+      # `@test "name" { ... }` form, but shfmt has understood it since v3.2.0
+      # (mvdan/sh, 2020-10-29). An shfmt older than that fails loudly on these
+      # paths rather than skipping them.
       if is_direct_bin_shell "$path" || is_repository_sh "$path" || [[ "$path" == tests/test_helper.bash ]] || [[ "$path" == tests/*.bats ]]; then printf '%s\0' "$path"; fi
       ;;
   esac

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -420,6 +420,13 @@ SD_TMPDIR=""
 # `rm -rf`s the directory before the caller can write a single byte. The
 # directory and its trap have to be established in the shell that will
 # actually use them, so the path comes back through `printf -v`, not stdout.
+#
+# The EXIT trap REPLACES any the caller already had. That is an accepted side
+# effect of sourcing, not an oversight: chaining would mean parsing `trap -p`
+# output and re-evaluating the recovered handler string, which is a quoting and
+# injection hazard well out of proportion to the exposure. Sourcing this script
+# already sets `e`, `u`, and pipefail in the caller unconditionally, so a caller
+# that sources it is already accepting that its shell state is not preserved.
 sd_tmp() {
   local __sd_new
   if [ -z "$SD_TMPDIR" ]; then
@@ -569,7 +576,21 @@ sd_check_seed() {
   fi
   sd_tmp tnorm || return 2
   sd_tmp snorm || return 2
+  # Allocated once per seed, not once per block: the diff output is consumed
+  # before the next iteration overwrites it, so nine blocks do not need
+  # eighteen files. Same reuse as tnorm/snorm/sscan above.
+  sd_tmp behind || return 2
+  sd_tmp ahead || return 2
+  # sd_main already fails closed when the doc yields no rows, so this counter
+  # guards a case that cannot happen today. It is here because the loop reads
+  # through a process substitution, whose failure is invisible to both `set -e`
+  # and pipefail: were the doc to become unreadable between sd_main's parse and
+  # this one, the body would never run, rc would stay 0, and the seed would be
+  # reported clean having compared nothing. Same invariant, same reasoning as
+  # the empty-template guard below.
+  local rows=0
   while IFS=$'\t' read -r block anchor; do
+    rows=$((rows + 1))
     # Branch on the ORIGINAL status. sd_extract returns 4 for "anchor absent"
     # and 3 for "the block would not parse"; `if ! sd_extract` flattens both
     # into one branch, so a seed whose block is unextractable would be
@@ -619,8 +640,6 @@ sd_check_seed() {
     esac
     # Same file-not-substitution rule as sd_verdict: a removed blank line must
     # survive into the count and the samples.
-    sd_tmp behind || return 2
-    sd_tmp ahead || return 2
     if ! sd_diff_lines "$tnorm" "$snorm" '<' >"$behind" ||
       ! sd_diff_lines "$tnorm" "$snorm" '>' >"$ahead"; then
       sd_report_block ERROR "$block" 'diff failed'
@@ -676,6 +695,11 @@ sd_check_seed() {
       sd_report_thin seed "$esize"
     fi
   done < <(sd_parse_doc "$SD_DOC")
+  if [ "$rows" -eq 0 ]; then
+    sd_report_block ERROR '(whole file)' 'no blocks read from the doc table'
+    sd_report_action 'check the Step 1 table in catch-up-local-seed.md'
+    return 2
+  fi
   return "$rc"
 }
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -600,7 +600,7 @@ sd_visit_dir() {
 }
 
 sd_visit_candidates() {
-  local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand rc=0
+  local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand rc=0 visited=0
   # The scalar, not `${#SD_CANDIDATES[@]}`: expanding an empty array under
   # `set -u` errors on bash 3.2, still the system bash on macOS
   # (bin/common.sh:392). The `"${SD_CANDIDATES[@]}"` below is reached only
@@ -612,7 +612,17 @@ sd_visit_candidates() {
       # A directory without .devcontainer/ is not a candidate: silent, not skipped.
       [ -d "$cand/.devcontainer" ] || continue
       sd_visit_dir "$cand"
+      visited=$((visited + 1))
     done
+    if [ "$visited" -eq 0 ]; then
+      # Scoped to discovery only: an explicitly-named absent project is
+      # still a skip at exit 0 (the brief states this outright). But
+      # discovery finding zero projects means the detector could not do its
+      # job at all — 0 checked here is a broken gate, not a clean bill of
+      # health, so this fails closed rather than reporting a quiet "clean".
+      printf 'seed-drift: no projects found under %s\n' "$root" >&2
+      return 2
+    fi
     return 0
   fi
   for cand in "${SD_CANDIDATES[@]}"; do
@@ -726,7 +736,13 @@ sd_main() {
   if [ "$absent" -ne 0 ]; then
     return 2
   fi
-  sd_visit_candidates
+  local vrc=0
+  # `|| vrc=$?`, not a bare call: sd_visit_candidates now returns 2 when
+  # discovery finds nothing, and an uncaptured non-zero status here would
+  # trip `set -e` and exit before sd_summary ever runs — silently dropping
+  # the summary line the "discovery finds nothing" report depends on.
+  sd_visit_candidates || vrc=$?
+  sd_worst "$vrc"
   sd_summary
   return "$SD_WORST"
 }

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -508,6 +508,13 @@ sd_verdict() {
 }
 
 SD_TEMPLATE="" SD_DOC="" SD_TEMPLATE_SCAN=""
+# Pre-declared for the same reason as SD_TEMPLATE_SCAN above: only sd_main
+# assigns these, but sd_visit_candidates reads the count, and a sourced caller
+# reaching that function without going through sd_main would abort on `unbound
+# variable` under `set -u`. The empty array is safe to declare on bash 3.2 —
+# only expanding it is not, and the count guard already covers that.
+SD_CANDIDATES=()
+SD_CANDIDATE_COUNT=0
 SD_CHECKED=0 SD_SKIPPED=0
 SD_BEHIND=0 SD_AHEAD=0 SD_DIVERGED=0 SD_MISSING=0
 SD_WORST=0

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -405,6 +405,38 @@ sd_count_lines() {
   printf '%s' "${n//[[:space:]]/}"
 }
 
+# Pure classifier: given the two difference counts, name the direction. Split
+# out from sd_verdict so a caller that already holds the counts can name the
+# verdict without re-running diff — and, more importantly, without the
+# `verdict=$(sd_verdict ...)` form, whose non-zero status aborts the whole
+# program under `set -e` and skips every project after it.
+sd_verdict_from_counts() {
+  # BEHIND_COUNT AHEAD_COUNT
+  if [ "$1" -eq 0 ] && [ "$2" -eq 0 ]; then
+    printf 'ok\n'
+  elif [ "$2" -eq 0 ]; then
+    printf 'BEHIND\n'
+  elif [ "$1" -eq 0 ]; then
+    printf 'AHEAD\n'
+  else
+    return 1
+  fi
+}
+
+sd_verdict() {
+  # Files, not nested command substitutions: substitution both loses blank
+  # differing lines and swallows a non-zero status from sd_diff_lines, so a
+  # broken diff would silently read as `ok`.
+  local bf af behind ahead
+  sd_tmp bf || return 3
+  sd_tmp af || return 3
+  sd_diff_lines "$1" "$2" '<' >"$bf" || return 3
+  sd_diff_lines "$1" "$2" '>' >"$af" || return 3
+  behind=$(sd_count_lines "$bf")
+  ahead=$(sd_count_lines "$af")
+  sd_verdict_from_counts "$behind" "$ahead"
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -419,7 +419,7 @@ sd_verdict_from_counts() {
   elif [ "$1" -eq 0 ]; then
     printf 'AHEAD\n'
   else
-    return 1
+    printf 'DIVERGED\n'
   fi
 }
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -54,6 +54,34 @@ sd_parse_doc() {
   awk "$SD_DOC_AWK" <"$doc"
 }
 
+SD_SCAN_AWK=$(
+  cat <<'SDAWK'
+function emit(tag, text) {
+  if (para == 0 || brk) {
+    para++
+    brk = 0
+  }
+  printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
+}
+{
+  if ($0 ~ /^[ \t]*$/) {
+    brk = 1
+    next
+  }
+  emit("C", $0)
+}
+SDAWK
+)
+
+sd_scan() {
+  local file="$1"
+  if [ ! -r "$file" ]; then
+    printf 'seed-drift: cannot read %s\n' "$file" >&2
+    return 3
+  fi
+  awk "$SD_SCAN_AWK" <"$file"
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -167,6 +167,13 @@ function scan(line,   n, i, c, j, d, w) {
   emit("C", scan($0))
   if (nq > 0) popq()
 }
+END {
+  if (failed) exit 3
+  if (hd) {
+    printf("seed-drift: unterminated heredoc %s\n", hdelim) >"/dev/stderr"
+    exit 3
+  }
+}
 SDAWK
 )
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -477,6 +477,15 @@ sd_verdict_from_counts() {
   fi
 }
 
+# TEST-ONLY. Nothing in the production path calls this: sd_check_seed runs the
+# same four steps inline, because capturing this function's output with
+# `verdict=$(sd_verdict ...)` would swallow a diff failure's non-zero status
+# and, under `set -e`, abort the whole run outside the public 0/1/2 contract
+# (see the comment above that call site). Do NOT "remove the duplication" by
+# wiring this in — the duplication is the fix, not the defect. It survives
+# because the tests exercise the composition of sd_diff_lines, sd_count_lines,
+# and sd_verdict_from_counts in one place; keep it in sync with sd_check_seed
+# if either changes.
 sd_verdict() {
   # Files, not nested command substitutions: substitution both loses blank
   # differing lines and swallows a non-zero status from sd_diff_lines, so a

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -556,7 +556,7 @@ sd_report_thin() {
 
 sd_check_seed() {
   local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
-  local behind ahead nb na est tst tsize esize
+  local behind ahead nb na est tst tsize esize docrows
   name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
   printf '%s  %s\n' "$name" "$seed"
   if ! bash -n "$seed" 2>/dev/null; then
@@ -581,13 +581,25 @@ sd_check_seed() {
   # eighteen files. Same reuse as tnorm/snorm/sscan above.
   sd_tmp behind || return 2
   sd_tmp ahead || return 2
-  # sd_main already fails closed when the doc yields no rows, so this counter
-  # guards a case that cannot happen today. It is here because the loop reads
-  # through a process substitution, whose failure is invisible to both `set -e`
-  # and pipefail: were the doc to become unreadable between sd_main's parse and
-  # this one, the body would never run, rc would stay 0, and the seed would be
-  # reported clean having compared nothing. Same invariant, same reasoning as
-  # the empty-template guard below.
+  # Parsed to a file, not piped into the loop through `< <(sd_parse_doc …)`: a
+  # process substitution discards its command's exit status, which is invisible
+  # to both `set -e` and pipefail. Were the doc to become unreadable — or awk to
+  # die partway through it — between sd_main's parse and this one, the loop would
+  # run over however many rows had already been emitted and report the seed on a
+  # truncated block list, or report it clean having compared nothing. Capturing
+  # the status separately from the rows is what sd_main already does with
+  # `if ! blocks=$(sd_parse_doc "$doc")`; this is the same check on the same
+  # input, at the point where the rows are actually consumed.
+  sd_tmp docrows || return 2
+  if ! sd_parse_doc "$SD_DOC" >"$docrows"; then
+    sd_report_block ERROR '(whole file)' 'the doc table could not be parsed'
+    sd_report_action 'check the Step 1 table in catch-up-local-seed.md'
+    return 2
+  fi
+  # A successful parse emitting nothing is a separate case: sd_parse_doc's awk
+  # already exits non-zero on zero rows, so this counter guards a shape that
+  # cannot arise today. It stays because "compared nothing" must never read as
+  # "clean" — same invariant, same reasoning as the empty-template guard below.
   local rows=0
   while IFS=$'\t' read -r block anchor; do
     rows=$((rows + 1))
@@ -694,7 +706,7 @@ sd_check_seed() {
     if [ "$esize" -lt "$SD_THIN_WINDOW" ]; then
       sd_report_thin seed "$esize"
     fi
-  done < <(sd_parse_doc "$SD_DOC")
+  done <"$docrows"
   if [ "$rows" -eq 0 ]; then
     sd_report_block ERROR '(whole file)' 'no blocks read from the doc table'
     sd_report_action 'check the Step 1 table in catch-up-local-seed.md'

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -232,44 +232,6 @@ sd_window() {
   printf '%s %s\n' "$start" "$end"
 }
 
-# The non-root ownership-verification idiom, matched fully literally at the
-# comparison stage (see sd_apply_ownership_rule), never during per-file
-# normalization: template lines 491-492 (chown -R, "$NVIM_DIST.new") and
-# 594-595 (plain chown, "$TS_BIN.new"). Two physical lines each, because the
-# first ends in `||` and the second in `; } &&`. Nothing in the match is free —
-# a changed flag, target or identity is drift, not vocabulary.
-SD_OWNERSHIP_DROP=(
-  '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
-  '[ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
-  '{ chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||'
-  '[ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
-)
-
-# Fix round 1 (Task 7 review): each idiom instance is TWO physical lines, and
-# only the first (the chown half) contains `chown`/`chgrp` — the second (the
-# find half) is the actual verification and contains neither. A guard that
-# only looked for `chown|chgrp` in AHEAD_FILE was blind to a seed that leaves
-# the chown half untouched and edits only the find half (e.g. the identity in
-# `! -uid`): that half cancels out of the diff, AHEAD_FILE holds only the
-# modified, chown-free find line, the guard fired anyway, and the block
-# reported AHEAD ("promotion candidate") for a seed whose ownership check no
-# longer verifies what it claims to — exactly the class of bug the Task 7
-# relocation was meant to eliminate, surviving in the half nobody looked at.
-# `! -uid`/`! -gid` are the tokens that survive every modification that
-# matters (changed target, flag, or identity), which is why they work as a
-# guard for the find half. One variable, used by both this guard and the
-# meta-test below that pins it to SD_OWNERSHIP_DROP, so the two cannot drift
-# apart silently if another idiom line is ever added to the array.
-#
-# Widening the guard trades toward more false DIVERGED (a root-flavored seed
-# that omits the idiom entirely, but happens to carry an unrelated seed-only
-# chown/find line, now reports DIVERGED instead of a clean drop) rather than
-# false AHEAD. That is the correct side to err on: a false DIVERGED says
-# "inspect by hand" and costs a human two minutes; a false AHEAD says
-# "promotion candidate" and invites promoting a broken ownership check into
-# the template, which is silent damage.
-SD_OWNERSHIP_GUARD_PATTERN='chown|chgrp|! -uid|! -gid'
-
 sd_neutralize_paths() {
   sed -e 's/\${SEED_HOME}/«HOME»/g' -e 's/\$SEED_HOME/«HOME»/g' \
     -e 's/\${DOTFILES_HOME}/«HOME»\/.dotfiles/g' \
@@ -429,35 +391,6 @@ sd_count_lines() {
   printf '%s' "${n//[[:space:]]/}"
 }
 
-# The ownership rule is inherently cross-file — "does the OTHER side still
-# show an ownership difference of its own?" — so it cannot be decided while
-# normalizing one file in isolation; that was the Task 6 design's mistake.
-# Applied here, at the comparison stage, after diffing: BEHIND_FILE and
-# AHEAD_FILE already hold the template-only and seed-only lines. If AHEAD_FILE
-# matches none of SD_OWNERSHIP_GUARD_PATTERN, the seed is silent about
-# ownership on both idiom halves (typically the non-root idiom omitted
-# wholesale under a root-flavored seed), so the exact idiom lines are dropped
-# from BEHIND_FILE and the block reads clean. If AHEAD_FILE matches the
-# pattern, the seed changed something on either half — chown target, `-R`,
-# identity on either half, or an unrelated chown entirely — and nothing is
-# dropped, so the mismatch surfaces as DIVERGED. Called identically from
-# sd_verdict and sd_check_seed so both compute the same verdict from the same
-# counts; if they disagreed, a caller using sd_verdict directly (as the tests
-# do) could see a different answer than a full run.
-sd_apply_ownership_rule() {
-  local behind="$1" ahead="$2" patterns filtered rc=0
-  grep -qE "$SD_OWNERSHIP_GUARD_PATTERN" "$ahead" && return 0
-  sd_tmp patterns || return 3
-  sd_tmp filtered || return 3
-  printf '%s\n' "${SD_OWNERSHIP_DROP[@]}" >"$patterns"
-  grep -Fvxf "$patterns" "$behind" >"$filtered" || rc=$?
-  if [ "$rc" -gt 1 ]; then
-    printf 'seed-drift: ownership filter failed on %s\n' "$behind" >&2
-    return 3
-  fi
-  cp -- "$filtered" "$behind"
-}
-
 # Pure classifier: given the two difference counts, name the direction. Split
 # out from sd_verdict so a caller that already holds the counts can name the
 # verdict without re-running diff — and, more importantly, without the
@@ -485,7 +418,6 @@ sd_verdict() {
   sd_tmp af || return 3
   sd_diff_lines "$1" "$2" '<' >"$bf" || return 3
   sd_diff_lines "$1" "$2" '>' >"$af" || return 3
-  sd_apply_ownership_rule "$bf" "$af" || return 3
   behind=$(sd_count_lines "$bf")
   ahead=$(sd_count_lines "$af")
   sd_verdict_from_counts "$behind" "$ahead"
@@ -589,11 +521,6 @@ sd_check_seed() {
     if ! sd_diff_lines "$tnorm" "$snorm" '<' >"$behind" ||
       ! sd_diff_lines "$tnorm" "$snorm" '>' >"$ahead"; then
       sd_report_block ERROR "$block" 'diff failed'
-      rc=2
-      continue
-    fi
-    if ! sd_apply_ownership_rule "$behind" "$ahead"; then
-      sd_report_block ERROR "$block" 'ownership filter failed'
       rc=2
       continue
     fi

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -56,6 +56,11 @@ sd_parse_doc() {
 
 SD_SCAN_AWK=$(
   cat <<'SDAWK'
+function fail(msg) {
+  printf("seed-drift: %s (line %d)\n", msg, NR) >"/dev/stderr"
+  failed = 1
+  exit 3
+}
 function emit(tag, text) {
   if (para == 0 || brk) {
     para++
@@ -63,7 +68,18 @@ function emit(tag, text) {
   }
   printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
 }
-function scan(line,   n, i, c) {
+function delimword(line, i, n,   w, c) {
+  w = ""
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (c !~ /[A-Za-z0-9_.-]/) break
+    w = w c
+    i++
+  }
+  wend = i
+  return w
+}
+function scan(line,   n, i, c, j, w) {
   n = length(line)
   i = 1
   while (i <= n) {
@@ -83,16 +99,45 @@ function scan(line,   n, i, c) {
     if (c == "'") { inq = "'"; i++; continue }
     if (c == "\"") { inq = "\""; i++; continue }
     if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t]/)) return substr(line, 1, i - 1)
-    i++
+    if (c != "<") { i++; continue }
+    if (substr(line, i, 2) != "<<") { i++; continue }
+    i += 2
+    c = substr(line, i, 1)
+    if (c == "'" || c == "\"") {
+      j = index(substr(line, i + 1), c)
+      if (j == 0) fail("unterminated heredoc delimiter quote")
+      hdelim = substr(line, i + 1, j - 1)
+      hquot = 1
+      opened = 1
+      i = i + j + 1
+      continue
+    }
+    w = delimword(line, i, n)
+    if (w == "") fail("unrecognized heredoc delimiter after <<")
+    hdelim = w
+    hquot = 0
+    opened = 1
+    i = wend
   }
   return line
 }
 {
+  if (hd) {
+    if ($0 == hdelim) {
+      emit("C", $0)
+      hd = 0
+    } else {
+      emit(hquot ? "Hq" : "Hu", $0)
+    }
+    next
+  }
   if ($0 ~ /^[ \t]*$/ && inq == "") {
     brk = 1
     next
   }
+  opened = 0
   emit("C", scan($0))
+  if (opened) hd = 1
 }
 SDAWK
 )

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -245,6 +245,31 @@ SD_OWNERSHIP_DROP=(
   '[ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
 )
 
+# Fix round 1 (Task 7 review): each idiom instance is TWO physical lines, and
+# only the first (the chown half) contains `chown`/`chgrp` — the second (the
+# find half) is the actual verification and contains neither. A guard that
+# only looked for `chown|chgrp` in AHEAD_FILE was blind to a seed that leaves
+# the chown half untouched and edits only the find half (e.g. the identity in
+# `! -uid`): that half cancels out of the diff, AHEAD_FILE holds only the
+# modified, chown-free find line, the guard fired anyway, and the block
+# reported AHEAD ("promotion candidate") for a seed whose ownership check no
+# longer verifies what it claims to — exactly the class of bug the Task 7
+# relocation was meant to eliminate, surviving in the half nobody looked at.
+# `! -uid`/`! -gid` are the tokens that survive every modification that
+# matters (changed target, flag, or identity), which is why they work as a
+# guard for the find half. One variable, used by both this guard and the
+# meta-test below that pins it to SD_OWNERSHIP_DROP, so the two cannot drift
+# apart silently if another idiom line is ever added to the array.
+#
+# Widening the guard trades toward more false DIVERGED (a root-flavored seed
+# that omits the idiom entirely, but happens to carry an unrelated seed-only
+# chown/find line, now reports DIVERGED instead of a clean drop) rather than
+# false AHEAD. That is the correct side to err on: a false DIVERGED says
+# "inspect by hand" and costs a human two minutes; a false AHEAD says
+# "promotion candidate" and invites promoting a broken ownership check into
+# the template, which is silent damage.
+SD_OWNERSHIP_GUARD_PATTERN='chown|chgrp|! -uid|! -gid'
+
 sd_neutralize_paths() {
   sed -e 's/\${SEED_HOME}/«HOME»/g' -e 's/\$SEED_HOME/«HOME»/g' \
     -e 's/\${DOTFILES_HOME}/«HOME»\/.dotfiles/g' \
@@ -405,22 +430,23 @@ sd_count_lines() {
 }
 
 # The ownership rule is inherently cross-file — "does the OTHER side still
-# show a chown/chgrp difference of its own?" — so it cannot be decided while
+# show an ownership difference of its own?" — so it cannot be decided while
 # normalizing one file in isolation; that was the Task 6 design's mistake.
 # Applied here, at the comparison stage, after diffing: BEHIND_FILE and
 # AHEAD_FILE already hold the template-only and seed-only lines. If AHEAD_FILE
-# has no chown/chgrp line of its own, the seed is silent about ownership
-# (typically the non-root idiom omitted wholesale under a root-flavored seed),
-# so the exact idiom lines are dropped from BEHIND_FILE and the block reads
-# clean. If AHEAD_FILE does mention chown/chgrp, the seed changed something —
-# target, `-R`, identity, or an unrelated chown entirely — and nothing is
+# matches none of SD_OWNERSHIP_GUARD_PATTERN, the seed is silent about
+# ownership on both idiom halves (typically the non-root idiom omitted
+# wholesale under a root-flavored seed), so the exact idiom lines are dropped
+# from BEHIND_FILE and the block reads clean. If AHEAD_FILE matches the
+# pattern, the seed changed something on either half — chown target, `-R`,
+# identity on either half, or an unrelated chown entirely — and nothing is
 # dropped, so the mismatch surfaces as DIVERGED. Called identically from
 # sd_verdict and sd_check_seed so both compute the same verdict from the same
 # counts; if they disagreed, a caller using sd_verdict directly (as the tests
 # do) could see a different answer than a full run.
 sd_apply_ownership_rule() {
   local behind="$1" ahead="$2" patterns filtered rc=0
-  grep -qE 'chown|chgrp' "$ahead" && return 0
+  grep -qE "$SD_OWNERSHIP_GUARD_PATTERN" "$ahead" && return 0
   sd_tmp patterns || return 3
   sd_tmp filtered || return 3
   printf '%s\n' "${SD_OWNERSHIP_DROP[@]}" >"$patterns"

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -201,6 +201,37 @@ sd_para_range() {
   awk -F'\t' -v p="$2" '$1 == p { if (!s) s = $2; e = $2 } END { if (s) print s, e }' "$1"
 }
 
+# Grows the window until the extracted fragment parses: forward first, then
+# backward once the end of file is reached. The fragment is read straight from
+# FILE by line number, because the scan text is comment-stripped and would not
+# parse the same way.
+sd_window() {
+  local file="$1" scan="$2" para="$3"
+  local first last lo hi start end range
+
+  first=$(awk -F'\t' 'NR == 1 { print $1; exit }' "$scan")
+  last=$(awk -F'\t' 'END { print $1 }' "$scan")
+  range=$(sd_para_range "$scan" "$para")
+  [ -n "$range" ] || return 3
+
+  lo="$para" hi="$para"
+  start="${range% *}" end="${range#* }"
+  while ! sed -n "${start},${end}p" "$file" | bash -n 2>/dev/null; do
+    if [ "$hi" -lt "$last" ]; then
+      hi=$((hi + 1))
+      range=$(sd_para_range "$scan" "$hi")
+      end="${range#* }"
+    elif [ "$lo" -gt "$first" ]; then
+      lo=$((lo - 1))
+      range=$(sd_para_range "$scan" "$lo")
+      start="${range% *}"
+    else
+      return 3
+    fi
+  done
+  printf '%s %s\n' "$start" "$end"
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -437,7 +437,7 @@ sd_verdict() {
   sd_verdict_from_counts "$behind" "$ahead"
 }
 
-SD_TEMPLATE="" SD_DOC=""
+SD_TEMPLATE="" SD_DOC="" SD_TEMPLATE_SCAN=""
 SD_CHECKED=0 SD_SKIPPED=0
 SD_BEHIND=0 SD_AHEAD=0 SD_DIVERGED=0 SD_MISSING=0
 SD_WORST=0

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -336,6 +336,25 @@ sd_normalize() {
   [ "$joining" = 0 ] || sd_normalize_code_line "$pending"
 }
 
+sd_extract() {
+  local file="$1" scan="$2" anchor="$3" paras para window ranges=""
+
+  paras=$(sd_paras_with_anchor "$scan" "$anchor")
+  [ -n "$paras" ] || return 4
+
+  for para in $paras; do
+    window=$(sd_window "$file" "$scan" "$para") || return 3
+    ranges+="$window"$'\n'
+  done
+
+  # Union the windows by source line number: `sort -n -u` puts them in file
+  # order and collapses lines two overlapping windows both claim.
+  printf '%s' "$ranges" |
+    awk '{ for (i = $1; i <= $2; i++) print i }' | sort -n -u |
+    awk -F'\t' 'NR == FNR { keep[$1] = 1; next } keep[$2]' - "$scan" |
+    sd_normalize
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -437,6 +437,101 @@ sd_verdict() {
   sd_verdict_from_counts "$behind" "$ahead"
 }
 
+SD_TEMPLATE="" SD_DOC=""
+SD_CHECKED=0 SD_SKIPPED=0
+SD_BEHIND=0 SD_AHEAD=0 SD_DIVERGED=0 SD_MISSING=0
+SD_WORST=0
+
+sd_worst() {
+  [ "$1" -gt "$SD_WORST" ] && SD_WORST="$1"
+  return 0
+}
+
+sd_report_block() {
+  if [ -n "$3" ]; then
+    printf '  %-8s %-20s %s\n' "$1" "$2" "$3"
+  else
+    printf '  %-8s %s\n' "$1" "$2"
+  fi
+}
+
+sd_report_samples() {
+  local shown=0 line
+  while IFS= read -r line; do
+    [ "$shown" -lt 2 ] || break
+    [ "${#line}" -le 56 ] || line="${line:0:53}..."
+    printf '             - %s\n' "$line"
+    shown=$((shown + 1))
+  done
+}
+
+sd_report_action() {
+  printf '             -> %s\n' "$1"
+}
+
+sd_check_seed() {
+  local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
+  name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
+  printf '%s  %s\n' "$name" "$seed"
+  # Each file is scanned exactly once. The template scan is built by sd_main
+  # and reused across every seed; the seed scan is built here, once, and
+  # reused across every block. sd_extract needs a scan path — passing "" would
+  # make awk fail to open its input on every call. `sd_tmp NAME`, never
+  # `$(sd_tmp)`: the subshell form deletes the temp dir on subshell exit.
+  sd_tmp sscan || return 2
+  if ! sd_scan "$seed" >"$sscan"; then
+    sd_report_block ERROR '(whole file)' 'seed could not be scanned'
+    sd_report_action 'check the seed parses; see catch-up-local-seed.md Step 3'
+    return 2
+  fi
+  sd_tmp tnorm || return 2
+  sd_tmp snorm || return 2
+  while IFS=$'\t' read -r block anchor; do
+    sd_extract "$SD_TEMPLATE" "$SD_TEMPLATE_SCAN" "$anchor" >"$tnorm" || continue
+    sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || continue
+    verdict=$(sd_verdict "$tnorm" "$snorm") || continue
+    case "$verdict" in
+      ok) sd_report_block ok "$block" '' ;;
+    esac
+  done < <(sd_parse_doc "$SD_DOC")
+  return "$rc"
+}
+
+sd_summary() {
+  local drifted=$((SD_BEHIND + SD_AHEAD + SD_DIVERGED + SD_MISSING)) parts="" pair
+  for pair in "behind:$SD_BEHIND" "ahead:$SD_AHEAD" \
+    "diverged:$SD_DIVERGED" "missing:$SD_MISSING"; do
+    [ "${pair#*:}" -gt 0 ] || continue
+    parts="${parts:+$parts, }${pair#*:} ${pair%%:*}"
+  done
+  printf '\n%d checked, %d skipped, %d blocks drifted%s\n' \
+    "$SD_CHECKED" "$SD_SKIPPED" "$drifted" "${parts:+ ($parts)}"
+}
+
+sd_visit_dir() {
+  local dir="$1" seed="$1/.devcontainer/local-seed.sh" rc=0
+  if [ ! -f "$seed" ]; then
+    printf '%s  .devcontainer/ present, no local-seed.sh - skipped\n' \
+      "$(basename -- "$dir")"
+    SD_SKIPPED=$((SD_SKIPPED + 1))
+    return 0
+  fi
+  SD_CHECKED=$((SD_CHECKED + 1))
+  sd_check_seed "$seed" || rc=$?
+  sd_worst "$rc"
+}
+
+sd_visit_candidates() {
+  local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand
+  shopt -s nullglob
+  for cand in "$root"/*/; do
+    cand="${cand%/}"
+    # A directory without .devcontainer/ is not a candidate: silent, not skipped.
+    [ -d "$cand/.devcontainer" ] || continue
+    sd_visit_dir "$cand"
+  done
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()
@@ -487,18 +582,28 @@ sd_main() {
     return 2
   fi
 
-  local blocks
+  local blocks name anchor absent=0
+  SD_TEMPLATE="$template"
+  SD_DOC="$doc"
+  SD_TEMPLATE_SCAN=""
+  if ! sd_tmp SD_TEMPLATE_SCAN; then
+    printf 'seed-drift: cannot create a temporary file\n' >&2
+    return 2
+  fi
+  if ! sd_scan "$template" >"$SD_TEMPLATE_SCAN"; then
+    printf 'seed-drift: cannot scan template %s\n' "$template" >&2
+    return 2
+  fi
   if ! blocks=$(sd_parse_doc "$doc"); then
     printf 'seed-drift: no block table found in %s\n' "$doc" >&2
     return 2
   fi
-
-  local name anchor absent=0
   while IFS=$'\t' read -r name anchor; do
-    # Raw grep is deliberately the Task 1 form; Task 6 replaces it with a check
-    # against the template scan's C records once the scanner exists, so that an
-    # anchor appearing only in a comment fails validation.
-    if ! grep -qF -- "$anchor" "$template"; then
+    # Against the scan, not `grep -qF "$anchor" "$template"`. Anchors name
+    # code, and the scan's C records are comment-stripped — so an anchor that
+    # survives only inside a comment now fails validation instead of passing
+    # and then extracting nothing.
+    if [ -z "$(sd_paras_with_anchor "$SD_TEMPLATE_SCAN" "$anchor")" ]; then
       printf 'seed-drift: anchor %s (block: %s) is absent from %s\n' \
         "$anchor" "$name" "$template" >&2
       absent=1
@@ -507,8 +612,9 @@ sd_main() {
   if [ "$absent" -ne 0 ]; then
     return 2
   fi
-
-  return 0
+  sd_visit_candidates
+  sd_summary
+  return "$SD_WORST"
 }
 
 if [ "${SEED_DRIFT_SOURCE_ONLY:-0}" != 1 ]; then

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -497,8 +497,15 @@ SD_BEHIND=0 SD_AHEAD=0 SD_DIVERGED=0 SD_MISSING=0
 SD_WORST=0
 
 sd_worst() {
-  [ "$1" -gt "$SD_WORST" ] && SD_WORST="$1"
-  return 0
+  # `if`, not `[ … ] && …`: the bare-`&&` form leaves the function's status at
+  # 1 on every not-worse call, so it is correct only while a `return 0` stays
+  # the immediately-following statement. All three call sites invoke this as a
+  # bare statement under `set -e`, so a later insert between the two lines
+  # would abort the run on every clean project. An `if` with no else exits 0
+  # whether or not the branch is taken, which removes the dependency.
+  if [ "$1" -gt "$SD_WORST" ]; then
+    SD_WORST="$1"
+  fi
 }
 
 sd_report_block() {

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SD_SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SD_REPO_ROOT="${SD_SELF_DIR%/bin}"
+SD_SKILL_DIR="$SD_REPO_ROOT/ai/marketplace/plugins/my/skills/project-claude-setup"
+SD_TEMPLATE_DEFAULT="$SD_SKILL_DIR/templates/local-seed.sh"
+SD_DOC_DEFAULT="$SD_SKILL_DIR/catch-up-local-seed.md"
+
+sd_usage() {
+  cat <<'SDUSAGE'
+Usage: bin/seed-drift [--template PATH] [--doc PATH] [--help] [CANDIDATE...]
+
+Reports, per project and per documented block, whether a project's
+.devcontainer/local-seed.sh is behind, ahead of, or diverged from the
+project-claude-setup template.
+
+  --template PATH  template to compare against
+  --doc PATH       catch-up doc holding the block table
+  --help           show this message
+
+With no CANDIDATE, candidates are ${SEED_DRIFT_ROOT:-$HOME/workspace}/*/.
+Exit: 0 clean, 1 drift, 2 usage/template/doc/extraction error.
+SDUSAGE
+}
+
+sd_main() {
+  local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
+  SD_CANDIDATES=()
+  # Counted alongside the array because Task 6 must ask "were any candidates
+  # given?" without expanding an empty array under `set -u` — the bash 3.2
+  # pitfall bin/common.sh:392 calls out. macOS ships bash 3.2.
+  SD_CANDIDATE_COUNT=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --template | --doc)
+        if [ $# -lt 2 ]; then
+          printf 'seed-drift: %s needs a PATH\n' "$1" >&2
+          sd_usage >&2
+          return 2
+        fi
+        if [ "$1" = --template ]; then template="$2"; else doc="$2"; fi
+        shift 2
+        ;;
+      --help | -h)
+        sd_usage
+        return 0
+        ;;
+      --)
+        shift
+        SD_CANDIDATES+=("$@")
+        SD_CANDIDATE_COUNT=$((SD_CANDIDATE_COUNT + $#))
+        break
+        ;;
+      -*)
+        printf 'seed-drift: unknown option %s\n' "$1" >&2
+        sd_usage >&2
+        return 2
+        ;;
+      *)
+        SD_CANDIDATES+=("$1")
+        SD_CANDIDATE_COUNT=$((SD_CANDIDATE_COUNT + 1))
+        shift
+        ;;
+    esac
+  done
+
+  if [ ! -r "$template" ]; then
+    printf 'seed-drift: cannot read template %s\n' "$template" >&2
+    return 2
+  fi
+  if [ ! -r "$doc" ]; then
+    printf 'seed-drift: cannot read doc %s\n' "$doc" >&2
+    return 2
+  fi
+
+  return 0
+}
+
+if [ "${SEED_DRIFT_SOURCE_ONLY:-0}" != 1 ]; then
+  sd_main "$@"
+fi

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -232,6 +232,18 @@ sd_window() {
   printf '%s %s\n' "$start" "$end"
 }
 
+# The non-root ownership-verification idiom, matched fully literally after
+# normalization: template lines 491-492 (chown -R, "$NVIM_DIST.new") and
+# 594-595 (plain chown, "$TS_BIN.new"). Two physical lines each, because the
+# first ends in `||` and the second in `; } &&`. Nothing in the match is free —
+# a changed flag, target or identity is drift, not vocabulary.
+SD_OWNERSHIP_DROP=(
+  '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
+  '[ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+  '{ chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||'
+  '[ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+)
+
 sd_neutralize_paths() {
   sed -e 's/\${SEED_HOME}/«HOME»/g' -e 's/\$SEED_HOME/«HOME»/g' \
     -e 's/\${DOTFILES_HOME}/«HOME»\/.dotfiles/g' \
@@ -269,7 +281,7 @@ sd_drop_priv_prefix() {
 }
 
 sd_normalize_code_line() {
-  local line="$1"
+  local line="$1" drop
   line="${line//$'\t'/ }"
   while [ "$line" != "${line//  / }" ]; do line="${line//  / }"; done
   line="${line#"${line%%[![:space:]]*}"}"
@@ -277,6 +289,9 @@ sd_normalize_code_line() {
   [ -n "$line" ] || return 0
   line=$(sd_drop_priv_prefix "$line")
   [ -n "$line" ] || return 0
+  for drop in "${SD_OWNERSHIP_DROP[@]}"; do
+    [ "$line" = "$drop" ] && return 0
+  done
   printf '%s\n' "$line" | sd_neutralize_paths
 }
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -232,6 +232,81 @@ sd_window() {
   printf '%s %s\n' "$start" "$end"
 }
 
+sd_neutralize_paths() {
+  sed -e 's/\${SEED_HOME}/«HOME»/g' -e 's/\$SEED_HOME/«HOME»/g' \
+    -e 's/\${DOTFILES_HOME}/«HOME»\/.dotfiles/g' \
+    -e 's/\$DOTFILES_HOME/«HOME»\/.dotfiles/g' \
+    -e 's/\${WORKSPACE}/«WS»/g' -e 's/\$WORKSPACE/«WS»/g' \
+    -e 's/\${HOME}/«HOME»/g' -e 's/\$HOME/«HOME»/g'
+}
+
+sd_drop_priv_prefix() {
+  # Privilege words are dropped in COMMAND POSITION only: at line start, or
+  # right after an operator/keyword that begins a new command. `as_user` sits
+  # mid-line 8 times in the template (`if as_user test -x ...`,
+  # `... || as_user bash -lc ...`) and the live seeds split on it —
+  # wanderer-kills writes `if ! as_user test -f "$GITIGNORE"; then` where
+  # wanderer writes `if [ ! -f "$GITIGNORE" ]; then` — so a line-start-only
+  # rule would report every one of those shapes as drift.
+  #
+  # No `\b`: that boundary is a GNU extension and this script must also run
+  # under the BSD sed macOS ships. Operators are self-delimiting, so they need
+  # no boundary; the keywords take an explicit `(^|[[:space:]])` left boundary
+  # instead, which is why they are a separate expression. `sd_normalize_code_line`
+  # has already collapsed runs of whitespace to single spaces before we get here.
+  local line="$1" prev=""
+  while [ "$line" != "$prev" ]; do
+    prev="$line"
+    line=$(printf '%s\n' "$line" | sed -E \
+      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2/g' \
+      -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2\3/g' \
+      -e 's/^(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+//' \
+      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2/g' \
+      -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2\3/g' \
+      -e 's/^runuser -u [^[:space:]]+ --[[:space:]]+//')
+  done
+  printf '%s' "$line"
+}
+
+sd_normalize_code_line() {
+  local line="$1"
+  line="${line//$'\t'/ }"
+  while [ "$line" != "${line//  / }" ]; do line="${line//  / }"; done
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [ -n "$line" ] || return 0
+  line=$(sd_drop_priv_prefix "$line")
+  [ -n "$line" ] || return 0
+  printf '%s\n' "$line" | sd_neutralize_paths
+}
+
+sd_normalize() {
+  local rec tag text rest pending="" joining=0
+  # Positional split, not `IFS=$'\t' read`: that form strips leading tabs from
+  # `text`, which would corrupt every `<<-` heredoc body. `para` and `lineno`
+  # are skipped rather than bound — binding them trips SC2034 under
+  # `shellcheck -S warning`, which this repo gates on.
+  while IFS= read -r rec; do
+    rest="${rec#*$'\t'}"
+    rest="${rest#*$'\t'}"
+    tag="${rest%%$'\t'*}"
+    text="${rest#*$'\t'}"
+    if [ "$joining" = 1 ]; then
+      pending="$pending ${text#"${text%%[![:space:]]*}"}"
+    else
+      pending="$text"
+    fi
+    if [ "${pending%\\}" != "$pending" ]; then
+      pending="${pending%\\}"
+      joining=1
+      continue
+    fi
+    sd_normalize_code_line "$pending"
+    pending="" joining=0
+  done
+  [ "$joining" = 0 ] || sd_normalize_code_line "$pending"
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -291,18 +291,32 @@ sd_normalize() {
     rest="${rest#*$'\t'}"
     tag="${rest%%$'\t'*}"
     text="${rest#*$'\t'}"
-    if [ "$joining" = 1 ]; then
-      pending="$pending ${text#"${text%%[![:space:]]*}"}"
-    else
-      pending="$text"
-    fi
-    if [ "${pending%\\}" != "$pending" ]; then
-      pending="${pending%\\}"
-      joining=1
+    if [ "$tag" = C ]; then
+      if [ "$joining" = 1 ]; then
+        pending="$pending ${text#"${text%%[![:space:]]*}"}"
+      else
+        pending="$text"
+      fi
+      if [ "${pending%\\}" != "$pending" ]; then
+        pending="${pending%\\}"
+        joining=1
+        continue
+      fi
+      sd_normalize_code_line "$pending"
+      pending="" joining=0
       continue
     fi
-    sd_normalize_code_line "$pending"
-    pending="" joining=0
+    # A heredoc body ends any pending continuation: a payload line is data and
+    # must never be folded into the shell line above it.
+    if [ "$joining" = 1 ]; then
+      sd_normalize_code_line "$pending"
+      pending="" joining=0
+    fi
+    if [ "$tag" = Hu ]; then
+      printf '%s\n' "$text" | sd_neutralize_paths
+    else
+      printf '%s\n' "$text"
+    fi
   done
   [ "$joining" = 0 ] || sd_normalize_code_line "$pending"
 }

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -474,6 +474,10 @@ sd_check_seed() {
   local behind ahead nb na est tst
   name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
   printf '%s  %s\n' "$name" "$seed"
+  if ! bash -n "$seed" 2>/dev/null; then
+    sd_report_block ERROR "$name" 'does not parse (bash -n)'
+    return 2
+  fi
   # Each file is scanned exactly once. The template scan is built by sd_main
   # and reused across every seed; the seed scan is built here, once, and
   # reused across every block. sd_extract needs a scan path — passing "" would
@@ -677,6 +681,11 @@ sd_main() {
   fi
   if [ ! -r "$doc" ]; then
     printf 'seed-drift: cannot read doc %s\n' "$doc" >&2
+    return 2
+  fi
+
+  if ! bash -n "$template" 2>/dev/null; then
+    printf 'seed-drift: template does not parse: %s\n' "$template" >&2
     return 2
   fi
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -79,7 +79,7 @@ function delimword(line, i, n,   w, c) {
   wend = i
   return w
 }
-function scan(line,   n, i, c, j, w) {
+function scan(line,   n, i, c, j, d, w) {
   n = length(line)
   i = 1
   while (i <= n) {
@@ -100,22 +100,38 @@ function scan(line,   n, i, c, j, w) {
     if (c == "\"") { inq = "\""; i++; continue }
     if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t]/)) return substr(line, 1, i - 1)
     if (c != "<") { i++; continue }
+    if (substr(line, i, 3) == "<<<") { i += 3; continue }
     if (substr(line, i, 2) != "<<") { i++; continue }
     i += 2
+    d = 0
+    if (substr(line, i, 1) == "-") { d = 1; i++ }
+    while (substr(line, i, 1) == " " || substr(line, i, 1) == "\t") i++
     c = substr(line, i, 1)
     if (c == "'" || c == "\"") {
       j = index(substr(line, i + 1), c)
       if (j == 0) fail("unterminated heredoc delimiter quote")
       hdelim = substr(line, i + 1, j - 1)
       hquot = 1
+      hdash = d
       opened = 1
       i = i + j + 1
+      continue
+    }
+    if (c == "\\") {
+      w = delimword(line, i + 1, n)
+      if (w == "") fail("unrecognized heredoc delimiter after <<")
+      hdelim = w
+      hquot = 1
+      hdash = d
+      opened = 1
+      i = wend
       continue
     }
     w = delimword(line, i, n)
     if (w == "") fail("unrecognized heredoc delimiter after <<")
     hdelim = w
     hquot = 0
+    hdash = d
     opened = 1
     i = wend
   }
@@ -123,7 +139,9 @@ function scan(line,   n, i, c, j, w) {
 }
 {
   if (hd) {
-    if ($0 == hdelim) {
+    closer = $0
+    if (hdash) sub(/^\t+/, "", closer)
+    if (closer == hdelim) {
       emit("C", $0)
       hd = 0
     } else {

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -25,6 +25,35 @@ Exit: 0 clean, 1 drift, 2 usage/template/doc/extraction error.
 SDUSAGE
 }
 
+SD_DOC_AWK=$(
+  cat <<'SDAWK'
+BEGIN { FS = "|" }
+/^\|/ && NF >= 4 {
+  name = $2
+  anchor = $3
+  gsub(/^[ \t]+|[ \t]+$/, "", name)
+  gsub(/^[ \t]+|[ \t]+$/, "", anchor)
+  if (name == "Block" || name ~ /^-+$/) next
+  if (anchor !~ /^`.*`$/) next
+  gsub(/`/, "", name)
+  sub(/^`/, "", anchor)
+  sub(/`$/, "", anchor)
+  printf("%s\t%s\n", name, anchor)
+  rows++
+}
+END { if (rows == 0) exit 1 }
+SDAWK
+)
+
+sd_parse_doc() {
+  local doc="$1"
+  if [ ! -r "$doc" ]; then
+    printf 'seed-drift: cannot read doc %s\n' "$doc" >&2
+    return 3
+  fi
+  awk "$SD_DOC_AWK" <"$doc"
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -104,6 +104,27 @@ sd_main() {
     return 2
   fi
 
+  local blocks
+  if ! blocks=$(sd_parse_doc "$doc"); then
+    printf 'seed-drift: no block table found in %s\n' "$doc" >&2
+    return 2
+  fi
+
+  local name anchor absent=0
+  while IFS=$'\t' read -r name anchor; do
+    # Raw grep is deliberately the Task 1 form; Task 6 replaces it with a check
+    # against the template scan's C records once the scanner exists, so that an
+    # anchor appearing only in a comment fails validation.
+    if ! grep -qF -- "$anchor" "$template"; then
+      printf 'seed-drift: anchor %s (block: %s) is absent from %s\n' \
+        "$anchor" "$name" "$template" >&2
+      absent=1
+    fi
+  done <<<"$blocks"
+  if [ "$absent" -ne 0 ]; then
+    return 2
+  fi
+
   return 0
 }
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -186,6 +186,21 @@ sd_scan() {
   awk "$SD_SCAN_AWK" <"$file"
 }
 
+sd_paras_with_anchor() {
+  # $4 would stop at the next tab; take everything after the third tab so a
+  # tab-bearing line is matched in full.
+  awk -F'\t' -v a="$2" '
+    $3 == "C" {
+      t = $0
+      sub(/^[^\t]*\t[^\t]*\t[^\t]*\t/, "", t)
+      if (index(t, a) && !seen[$1]++) print $1
+    }' "$1"
+}
+
+sd_para_range() {
+  awk -F'\t' -v p="$2" '$1 == p { if (!s) s = $2; e = $2 } END { if (s) print s, e }' "$1"
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -596,13 +596,37 @@ sd_visit_dir() {
 }
 
 sd_visit_candidates() {
-  local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand
-  shopt -s nullglob
-  for cand in "$root"/*/; do
-    cand="${cand%/}"
-    # A directory without .devcontainer/ is not a candidate: silent, not skipped.
-    [ -d "$cand/.devcontainer" ] || continue
-    sd_visit_dir "$cand"
+  local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand rc=0
+  # The scalar, not `${#SD_CANDIDATES[@]}`: expanding an empty array under
+  # `set -u` errors on bash 3.2, still the system bash on macOS
+  # (bin/common.sh:392). The `"${SD_CANDIDATES[@]}"` below is reached only
+  # when the count is non-zero, so it is safe.
+  if [ "$SD_CANDIDATE_COUNT" -eq 0 ]; then
+    shopt -s nullglob
+    for cand in "$root"/*/; do
+      cand="${cand%/}"
+      # A directory without .devcontainer/ is not a candidate: silent, not skipped.
+      [ -d "$cand/.devcontainer" ] || continue
+      sd_visit_dir "$cand"
+    done
+    return 0
+  fi
+  for cand in "${SD_CANDIDATES[@]}"; do
+    if [ -d "$cand" ]; then
+      [ -d "$cand/.devcontainer" ] || continue
+      sd_visit_dir "$cand"
+    elif [ -e "$cand" ]; then
+      # An existing file is a direct local-seed.sh path.
+      SD_CHECKED=$((SD_CHECKED + 1))
+      rc=0
+      sd_check_seed "$cand" || rc=$?
+      sd_worst "$rc"
+    else
+      # Not checked out here. A skip, so the same project list works on every
+      # machine; it names the path and is counted, so a typo stays visible.
+      printf '%s - not present on this machine - skipped\n' "$cand"
+      SD_SKIPPED=$((SD_SKIPPED + 1))
+    fi
   done
 }
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -201,35 +201,62 @@ sd_para_range() {
   awk -F'\t' -v p="$2" '$1 == p { if (!s) s = $2; e = $2 } END { if (s) print s, e }' "$1"
 }
 
-# Grows the window until the extracted fragment parses: forward first, then
-# backward once the end of file is reached. The fragment is read straight from
-# FILE by line number, because the scan text is comment-stripped and would not
-# parse the same way.
+# Bounds the ERROR path, not the success path. A window that parses exits on
+# its first successful parse, and on the real corpus every window but one
+# parses at the very first pair the search tries — so this cap costs a passing
+# anchor nothing. It is only ever reached by an anchor whose block never
+# parses at all, where the search is O(paragraphs^2) `bash -n` invocations
+# rather than O(paragraphs). 400 is far above any real block's needs (the
+# largest real window is 109 lines inside a 961-line template) and still
+# bounds the failing case to a second or two.
+SD_MAX_PARSE_ATTEMPTS=400
+
+# Grows the window until the extracted fragment parses. The search is
+# two-dimensional — every (lo, hi) paragraph pair, `lo` walking down from the
+# anchor's paragraph and `hi` up from it — because the common real case is an
+# anchor inside a multi-paragraph function body, which needs the window grown
+# BACK to `funcname() {` and FORWARD to the closing `}` at the same time.
+#
+# A one-dimensional walk cannot express that pair. Worse, the previous
+# forward-to-EOF-then-backward form left `end` pinned at EOF once forward
+# growth exhausted, so ANY block needing backward growth extracted
+# `[lo's start .. EOF]` and was diffed as if the whole tail of the file
+# belonged to it — reporting other blocks' drift under this block's name.
+#
+# (para, para) is tried first, so a paragraph that already parses standalone
+# costs exactly one `bash -n`, exactly as before. The fragment is read
+# straight from FILE by line number, because the scan text is comment-stripped
+# and would not parse the same way.
 sd_window() {
   local file="$1" scan="$2" para="$3"
-  local first last lo hi start end range
+  local first last lo hi start end range tries=0
 
   first=$(awk -F'\t' 'NR == 1 { print $1; exit }' "$scan")
   last=$(awk -F'\t' 'END { print $1 }' "$scan")
   range=$(sd_para_range "$scan" "$para")
   [ -n "$range" ] || return 3
 
-  lo="$para" hi="$para"
-  start="${range% *}" end="${range#* }"
-  while ! sed -n "${start},${end}p" "$file" | bash -n 2>/dev/null; do
-    if [ "$hi" -lt "$last" ]; then
-      hi=$((hi + 1))
+  lo="$para"
+  while [ "$lo" -ge "$first" ]; do
+    range=$(sd_para_range "$scan" "$lo")
+    start="${range% *}"
+    hi="$para"
+    while [ "$hi" -le "$last" ]; do
       range=$(sd_para_range "$scan" "$hi")
       end="${range#* }"
-    elif [ "$lo" -gt "$first" ]; then
-      lo=$((lo - 1))
-      range=$(sd_para_range "$scan" "$lo")
-      start="${range% *}"
-    else
-      return 3
-    fi
+      tries=$((tries + 1))
+      # Same status the exhaustion path below returns: sd_extract and
+      # sd_check_seed already route 3 to "block could not be extracted".
+      [ "$tries" -le "$SD_MAX_PARSE_ATTEMPTS" ] || return 3
+      if sed -n "${start},${end}p" "$file" | bash -n 2>/dev/null; then
+        printf '%s %s\n' "$start" "$end"
+        return 0
+      fi
+      hi=$((hi + 1))
+    done
+    lo=$((lo - 1))
   done
-  printf '%s %s\n' "$start" "$end"
+  return 3
 }
 
 # Below this many raw (pre-normalization) lines, a window has proven too

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -355,6 +355,56 @@ sd_extract() {
     sd_normalize
 }
 
+# One temp dir for the whole run, removed by a single trap. Callers never
+# clean up individually, so no early `return` can leak a file.
+SD_TMPDIR=""
+
+# sd_tmp VARNAME — assigns a fresh temp file path to VARNAME in the CALLER's
+# scope, and must never be called inside a command substitution. `$(sd_tmp)`
+# runs in a subshell: the subshell creates the directory, installs the EXIT
+# trap, prints the path, and then — on subshell exit — fires that trap and
+# `rm -rf`s the directory before the caller can write a single byte. The
+# directory and its trap have to be established in the shell that will
+# actually use them, so the path comes back through `printf -v`, not stdout.
+sd_tmp() {
+  local __sd_new
+  if [ -z "$SD_TMPDIR" ]; then
+    SD_TMPDIR="$(mktemp -d)" || return 3
+    trap 'rm -rf -- "$SD_TMPDIR"' EXIT HUP INT TERM
+  fi
+  __sd_new="$(mktemp "$SD_TMPDIR/sd.XXXXXX")" || return 3
+  printf -v "$1" '%s' "$__sd_new"
+}
+
+sd_diff_lines() {
+  # TPL_NORM SEED_NORM MARKER; MARKER is '<' for template-only lines and '>'
+  # for seed-only lines. The diff is ordered, so a pure reordering yields lines
+  # under both markers rather than comparing equal.
+  #
+  # diff goes to a FILE, not a command substitution. A removed blank line is
+  # emitted by diff as the record `< ` (marker, space, empty text); command
+  # substitution would strip the trailing newline and sed, preserving the
+  # absent final newline, would then emit zero bytes — making a deleted blank
+  # line read as no difference at all. Via a file every record keeps its
+  # newline and the blank one survives.
+  local rc=0 raw
+  sd_tmp raw || return 3
+  diff -- "$1" "$2" >"$raw" || rc=$?
+  if [ "$rc" -gt 1 ]; then
+    printf 'seed-drift: diff failed comparing %s and %s\n' "$1" "$2" >&2
+    return 3
+  fi
+  sed -n "s/^$3 //p" "$raw"
+}
+
+# Takes a FILE, and counts every record including empty ones. `grep -c .`
+# would skip exactly the blank lines this tool has to notice.
+sd_count_lines() {
+  local n
+  n=$(wc -l <"$1")
+  printf '%s' "${n//[[:space:]]/}"
+}
+
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -63,12 +63,36 @@ function emit(tag, text) {
   }
   printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
 }
+function scan(line,   n, i, c) {
+  n = length(line)
+  i = 1
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (inq == "'") {
+      if (c == "'") inq = ""
+      i++
+      continue
+    }
+    if (inq == "\"") {
+      if (c == "\\") { i += 2; continue }
+      if (c == "\"") inq = ""
+      i++
+      continue
+    }
+    if (c == "\\") { i += 2; continue }
+    if (c == "'") { inq = "'"; i++; continue }
+    if (c == "\"") { inq = "\""; i++; continue }
+    if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t]/)) return substr(line, 1, i - 1)
+    i++
+  }
+  return line
+}
 {
-  if ($0 ~ /^[ \t]*$/) {
+  if ($0 ~ /^[ \t]*$/ && inq == "") {
     brk = 1
     next
   }
-  emit("C", $0)
+  emit("C", scan($0))
 }
 SDAWK
 )

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -206,10 +206,29 @@ sd_para_range() {
 # parses at the very first pair the search tries — so this cap costs a passing
 # anchor nothing. It is only ever reached by an anchor whose block never
 # parses at all, where the search is O(paragraphs^2) `bash -n` invocations
-# rather than O(paragraphs). 400 is far above any real block's needs (the
-# largest real window is 109 lines inside a 961-line template) and still
-# bounds the failing case to a second or two.
-SD_MAX_PARSE_ATTEMPTS=400
+# rather than O(paragraphs).
+#
+# 2000 is deliberate headroom, not a measurement. The worst plausible real
+# shape was measured at ~280 attempts (the largest real window is 109 lines
+# inside a 961-line template), so this sits roughly 7x above it. The margin is
+# that wide on purpose, for two reasons:
+#
+#   1. The failure mode is asymmetric. Exceeding the cap turns a legitimate
+#      block into a hard exit-2 ERROR — a false alarm on good input. Going
+#      over costs only ~2000 `bash -n` invocations on a block that was going
+#      to fail anyway.
+#   2. The sweep below is NOT strictly smallest-window-first: the inner loop
+#      always runs `hi` to `last`, so (para, last) is tried before
+#      (para-1, para), and a backward-only case burns a full forward sweep per
+#      step. The attempt count therefore does not track window size, which is
+#      why the margin is set this wide rather than at a tight multiple of the
+#      ~280 measurement.
+#
+# Do not "tune" this down to hug the measurement. The ordering it compensates
+# for is deliberate — it was verified against the real corpus by exhaustive
+# old-vs-new window comparison, and reordering the search would change which
+# window an ambiguous anchor resolves to.
+SD_MAX_PARSE_ATTEMPTS=2000
 
 # Grows the window until the extracted fragment parses. The search is
 # two-dimensional — every (lo, hi) paragraph pair, `lo` walking down from the
@@ -680,6 +699,12 @@ sd_visit_candidates() {
     # so setting nullglob and walking away would silently change globbing in
     # the caller's shell. The restore sits after the loop, ahead of both
     # returns below, so no exit path from here leaks it.
+    #
+    # Not a trap. A `set -e` abort from inside the loop would still leak, and
+    # an ERR trap would not catch it without `set -E` — a larger change than
+    # this justifies. More to the point, sourcing this script already sets
+    # `e`, `u`, and pipefail in the caller unconditionally, on the success
+    # path, so an abort-only nullglob edge is not the marginal exposure here.
     local had_nullglob=0
     shopt -q nullglob && had_nullglob=1
     shopt -s nullglob

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -471,6 +471,7 @@ sd_report_action() {
 
 sd_check_seed() {
   local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
+  local behind ahead nb na est tst
   name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
   printf '%s  %s\n' "$name" "$seed"
   # Each file is scanned exactly once. The template scan is built by sd_main
@@ -487,11 +488,84 @@ sd_check_seed() {
   sd_tmp tnorm || return 2
   sd_tmp snorm || return 2
   while IFS=$'\t' read -r block anchor; do
-    sd_extract "$SD_TEMPLATE" "$SD_TEMPLATE_SCAN" "$anchor" >"$tnorm" || continue
-    sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || continue
-    verdict=$(sd_verdict "$tnorm" "$snorm") || continue
+    # Branch on the ORIGINAL status. sd_extract returns 4 for "anchor absent"
+    # and 3 for "the block would not parse"; `if ! sd_extract` flattens both
+    # into one branch, so a seed whose block is unextractable would be
+    # reported as MISSING and exit 1 — a wrong verdict at the wrong severity.
+    tst=0
+    sd_extract "$SD_TEMPLATE" "$SD_TEMPLATE_SCAN" "$anchor" >"$tnorm" || tst=$?
+    case "$tst" in
+      0) ;;
+      4)
+        sd_report_block ERROR "$block" 'anchor absent from template'
+        rc=2
+        continue
+        ;;
+      *)
+        sd_report_block ERROR "$block" 'template block could not be extracted'
+        rc=2
+        continue
+        ;;
+    esac
+    est=0
+    sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || est=$?
+    case "$est" in
+      0) ;;
+      4)
+        sd_report_block MISSING "$block" 'anchor absent from seed'
+        sd_report_action 'port the block; see catch-up-local-seed.md Step 2'
+        SD_MISSING=$((SD_MISSING + 1))
+        [ "$rc" -ge 1 ] || rc=1
+        continue
+        ;;
+      *)
+        sd_report_block ERROR "$block" 'seed block could not be extracted'
+        rc=2
+        continue
+        ;;
+    esac
+    # Same file-not-substitution rule as sd_verdict: a removed blank line must
+    # survive into the count and the samples.
+    sd_tmp behind || return 2
+    sd_tmp ahead || return 2
+    if ! sd_diff_lines "$tnorm" "$snorm" '<' >"$behind" ||
+      ! sd_diff_lines "$tnorm" "$snorm" '>' >"$ahead"; then
+      sd_report_block ERROR "$block" 'diff failed'
+      rc=2
+      continue
+    fi
+    nb=$(sd_count_lines "$behind")
+    na=$(sd_count_lines "$ahead")
+    # From the counts just computed, not `verdict=$(sd_verdict ...)`: that
+    # form re-runs the same two diffs, and its non-zero status on a diff
+    # failure would abort the program under `set -e` — exiting 3 outside the
+    # public 0/1/2 contract and skipping every remaining project.
+    verdict=$(sd_verdict_from_counts "$nb" "$na")
     case "$verdict" in
-      ok) sd_report_block ok "$block" '' ;;
+      ok)
+        sd_report_block ok "$block" ''
+        ;;
+      BEHIND)
+        sd_report_block BEHIND "$block" "$nb template lines absent from seed"
+        sd_report_samples <"$behind"
+        sd_report_action 'port from template; see catch-up-local-seed.md Step 2'
+        SD_BEHIND=$((SD_BEHIND + 1))
+        [ "$rc" -ge 1 ] || rc=1
+        ;;
+      AHEAD)
+        sd_report_block AHEAD "$block" "$na seed lines absent from template"
+        sd_report_samples <"$ahead"
+        sd_report_action 'promotion candidate; do NOT overwrite the seed'
+        SD_AHEAD=$((SD_AHEAD + 1))
+        [ "$rc" -ge 1 ] || rc=1
+        ;;
+      DIVERGED)
+        sd_report_block DIVERGED "$block" \
+          "$nb template lines absent from seed, $na seed lines absent from template"
+        sd_report_action 'inspect by hand; do NOT overwrite the seed'
+        SD_DIVERGED=$((SD_DIVERGED + 1))
+        [ "$rc" -ge 1 ] || rc=1
+        ;;
     esac
   done < <(sd_parse_doc "$SD_DOC")
   return "$rc"

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -68,6 +68,24 @@ function emit(tag, text) {
   }
   printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
 }
+function push(delim, quoted, dash) {
+  nq++
+  qd[nq] = delim
+  qq[nq] = quoted
+  qs[nq] = dash
+}
+function popq() {
+  hdelim = qd[1]
+  hquot = qq[1]
+  hdash = qs[1]
+  hd = 1
+  for (k = 1; k < nq; k++) {
+    qd[k] = qd[k + 1]
+    qq[k] = qq[k + 1]
+    qs[k] = qs[k + 1]
+  }
+  nq--
+}
 function delimword(line, i, n,   w, c) {
   w = ""
   while (i <= n) {
@@ -110,29 +128,20 @@ function scan(line,   n, i, c, j, d, w) {
     if (c == "'" || c == "\"") {
       j = index(substr(line, i + 1), c)
       if (j == 0) fail("unterminated heredoc delimiter quote")
-      hdelim = substr(line, i + 1, j - 1)
-      hquot = 1
-      hdash = d
-      opened = 1
+      push(substr(line, i + 1, j - 1), 1, d)
       i = i + j + 1
       continue
     }
     if (c == "\\") {
       w = delimword(line, i + 1, n)
       if (w == "") fail("unrecognized heredoc delimiter after <<")
-      hdelim = w
-      hquot = 1
-      hdash = d
-      opened = 1
+      push(w, 1, d)
       i = wend
       continue
     }
     w = delimword(line, i, n)
     if (w == "") fail("unrecognized heredoc delimiter after <<")
-    hdelim = w
-    hquot = 0
-    hdash = d
-    opened = 1
+    push(w, 0, d)
     i = wend
   }
   return line
@@ -144,6 +153,7 @@ function scan(line,   n, i, c, j, d, w) {
     if (closer == hdelim) {
       emit("C", $0)
       hd = 0
+      if (nq > 0) popq()
     } else {
       emit(hquot ? "Hq" : "Hu", $0)
     }
@@ -153,9 +163,9 @@ function scan(line,   n, i, c, j, d, w) {
     brk = 1
     next
   }
-  opened = 0
+  nq = 0
   emit("C", scan($0))
-  if (opened) hd = 1
+  if (nq > 0) popq()
 }
 SDAWK
 )

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -617,7 +617,14 @@ sd_visit_candidates() {
   fi
   for cand in "${SD_CANDIDATES[@]}"; do
     if [ -d "$cand" ]; then
-      [ -d "$cand/.devcontainer" ] || continue
+      if [ ! -d "$cand/.devcontainer" ]; then
+        # An explicitly-named project is a promise, not a glob match: a
+        # renamed or removed .devcontainer/ must be visible in the count, not
+        # silently absorbed the way an unrelated discovery-mode directory is.
+        printf '%s  no .devcontainer/ - skipped\n' "$(basename -- "$cand")"
+        SD_SKIPPED=$((SD_SKIPPED + 1))
+        continue
+      fi
       sd_visit_dir "$cand"
     elif [ -e "$cand" ]; then
       # An existing file is a direct local-seed.sh path.

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -267,6 +267,11 @@ sd_window() {
 SD_THIN_WINDOW=5
 
 sd_neutralize_paths() {
+  # Deliberately unanchored on the right: `$HOME` also rewrites inside
+  # `$HOMEBREW_PREFIX`, and a right boundary is genuinely awkward in
+  # BSD-portable sed. It cannot flip a verdict, because the identical rule is
+  # applied to both sides before they are diffed; the cost is confined to
+  # mangled text in the sample lines printed for a drifted block.
   sed -e 's/\${SEED_HOME}/«HOME»/g' -e 's/\$SEED_HOME/«HOME»/g' \
     -e 's/\${DOTFILES_HOME}/«HOME»\/.dotfiles/g' \
     -e 's/\$DOTFILES_HOME/«HOME»\/.dotfiles/g' \
@@ -549,6 +554,17 @@ sd_check_seed() {
         continue
         ;;
     esac
+    # An empty template side must never reach the comparison:
+    # sd_verdict_from_counts 0 0 is `ok`, so it would report a clean block
+    # having compared nothing at all. sd_main's anchor validation makes this
+    # unreachable today — the anchor must appear in a `C` record — but that
+    # guarantee lives two functions away, and this is the invariant that
+    # matters here, so it is enforced where it is relied on.
+    if [ ! -s "$tnorm" ]; then
+      sd_report_block ERROR "$block" 'template block extracted to nothing'
+      rc=2
+      continue
+    fi
     est=0
     sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || est=$?
     case "$est" in
@@ -612,8 +628,18 @@ sd_check_seed() {
     # Informational only, fires regardless of verdict (including ok) and never
     # touches rc or the drift tallies above — a thin window means the check
     # covered too little to trust, not that the block itself is wrong.
-    [ "$tsize" -lt "$SD_THIN_WINDOW" ] && sd_report_thin template "$tsize"
-    [ "$esize" -lt "$SD_THIN_WINDOW" ] && sd_report_thin seed "$esize"
+    #
+    # `if`, not `[ … ] && …`: the bare-`&&` form leaves the loop body's status
+    # at 1 whenever the window is thick, so it is safe only while the explicit
+    # `return "$rc"` below stays the very next statement. Appending a line
+    # after it would make a clean seed return 1 — inventing drift inside the
+    # public 0/1/2 contract.
+    if [ "$tsize" -lt "$SD_THIN_WINDOW" ]; then
+      sd_report_thin template "$tsize"
+    fi
+    if [ "$esize" -lt "$SD_THIN_WINDOW" ]; then
+      sd_report_thin seed "$esize"
+    fi
   done < <(sd_parse_doc "$SD_DOC")
   return "$rc"
 }
@@ -649,6 +675,13 @@ sd_visit_candidates() {
   # (bin/common.sh:392). The `"${SD_CANDIDATES[@]}"` below is reached only
   # when the count is non-zero, so it is safe.
   if [ "$SD_CANDIDATE_COUNT" -eq 0 ]; then
+    # Saved and restored around discovery only. The script is designed to be
+    # sourced (SEED_DRIFT_SOURCE_ONLY=1 — the whole test suite depends on it),
+    # so setting nullglob and walking away would silently change globbing in
+    # the caller's shell. The restore sits after the loop, ahead of both
+    # returns below, so no exit path from here leaks it.
+    local had_nullglob=0
+    shopt -q nullglob && had_nullglob=1
     shopt -s nullglob
     for cand in "$root"/*/; do
       cand="${cand%/}"
@@ -657,6 +690,9 @@ sd_visit_candidates() {
       sd_visit_dir "$cand"
       visited=$((visited + 1))
     done
+    if [ "$had_nullglob" -eq 0 ]; then
+      shopt -u nullglob
+    fi
     if [ "$visited" -eq 0 ]; then
       # Scoped to discovery only: an explicitly-named absent project is
       # still a skip at exit 0 (the brief states this outright). But

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -232,6 +232,13 @@ sd_window() {
   printf '%s %s\n' "$start" "$end"
 }
 
+# Below this many raw (pre-normalization) lines, a window has proven too
+# little to trust a verdict on. Calibrated against the real five-seed corpus
+# (Task 8 brief): the smallest window measured there is 9 lines, so 5 leaves
+# headroom against ordinary variation while still catching a genuinely
+# degenerate window. Do not raise this without re-measuring the corpus.
+SD_THIN_WINDOW=5
+
 sd_neutralize_paths() {
   sed -e 's/\${SEED_HOME}/«HOME»/g' -e 's/\$SEED_HOME/«HOME»/g' \
     -e 's/\${DOTFILES_HOME}/«HOME»\/.dotfiles/g' \
@@ -323,7 +330,7 @@ sd_normalize() {
 }
 
 sd_extract() {
-  local file="$1" scan="$2" anchor="$3" paras para window ranges=""
+  local file="$1" scan="$2" anchor="$3" paras para window ranges="" keep
 
   paras=$(sd_paras_with_anchor "$scan" "$anchor")
   [ -n "$paras" ] || return 4
@@ -335,8 +342,18 @@ sd_extract() {
 
   # Union the windows by source line number: `sort -n -u` puts them in file
   # order and collapses lines two overlapping windows both claim.
-  printf '%s' "$ranges" |
-    awk '{ for (i = $1; i <= $2; i++) print i }' | sort -n -u |
+  keep=$(printf '%s' "$ranges" | awk '{ for (i = $1; i <= $2; i++) print i }' | sort -n -u)
+
+  # SD_LAST_WINDOW_SIZE is deliberately a global, not local: both call sites in
+  # sd_check_seed invoke sd_extract with a plain redirect (`sd_extract ... >"$f"`),
+  # not a command substitution, so sd_extract runs in the caller's own shell and
+  # this assignment survives the call — it does not need `printf -v` or a
+  # separate accessor. It is the raw (pre-normalization) line count of the
+  # unioned window, matching END-START+1 in the common single-paragraph case and
+  # generalizing correctly when an anchor matches more than one paragraph.
+  SD_LAST_WINDOW_SIZE=$(printf '%s\n' "$keep" | awk 'END { print NR }')
+
+  printf '%s\n' "$keep" |
     awk -F'\t' 'NR == FNR { keep[$1] = 1; next } keep[$2]' - "$scan" |
     sd_normalize
 }
@@ -455,9 +472,17 @@ sd_report_action() {
   printf '             -> %s\n' "$1"
 }
 
+# Informational only: a thin window proves little either way and must never
+# affect the verdict or the exit code. $1 names the side ("template" or
+# "seed"); $2 is the raw window size in lines.
+sd_report_thin() {
+  printf '             note: %s window is only %d lines (< %d) - check covers little\n' \
+    "$1" "$2" "$SD_THIN_WINDOW"
+}
+
 sd_check_seed() {
   local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
-  local behind ahead nb na est tst
+  local behind ahead nb na est tst tsize esize
   name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
   printf '%s  %s\n' "$name" "$seed"
   if ! bash -n "$seed" 2>/dev/null; then
@@ -485,7 +510,7 @@ sd_check_seed() {
     tst=0
     sd_extract "$SD_TEMPLATE" "$SD_TEMPLATE_SCAN" "$anchor" >"$tnorm" || tst=$?
     case "$tst" in
-      0) ;;
+      0) tsize="$SD_LAST_WINDOW_SIZE" ;;
       4)
         sd_report_block ERROR "$block" 'anchor absent from template'
         rc=2
@@ -500,7 +525,7 @@ sd_check_seed() {
     est=0
     sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || est=$?
     case "$est" in
-      0) ;;
+      0) esize="$SD_LAST_WINDOW_SIZE" ;;
       4)
         sd_report_block MISSING "$block" 'anchor absent from seed'
         sd_report_action 'port the block; see catch-up-local-seed.md Step 2'
@@ -557,6 +582,11 @@ sd_check_seed() {
         [ "$rc" -ge 1 ] || rc=1
         ;;
     esac
+    # Informational only, fires regardless of verdict (including ok) and never
+    # touches rc or the drift tallies above — a thin window means the check
+    # covered too little to trust, not that the block itself is wrong.
+    [ "$tsize" -lt "$SD_THIN_WINDOW" ] && sd_report_thin template "$tsize"
+    [ "$esize" -lt "$SD_THIN_WINDOW" ] && sd_report_thin seed "$esize"
   done < <(sd_parse_doc "$SD_DOC")
   return "$rc"
 }

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -232,7 +232,8 @@ sd_window() {
   printf '%s %s\n' "$start" "$end"
 }
 
-# The non-root ownership-verification idiom, matched fully literally after
+# The non-root ownership-verification idiom, matched fully literally at the
+# comparison stage (see sd_apply_ownership_rule), never during per-file
 # normalization: template lines 491-492 (chown -R, "$NVIM_DIST.new") and
 # 594-595 (plain chown, "$TS_BIN.new"). Two physical lines each, because the
 # first ends in `||` and the second in `; } &&`. Nothing in the match is free —
@@ -261,11 +262,12 @@ sd_drop_priv_prefix() {
   # wanderer writes `if [ ! -f "$GITIGNORE" ]; then` — so a line-start-only
   # rule would report every one of those shapes as drift.
   #
-  # No `\b`: that boundary is a GNU extension and this script must also run
-  # under the BSD sed macOS ships. Operators are self-delimiting, so they need
-  # no boundary; the keywords take an explicit `(^|[[:space:]])` left boundary
-  # instead, which is why they are a separate expression. `sd_normalize_code_line`
-  # has already collapsed runs of whitespace to single spaces before we get here.
+  # No word-boundary escape: that construct is a GNU sed extension and this
+  # script must also run under the BSD sed macOS ships. Operators are
+  # self-delimiting, so they need no boundary; the keywords take an explicit
+  # `(^|[[:space:]])` left boundary instead, which is why they are a separate
+  # expression. `sd_normalize_code_line` has already collapsed runs of
+  # whitespace to single spaces before we get here.
   local line="$1" prev=""
   while [ "$line" != "$prev" ]; do
     prev="$line"
@@ -281,7 +283,7 @@ sd_drop_priv_prefix() {
 }
 
 sd_normalize_code_line() {
-  local line="$1" drop
+  local line="$1"
   line="${line//$'\t'/ }"
   while [ "$line" != "${line//  / }" ]; do line="${line//  / }"; done
   line="${line#"${line%%[![:space:]]*}"}"
@@ -289,9 +291,6 @@ sd_normalize_code_line() {
   [ -n "$line" ] || return 0
   line=$(sd_drop_priv_prefix "$line")
   [ -n "$line" ] || return 0
-  for drop in "${SD_OWNERSHIP_DROP[@]}"; do
-    [ "$line" = "$drop" ] && return 0
-  done
   printf '%s\n' "$line" | sd_neutralize_paths
 }
 
@@ -405,6 +404,34 @@ sd_count_lines() {
   printf '%s' "${n//[[:space:]]/}"
 }
 
+# The ownership rule is inherently cross-file — "does the OTHER side still
+# show a chown/chgrp difference of its own?" — so it cannot be decided while
+# normalizing one file in isolation; that was the Task 6 design's mistake.
+# Applied here, at the comparison stage, after diffing: BEHIND_FILE and
+# AHEAD_FILE already hold the template-only and seed-only lines. If AHEAD_FILE
+# has no chown/chgrp line of its own, the seed is silent about ownership
+# (typically the non-root idiom omitted wholesale under a root-flavored seed),
+# so the exact idiom lines are dropped from BEHIND_FILE and the block reads
+# clean. If AHEAD_FILE does mention chown/chgrp, the seed changed something —
+# target, `-R`, identity, or an unrelated chown entirely — and nothing is
+# dropped, so the mismatch surfaces as DIVERGED. Called identically from
+# sd_verdict and sd_check_seed so both compute the same verdict from the same
+# counts; if they disagreed, a caller using sd_verdict directly (as the tests
+# do) could see a different answer than a full run.
+sd_apply_ownership_rule() {
+  local behind="$1" ahead="$2" patterns filtered rc=0
+  grep -qE 'chown|chgrp' "$ahead" && return 0
+  sd_tmp patterns || return 3
+  sd_tmp filtered || return 3
+  printf '%s\n' "${SD_OWNERSHIP_DROP[@]}" >"$patterns"
+  grep -Fvxf "$patterns" "$behind" >"$filtered" || rc=$?
+  if [ "$rc" -gt 1 ]; then
+    printf 'seed-drift: ownership filter failed on %s\n' "$behind" >&2
+    return 3
+  fi
+  cp -- "$filtered" "$behind"
+}
+
 # Pure classifier: given the two difference counts, name the direction. Split
 # out from sd_verdict so a caller that already holds the counts can name the
 # verdict without re-running diff — and, more importantly, without the
@@ -432,6 +459,7 @@ sd_verdict() {
   sd_tmp af || return 3
   sd_diff_lines "$1" "$2" '<' >"$bf" || return 3
   sd_diff_lines "$1" "$2" '>' >"$af" || return 3
+  sd_apply_ownership_rule "$bf" "$af" || return 3
   behind=$(sd_count_lines "$bf")
   ahead=$(sd_count_lines "$af")
   sd_verdict_from_counts "$behind" "$ahead"
@@ -535,6 +563,11 @@ sd_check_seed() {
     if ! sd_diff_lines "$tnorm" "$snorm" '<' >"$behind" ||
       ! sd_diff_lines "$tnorm" "$snorm" '>' >"$ahead"; then
       sd_report_block ERROR "$block" 'diff failed'
+      rc=2
+      continue
+    fi
+    if ! sd_apply_ownership_rule "$behind" "$ahead"; then
+      sd_report_block ERROR "$block" 'ownership filter failed'
       rc=2
       continue
     fi

--- a/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
+++ b/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
@@ -115,7 +115,8 @@ it runs the full detector before the function under test is even called.
 - `.bats` files are emitted for neither linter (`shfmt` takes only `tests/test_helper.bash`), so `tests/seed_drift.bats` is unlinted. That gap is deliberate, consistent with all 22 existing suites, and is left alone.
 - The detector is strictly **READ-ONLY**: seeds are gitignored, hand-owned files with no `git diff` and no revert path. Nothing in `bin/seed-drift` may open a seed for writing.
 - `SEED_VERSION` must never be compared, and must never appear as an anchor or in a comparison path.
-- `command make check` must pass — it runs `syntax lint test python-test validate`; baseline before this work is **323 passing bats tests**.
+- `command make check` must pass — it runs `syntax lint test python-test validate`; baseline before this work is **330 passing bats tests** (measured on this branch
+  after rebasing onto `origin/main` at #41, which added seven).
 - All bats tests use fixture `--template` / `--doc` files and a fixture `SEED_DRIFT_ROOT`; no test may depend on the real `~/workspace`.
 - `make` is shadowed by a zsh function in this environment; every make invocation is written `command make`.
 

--- a/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
+++ b/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
@@ -6,7 +6,8 @@
 
 **Architecture:** A single self-contained Bash executable, following the repository's `bin/` convention. It parses the block table in `catch-up-local-seed.md` for anchors, so the documented model and the executable one cannot disagree. For each anchor it extracts the surrounding block from both files using a heredoc-aware paragraph scanner whose windows are grown until the extracted fragment parses under `bash -n`, normalizes away the known vocabulary differences between seeds while leaving heredoc payloads verbatim, and reports an order-preserving diff (Decision 1) as `ok` / `MISSING` / `BEHIND` / `AHEAD` / `DIVERGED`.
 
-**Tech Stack:** Bash 5, awk (the scanner), `diff`, `bats` for tests. No new dependencies.
+**Tech Stack:** Bash 3.2-compatible shell, awk (the scanner), `diff`, `bats` for
+tests. No new dependencies.
 
 **Design spec:** `docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md`. Read it before starting; every decision below traces to a numbered Decision in that document.
 
@@ -94,6 +95,16 @@ it runs the full detector before the function under test is even called.
 ---
 
 ## Global Constraints
+
+- **Bash 3.2 compatibility for `bin/seed-drift`.** macOS is a supported platform
+  (`README.md:3`) and its system bash is still 3.2 — `bin/common.sh:394` says so
+  in as many words. Do not introduce `declare -A`, `mapfile`/`readarray`,
+  `${var,,}`/`${var^^}`, or negative array indices. Everything this plan
+  specifies is already 3.2-clean; keep it that way.
+  This constraint covers `bin/seed-drift` only. The **test suite** may use GNU
+  `sed -i` and `stat -c`, matching `tests/project_claude_setup_seed.bats` and
+  `tests/ai_installers.bats`, because CI is `ubuntu-latest` only
+  (`.github/workflows/check.yml:13`).
 
 - `bin/seed-drift` is `shfmt -i 2 -ci` clean — verified by `bin/list-check-files shfmt | xargs -0 shfmt -d -i 2 -ci` (the `lint` target).
 - `bin/seed-drift` is `shellcheck -x -S warning -e SC1091` clean — verified by `bin/list-check-files shellcheck | xargs -0 shellcheck -x -S warning -e SC1091` (the `lint` target).
@@ -455,6 +466,9 @@ In `bin/seed-drift`, replace the trailing `return 0` of `sd_main` (the last stat
 
   local name anchor absent=0
   while IFS=$'\t' read -r name anchor; do
+    # Raw grep is deliberately the Task 1 form; Task 6 replaces it with a check
+    # against the template scan's C records once the scanner exists, so that an
+    # anchor appearing only in a comment fails validation.
     if ! grep -qF -- "$anchor" "$template"; then
       printf 'seed-drift: anchor %s (block: %s) is absent from %s\n' \
         "$anchor" "$name" "$template" >&2
@@ -516,7 +530,20 @@ git commit -m "feat: fail with exit 2 when a doc anchor is absent from the templ
 
 - `SD_SCAN_AWK` — the awk program, as a shell variable. Later tasks call `sd_scan`, not awk directly.
 
-Every consumer in Tasks 3-8 (`sd_paras_with_anchor`, `sd_para_range`, `sd_window`, `sd_normalize`, `sd_extract`) reads this exact 4-field format with `IFS=$'\t' read -r para lineno tag text` or `awk -F'\t'`. Because `text` is last, it may itself contain tabs without breaking field splitting.
+Every consumer in Tasks 3-8 (`sd_paras_with_anchor`, `sd_para_range`,
+`sd_window`, `sd_normalize`, `sd_extract`) reads this exact 4-field format.
+`text` is last so it may contain tabs — but **neither obvious reader preserves
+them**, and heredoc payloads are required to be verbatim:
+
+- `IFS=$'\t' read -r para lineno tag text` strips *leading* tabs from `text`,
+  because tab is IFS whitespace. That is exactly the `<<-` indented-body case.
+- `awk -F'\t'`'s `$4` stops at the next tab, silently truncating the rest.
+
+So consumers must split positionally instead: in shell, read the whole record
+with `IFS= read -r rec` and peel three fields with `${rec%%$'\t'*}` /
+`${rec#*$'\t'}`, leaving the remainder untouched; in awk, take the text as
+everything after the third tab via `sub(/^[^\t]*\t[^\t]*\t[^\t]*\t/, "", t)`.
+Both are specified below and pinned by a tab-payload test in Task 7.
 
 ---
 
@@ -1252,7 +1279,7 @@ git commit -m "feat: treat an unterminated heredoc as an sd_scan extraction erro
 
 *Produces*
 
-- `sd_paras_with_anchor SCAN ANCHOR` -> stdout, one paragraph index per line, ascending, deduped. Empty output (exit 0) when the anchor matches nothing. Match is `index($4, a)` — fixed string, against `$3 == "C"` rows only.
+- `sd_paras_with_anchor SCAN ANCHOR` -> stdout, one paragraph index per line, ascending, deduped. Empty output (exit 0) when the anchor matches nothing. Match is awk `index()` — fixed string — against the text after the third tab, on `$3 == "C"` rows only. Not `$4`: that stops at the next tab and would truncate a tab-bearing line.
 - `sd_para_range SCAN PARA` -> stdout, one line, `start end` (space-separated source line numbers). Empty output when `PARA` does not exist.
 - `sd_window FILE SCAN PARA` -> stdout, one line, `start end`. Exit 3 if no grown window ever parses.
 
@@ -1319,7 +1346,14 @@ Append to `bin/seed-drift` after `sd_scan`:
 
 ```bash
 sd_paras_with_anchor() {
-  awk -F'\t' -v a="$2" '$3 == "C" && index($4, a) { if (!seen[$1]++) print $1 }' "$1"
+  # $4 would stop at the next tab; take everything after the third tab so a
+  # tab-bearing line is matched in full.
+  awk -F'\t' -v a="$2" '
+    $3 == "C" {
+      t = $0
+      sub(/^[^\t]*\t[^\t]*\t[^\t]*\t/, "", t)
+      if (index(t, a) && !seen[$1]++) print $1
+    }' "$1"
 }
 
 sd_para_range() {
@@ -1649,8 +1683,16 @@ sd_normalize_code_line() {
 }
 
 sd_normalize() {
-  local para lineno tag text pending="" joining=0
-  while IFS=$'\t' read -r para lineno tag text; do
+  local rec tag text rest pending="" joining=0
+  # Positional split, not `IFS=$'\t' read`: that form strips leading tabs from
+  # `text`, which would corrupt every `<<-` heredoc body. `para` and `lineno`
+  # are skipped rather than bound — binding them trips SC2034 under
+  # `shellcheck -S warning`, which this repo gates on.
+  while IFS= read -r rec; do
+    rest="${rec#*$'\t'}"
+    rest="${rest#*$'\t'}"
+    tag="${rest%%$'\t'*}"
+    text="${rest#*$'\t'}"
     if [ "$joining" = 1 ]; then
       pending="$pending ${text#"${text%%[![:space:]]*}"}"
     else
@@ -1731,8 +1773,16 @@ Replace the whole function:
 
 ```bash
 sd_normalize() {
-  local para lineno tag text pending="" joining=0
-  while IFS=$'\t' read -r para lineno tag text; do
+  local rec tag text rest pending="" joining=0
+  # Positional split, not `IFS=$'\t' read`: that form strips leading tabs from
+  # `text`, which would corrupt every `<<-` heredoc body. `para` and `lineno`
+  # are skipped rather than bound — binding them trips SC2034 under
+  # `shellcheck -S warning`, which this repo gates on.
+  while IFS= read -r rec; do
+    rest="${rec#*$'\t'}"
+    rest="${rest#*$'\t'}"
+    tag="${rest%%$'\t'*}"
+    text="${rest#*$'\t'}"
     if [ "$tag" = C ]; then
       if [ "$joining" = 1 ]; then
         pending="$pending ${text#"${text%%[![:space:]]*}"}"
@@ -2037,21 +2087,44 @@ produces differences in both directions and is reported `DIVERGED`.
   Insert into `bin/seed-drift`, immediately above `sd_main()`:
 
   ```bash
+  # One temp dir for the whole run, removed by a single trap. Callers never
+  # clean up individually, so no early `return` can leak a file.
+  SD_TMPDIR=""
+  sd_tmp() {
+    if [ -z "$SD_TMPDIR" ]; then
+      SD_TMPDIR="$(mktemp -d)"
+      trap 'rm -rf -- "$SD_TMPDIR"' EXIT HUP INT TERM
+    fi
+    mktemp "$SD_TMPDIR/sd.XXXXXX"
+  }
+
   sd_diff_lines() {
     # TPL_NORM SEED_NORM MARKER; MARKER is '<' for template-only lines and '>'
     # for seed-only lines. The diff is ordered, so a pure reordering yields lines
     # under both markers rather than comparing equal.
-    local out rc=0
-    out=$(diff -- "$1" "$2") || rc=$?
+    #
+    # diff goes to a FILE, not a command substitution. A removed blank line is
+    # emitted by diff as the record `< ` (marker, space, empty text); command
+    # substitution would strip the trailing newline and sed, preserving the
+    # absent final newline, would then emit zero bytes — making a deleted blank
+    # line read as no difference at all. Via a file every record keeps its
+    # newline and the blank one survives.
+    local rc=0 raw
+    raw="$(sd_tmp)"
+    diff -- "$1" "$2" >"$raw" || rc=$?
     if [ "$rc" -gt 1 ]; then
       printf 'seed-drift: diff failed comparing %s and %s\n' "$1" "$2" >&2
       return 3
     fi
-    printf '%s' "$out" | sed -n "s/^$3 //p"
+    sed -n "s/^$3 //p" "$raw"
   }
 
+  # Takes a FILE, and counts every record including empty ones. `grep -c .`
+  # would skip exactly the blank lines this tool has to notice.
   sd_count_lines() {
-    printf '%s' "$1" | grep -c . || true
+    local n
+    n=$(wc -l <"$1")
+    printf '%s' "${n//[[:space:]]/}"
   }
   ```
 
@@ -2119,9 +2192,16 @@ produces differences in both directions and is reported `DIVERGED`.
 
   ```bash
   sd_verdict() {
-    local behind ahead
-    behind=$(sd_count_lines "$(sd_diff_lines "$1" "$2" '<')")
-    ahead=$(sd_count_lines "$(sd_diff_lines "$1" "$2" '>')")
+    # Files, not nested command substitutions: substitution both loses blank
+    # differing lines and swallows a non-zero status from sd_diff_lines, so a
+    # broken diff would silently read as `ok`.
+    local bf af behind ahead
+    bf="$(sd_tmp)"
+    af="$(sd_tmp)"
+    sd_diff_lines "$1" "$2" '<' >"$bf" || return 3
+    sd_diff_lines "$1" "$2" '>' >"$af" || return 3
+    behind=$(sd_count_lines "$bf")
+    ahead=$(sd_count_lines "$af")
     if [ "$behind" -eq 0 ] && [ "$ahead" -eq 0 ]; then
       printf 'ok\n'
     elif [ "$ahead" -eq 0 ]; then
@@ -2368,20 +2448,29 @@ replacing it.
   }
 
   sd_check_seed() {
-    local seed="$1" name rc=0 block anchor verdict tnorm snorm
+    local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
     name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
     printf '%s  %s\n' "$name" "$seed"
-    tnorm="$(mktemp)"
-    snorm="$(mktemp)"
+    # Each file is scanned exactly once. The template scan is built by sd_main
+    # and reused across every seed; the seed scan is built here, once, and
+    # reused across every block. sd_extract needs a scan path — passing "" would
+    # make awk fail to open its input on every call.
+    sscan="$(sd_tmp)"
+    if ! sd_scan "$seed" >"$sscan"; then
+      sd_report_block ERROR '(whole file)' 'seed could not be scanned'
+      sd_report_action 'check the seed parses; see catch-up-local-seed.md Step 3'
+      return 2
+    fi
+    tnorm="$(sd_tmp)"
+    snorm="$(sd_tmp)"
     while IFS=$'\t' read -r block anchor; do
-      sd_extract "$SD_TEMPLATE" "" "$anchor" >"$tnorm"
-      sd_extract "$seed" "" "$anchor" >"$snorm"
+      sd_extract "$SD_TEMPLATE" "$SD_TEMPLATE_SCAN" "$anchor" >"$tnorm" || continue
+      sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || continue
       verdict=$(sd_verdict "$tnorm" "$snorm")
       case "$verdict" in
         ok) sd_report_block ok "$block" '' ;;
       esac
     done < <(sd_parse_doc "$SD_DOC")
-    rm -f -- "$tnorm" "$snorm"
     return "$rc"
   }
 
@@ -2421,11 +2510,39 @@ replacing it.
   }
   ```
 
-  Then replace the trailing `return 0` of `sd_main` with:
+  Then replace the anchor-validation block Task 1 added to `sd_main` — from
+  `local blocks` through its closing `return 0` — with the version below. Two
+  changes: the template is scanned **once** here and reused by every seed, and
+  anchor validation now runs against the scan's `C` records instead of raw
+  `grep`.
 
   ```bash
+    local blocks name anchor absent=0
     SD_TEMPLATE="$template"
     SD_DOC="$doc"
+    SD_TEMPLATE_SCAN="$(sd_tmp)"
+    if ! sd_scan "$template" >"$SD_TEMPLATE_SCAN"; then
+      printf 'seed-drift: cannot scan template %s\n' "$template" >&2
+      return 2
+    fi
+    if ! blocks=$(sd_parse_doc "$doc"); then
+      printf 'seed-drift: no block table found in %s\n' "$doc" >&2
+      return 2
+    fi
+    while IFS=$'\t' read -r name anchor; do
+      # Against the scan, not `grep -qF "$anchor" "$template"`. Anchors name
+      # code, and the scan's C records are comment-stripped — so an anchor that
+      # survives only inside a comment now fails validation instead of passing
+      # and then extracting nothing.
+      if [ -z "$(sd_paras_with_anchor "$SD_TEMPLATE_SCAN" "$anchor")" ]; then
+        printf 'seed-drift: anchor %s (block: %s) is absent from %s\n' \
+          "$anchor" "$name" "$template" >&2
+        absent=1
+      fi
+    done <<<"$blocks"
+    if [ "$absent" -ne 0 ]; then
+      return 2
+    fi
     sd_visit_candidates
     sd_summary
     return "$SD_WORST"
@@ -2515,20 +2632,52 @@ replacing it.
 
   ```bash
     while IFS=$'\t' read -r block anchor; do
-      if ! sd_extract "$SD_TEMPLATE" "" "$anchor" >"$tnorm"; then
-        sd_report_block ERROR "$block" 'anchor absent from template'
+      # Branch on the ORIGINAL status. sd_extract returns 4 for "anchor absent"
+      # and 3 for "the block would not parse"; `if ! sd_extract` flattens both
+      # into one branch, so a seed whose block is unextractable would be
+      # reported as MISSING and exit 1 — a wrong verdict at the wrong severity.
+      tst=0
+      sd_extract "$SD_TEMPLATE" "$SD_TEMPLATE_SCAN" "$anchor" >"$tnorm" || tst=$?
+      case "$tst" in
+        0) ;;
+        4)
+          sd_report_block ERROR "$block" 'anchor absent from template'
+          rc=2
+          continue
+          ;;
+        *)
+          sd_report_block ERROR "$block" 'template block could not be extracted'
+          rc=2
+          continue
+          ;;
+      esac
+      est=0
+      sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || est=$?
+      case "$est" in
+        0) ;;
+        4)
+          sd_report_block MISSING "$block" 'anchor absent from seed'
+          sd_report_action 'port the block; see catch-up-local-seed.md Step 2'
+          SD_MISSING=$((SD_MISSING + 1))
+          [ "$rc" -ge 1 ] || rc=1
+          continue
+          ;;
+        *)
+          sd_report_block ERROR "$block" 'seed block could not be extracted'
+          rc=2
+          continue
+          ;;
+      esac
+      # Same file-not-substitution rule as sd_verdict: a removed blank line must
+      # survive into the count and the samples.
+      behind="$(sd_tmp)"
+      ahead="$(sd_tmp)"
+      if ! sd_diff_lines "$tnorm" "$snorm" '<' >"$behind" ||
+        ! sd_diff_lines "$tnorm" "$snorm" '>' >"$ahead"; then
+        sd_report_block ERROR "$block" 'diff failed'
         rc=2
         continue
       fi
-      if ! sd_extract "$seed" "" "$anchor" >"$snorm"; then
-        sd_report_block MISSING "$block" 'anchor absent from seed'
-        sd_report_action 'port the block; see catch-up-local-seed.md Step 2'
-        SD_MISSING=$((SD_MISSING + 1))
-        [ "$rc" -ge 1 ] || rc=1
-        continue
-      fi
-      behind=$(sd_diff_lines "$tnorm" "$snorm" '<')
-      ahead=$(sd_diff_lines "$tnorm" "$snorm" '>')
       nb=$(sd_count_lines "$behind")
       na=$(sd_count_lines "$ahead")
       verdict=$(sd_verdict "$tnorm" "$snorm")
@@ -2538,14 +2687,14 @@ replacing it.
           ;;
         BEHIND)
           sd_report_block BEHIND "$block" "$nb template lines absent from seed"
-          printf '%s\n' "$behind" | sd_report_samples
+          sd_report_samples <"$behind"
           sd_report_action 'port from template; see catch-up-local-seed.md Step 2'
           SD_BEHIND=$((SD_BEHIND + 1))
           [ "$rc" -ge 1 ] || rc=1
           ;;
         AHEAD)
           sd_report_block AHEAD "$block" "$na seed lines absent from template"
-          printf '%s\n' "$ahead" | sd_report_samples
+          sd_report_samples <"$ahead"
           sd_report_action 'promotion candidate; do NOT overwrite the seed'
           SD_AHEAD=$((SD_AHEAD + 1))
           [ "$rc" -ge 1 ] || rc=1
@@ -2564,7 +2713,8 @@ replacing it.
   and widen the function's `local` line to declare the new variables:
 
   ```bash
-    local seed="$1" name rc=0 block anchor verdict tnorm snorm behind ahead nb na
+    local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
+    local behind ahead nb na est tst
   ```
 
 - [ ] **Step 9: run them and see them pass.**
@@ -2790,6 +2940,70 @@ t7_run() {
   run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC" "$@"
 }
 ```
+
+- [ ] **Step 1b: regression tests for the six integration defects.**
+
+These four pin bugs that a plan review caught before implementation. Each one
+fails *silently* if reintroduced — wrong verdict or false `ok`, never a crash —
+so they are the tests most worth having. Append to `tests/seed_drift.bats`:
+
+```bash
+@test "a tab inside a heredoc payload survives extraction verbatim" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  printf '#!/usr/bin/env bash\n\ntee "$G" <<%s\n\tcol1\tcol2\nGITEOF\n\ngit config --global core.excludesFile "$G"\n' "'GITEOF'" >"$TPL"
+  # Seed differs ONLY by collapsing the payload tabs to spaces.
+  printf '#!/usr/bin/env bash\n\ntee "$G" <<%s\n  col1  col2\nGITEOF\n\ngit config --global core.excludesFile "$G"\n' "'GITEOF'" >"$SEED"
+
+  t7_run
+  # If the reader strips or truncates tabs, both sides normalize alike and this
+  # reports ok — the exact false-clean the tool exists to prevent.
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "sd_count_lines counts blank records" {
+  printf '\n\na\n' >"$BATS_TEST_TMPDIR/three"
+  sd_source sd_count_lines "$BATS_TEST_TMPDIR/three"
+  [ "$status" -eq 0 ]
+  [ "$output" = 3 ]
+}
+
+@test "a seed block that cannot be extracted is ERROR and exit 2, not MISSING" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  printf '#!/usr/bin/env bash\n\ninstall_ts "$TREE_SITTER_VERSION"\n' >"$TPL"
+  # Anchor present, but no window around it ever parses: the `do` is never
+  # closed anywhere in the file, so sd_window exhausts both directions.
+  printf '#!/usr/bin/env bash\n\nfor x in a b; do\n  install_ts "$TREE_SITTER_VERSION"\n' >"$SEED"
+
+  t7_run
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  # The bug this pins: `if ! sd_extract` collapsed 3 and 4, reporting a seed
+  # that will not parse as merely behind the template.
+  [[ "$output" != *MISSING* ]]
+}
+
+@test "an anchor present only in a template comment fails validation" {
+  t7_setup
+  t7_doc "codex guard" local/bin/codex
+  printf '#!/usr/bin/env bash\n\n# once guarded local/bin/codex, now removed\necho hi\n' >"$TPL"
+  printf '#!/usr/bin/env bash\n\necho hi\n' >"$SEED"
+
+  t7_run
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"is absent from"* ]]
+}
+```
+
+- [ ] **Step 1c: run them and watch them fail for the right reason.**
+
+`bats tests/seed_drift.bats -f 'tab inside|blank records|cannot be extracted|only in a template comment'`
+
+Expected: four `not ok`. Confirm each fails on its assertion rather than on a
+missing function — if `sd_count_lines` reports `command not found`, Task 5 was
+not completed.
 
 - [ ] **Step 2: the MOTIVATING test — anchor present, surrounding block outdated.**
 

--- a/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
+++ b/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
@@ -1,7 +1,7 @@
 # Seed Drift Detector Implementation Plan
 
 > **Historical record — superseded in part. Not a description of the shipped tool.**
-> This plan is kept as written so the design history stays legible. Two things
+> This plan is kept as written so the design history stays legible. Three things
 > it specifies were changed during implementation, on evidence gathered after it
 > was written:
 >
@@ -11,6 +11,11 @@
 >    per-file asymmetry, blindness to a seed that *replaces* rather than omits
 >    the idiom, and `diff` hunk adjacency.
 > 2. **A thin-window warning was added**, which this plan does not mention.
+> 3. **`bin/list-check-files` was changed after all.** The two constraints below
+>    stating that no `bin/list-check-files` change is required and that `.bats`
+>    files are emitted for neither linter are both superseded: the shfmt class
+>    now emits `tests/*.bats`. `bash`, `shellcheck`, and `zsh` still exclude
+>    them — neither `bash -n` nor shellcheck parses `@test` syntax.
 >
 > For what the tool actually does, read
 > `docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md` — that spec

--- a/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
+++ b/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
@@ -1,5 +1,21 @@
 # Seed Drift Detector Implementation Plan
 
+> **Historical record — superseded in part. Not a description of the shipped tool.**
+> This plan is kept as written so the design history stays legible. Two things
+> it specifies were changed during implementation, on evidence gathered after it
+> was written:
+>
+> 1. **The ownership-verification special case (`SD_OWNERSHIP_DROP` and friends,
+>    described around lines 1531 and 1899-1919) was removed entirely.** It was
+>    measured to change no verdict on the real corpus, and it failed three ways:
+>    per-file asymmetry, blindness to a seed that *replaces* rather than omits
+>    the idiom, and `diff` hunk adjacency.
+> 2. **A thin-window warning was added**, which this plan does not mention.
+>
+> For what the tool actually does, read
+> `docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md` — that spec
+> is the live document and was amended as these decisions were taken.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build `bin/seed-drift`, which compares each project's gitignored `.devcontainer/local-seed.sh` against the `project-claude-setup` template at block granularity and exits non-zero when any block has drifted.

--- a/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
+++ b/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
@@ -59,7 +59,9 @@ para <TAB> lineno <TAB> tag <TAB> text
 | `sd_window FILE SCAN PARA` | `start end`, grown until it parses; exit 3 if it never does |
 | `sd_normalize` | filter: scan format on stdin -> normalized text lines on stdout |
 | `sd_extract FILE SCAN ANCHOR` | normalized lines for the union of windows, file order, deduped; exit 4 if the anchor is absent |
-| `sd_verdict TPL_NORM SEED_NORM` | prints `ok` \| `BEHIND` \| `AHEAD` \| `DIVERGED` |
+| `sd_tmp VARNAME` | assigns a fresh temp-file path to VARNAME in the caller's scope; exit 3 if `mktemp` fails. **Never** call as `$(sd_tmp)` — see Task 5 |
+| `sd_verdict_from_counts NB NA` | prints `ok` \| `BEHIND` \| `AHEAD` \| `DIVERGED` from two difference counts; cannot fail |
+| `sd_verdict TPL_NORM SEED_NORM` | prints `ok` \| `BEHIND` \| `AHEAD` \| `DIVERGED`; exit 3 if `diff` fails |
 | `sd_check_seed SEED` | per-block report; returns 0 clean / 1 drift / 2 error |
 
 Exit codes 3 and 4 are internal to helpers so they never collide with the
@@ -135,7 +137,7 @@ it runs the full detector before the function under test is even called.
 - `bin/seed-drift [--template PATH] [--doc PATH] [--help] [CANDIDATE...]` — `--help` prints usage on **stdout**, exit 0. Unknown flag, a flag missing its value, an unreadable `--template`, an unreadable `--doc`, a doc with no block table, or a doc anchor absent from the template all print to **stderr** and exit **2**.
 - `sd_parse_doc DOCFILE` — stdout, one line per table row: `blockname<TAB>anchor`. Backticks are stripped from *both* fields; the anchor keeps its inner quotes and asterisks verbatim (row 2 is exactly `Overlay-link gitignore<TAB>lname '*dotfiles/projects/*'`). Returns 3 if `DOCFILE` is unreadable, 1 if the file holds no table rows.
 - `SD_TEMPLATE_DEFAULT`, `SD_DOC_DEFAULT` — absolute paths resolved from `${BASH_SOURCE[0]}`, so the script works from any cwd.
-- `SD_CANDIDATES` — global array holding the positional arguments after flag parsing. Task 6 (discovery) reads this.
+- `SD_CANDIDATES` — global array holding the positional arguments after flag parsing. Task 6 (discovery) reads this. `SD_CANDIDATE_COUNT` — scalar count of the same, incremented alongside every push. Task 6 branches on the scalar: `${#SD_CANDIDATES[@]}` on an empty array is exactly the `set -u` / bash 3.2 hazard `bin/common.sh:392` documents.
 - `SEED_DRIFT_SOURCE_ONLY=1` — sourcing guard (repo convention, mirrors `INSTALL_SOURCE_ONLY` in `bin/install`). When set, sourcing `bin/seed-drift` defines the functions without running `sd_main`. Every unit test in `tests/seed_drift.bats` uses the `sd_source` helper this task adds.
 
 All commands run from the repo root `/home/tng/.dotfiles/.claude/worktrees/seed-drift-detector`.
@@ -249,6 +251,10 @@ SDUSAGE
 sd_main() {
   local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
   SD_CANDIDATES=()
+  # Counted alongside the array because Task 6 must ask "were any candidates
+  # given?" without expanding an empty array under `set -u` — the bash 3.2
+  # pitfall bin/common.sh:392 calls out. macOS ships bash 3.2.
+  SD_CANDIDATE_COUNT=0
   while [ $# -gt 0 ]; do
     case "$1" in
       --template | --doc)
@@ -267,6 +273,7 @@ sd_main() {
       --)
         shift
         SD_CANDIDATES+=("$@")
+        SD_CANDIDATE_COUNT=$((SD_CANDIDATE_COUNT + $#))
         break
         ;;
       -*)
@@ -276,6 +283,7 @@ sd_main() {
         ;;
       *)
         SD_CANDIDATES+=("$1")
+        SD_CANDIDATE_COUNT=$((SD_CANDIDATE_COUNT + 1))
         shift
         ;;
     esac
@@ -1658,13 +1666,21 @@ sd_drop_priv_prefix() {
   # wanderer-kills writes `if ! as_user test -f "$GITIGNORE"; then` where
   # wanderer writes `if [ ! -f "$GITIGNORE" ]; then` — so a line-start-only
   # rule would report every one of those shapes as drift.
+  #
+  # No `\b`: that boundary is a GNU extension and this script must also run
+  # under the BSD sed macOS ships. Operators are self-delimiting, so they need
+  # no boundary; the keywords take an explicit `(^|[[:space:]])` left boundary
+  # instead, which is why they are a separate expression. `sd_normalize_code_line`
+  # has already collapsed runs of whitespace to single spaces before we get here.
   local line="$1" prev=""
   while [ "$line" != "$prev" ]; do
     prev="$line"
     line=$(printf '%s\n' "$line" | sed -E \
-      -e 's/(^|[{(|;!]|&&|\|\||\bif|\bthen|\bwhile|\buntil|\bdo|\belif)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2/g' \
+      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2/g' \
+      -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2\3/g' \
       -e 's/^(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+//' \
-      -e 's/(^|[{(|;!]|&&|\|\||\bif|\bthen|\bwhile|\buntil|\bdo|\belif)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2/g' \
+      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2/g' \
+      -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2\3/g' \
       -e 's/^runuser -u [^[:space:]]+ --[[:space:]]+//')
   done
   printf '%s' "$line"
@@ -2048,9 +2064,17 @@ produces differences in both directions and is reported `DIVERGED`.
 - `sd_diff_lines TPL_NORM SEED_NORM MARKER` → the differing lines, one per line,
   on stdout. `MARKER` is `<` for template-only lines and `>` for seed-only lines.
   Returns `3` if `diff` fails for a reason other than "files differ".
-- `sd_count_lines TEXT` → the number of non-empty lines in `TEXT`, on stdout.
-- `sd_verdict TPL_NORM SEED_NORM` → exactly one of `ok`, `BEHIND`, `AHEAD`,
-  `DIVERGED` on stdout, exit `0`.
+- `sd_tmp VARNAME` → assigns a fresh temp-file path to `VARNAME` in the caller's
+  scope (via `printf -v`, not stdout), exit `3` if `mktemp` fails. The whole run
+  shares one directory, removed by a single trap. Never call it inside a command
+  substitution — the subshell would take the directory and the trap with it.
+- `sd_count_lines FILE` → the number of records in `FILE`, on stdout, blank
+  records included.
+- `sd_verdict_from_counts NB NA` → exactly one of `ok`, `BEHIND`, `AHEAD`,
+  `DIVERGED` on stdout, exit `0`. Pure: it cannot fail, which is why callers
+  holding the counts use it instead of `sd_verdict`.
+- `sd_verdict TPL_NORM SEED_NORM` → the same four tokens on stdout, exit `0`;
+  exit `3` if `diff` fails.
 
 ---
 
@@ -2090,12 +2114,22 @@ produces differences in both directions and is reported `DIVERGED`.
   # One temp dir for the whole run, removed by a single trap. Callers never
   # clean up individually, so no early `return` can leak a file.
   SD_TMPDIR=""
+
+  # sd_tmp VARNAME — assigns a fresh temp file path to VARNAME in the CALLER's
+  # scope, and must never be called inside a command substitution. `$(sd_tmp)`
+  # runs in a subshell: the subshell creates the directory, installs the EXIT
+  # trap, prints the path, and then — on subshell exit — fires that trap and
+  # `rm -rf`s the directory before the caller can write a single byte. The
+  # directory and its trap have to be established in the shell that will
+  # actually use them, so the path comes back through `printf -v`, not stdout.
   sd_tmp() {
+    local __sd_new
     if [ -z "$SD_TMPDIR" ]; then
-      SD_TMPDIR="$(mktemp -d)"
+      SD_TMPDIR="$(mktemp -d)" || return 3
       trap 'rm -rf -- "$SD_TMPDIR"' EXIT HUP INT TERM
     fi
-    mktemp "$SD_TMPDIR/sd.XXXXXX"
+    __sd_new="$(mktemp "$SD_TMPDIR/sd.XXXXXX")" || return 3
+    printf -v "$1" '%s' "$__sd_new"
   }
 
   sd_diff_lines() {
@@ -2110,7 +2144,7 @@ produces differences in both directions and is reported `DIVERGED`.
     # line read as no difference at all. Via a file every record keeps its
     # newline and the blank one survives.
     local rc=0 raw
-    raw="$(sd_tmp)"
+    sd_tmp raw || return 3
     diff -- "$1" "$2" >"$raw" || rc=$?
     if [ "$rc" -gt 1 ]; then
       printf 'seed-drift: diff failed comparing %s and %s\n' "$1" "$2" >&2
@@ -2191,26 +2225,36 @@ produces differences in both directions and is reported `DIVERGED`.
   two-direction case, and an unclassified pair must never fall through to `ok`:
 
   ```bash
+  # Pure classifier: given the two difference counts, name the direction. Split
+  # out from sd_verdict so a caller that already holds the counts can name the
+  # verdict without re-running diff — and, more importantly, without the
+  # `verdict=$(sd_verdict ...)` form, whose non-zero status aborts the whole
+  # program under `set -e` and skips every project after it.
+  sd_verdict_from_counts() {
+    # BEHIND_COUNT AHEAD_COUNT
+    if [ "$1" -eq 0 ] && [ "$2" -eq 0 ]; then
+      printf 'ok\n'
+    elif [ "$2" -eq 0 ]; then
+      printf 'BEHIND\n'
+    elif [ "$1" -eq 0 ]; then
+      printf 'AHEAD\n'
+    else
+      return 1
+    fi
+  }
+
   sd_verdict() {
     # Files, not nested command substitutions: substitution both loses blank
     # differing lines and swallows a non-zero status from sd_diff_lines, so a
     # broken diff would silently read as `ok`.
     local bf af behind ahead
-    bf="$(sd_tmp)"
-    af="$(sd_tmp)"
+    sd_tmp bf || return 3
+    sd_tmp af || return 3
     sd_diff_lines "$1" "$2" '<' >"$bf" || return 3
     sd_diff_lines "$1" "$2" '>' >"$af" || return 3
     behind=$(sd_count_lines "$bf")
     ahead=$(sd_count_lines "$af")
-    if [ "$behind" -eq 0 ] && [ "$ahead" -eq 0 ]; then
-      printf 'ok\n'
-    elif [ "$ahead" -eq 0 ]; then
-      printf 'BEHIND\n'
-    elif [ "$behind" -eq 0 ]; then
-      printf 'AHEAD\n'
-    else
-      return 1
-    fi
+    sd_verdict_from_counts "$behind" "$ahead"
   }
   ```
 
@@ -2266,7 +2310,7 @@ produces differences in both directions and is reported `DIVERGED`.
   pure reordering.
 
 - [ ] **Step 13: implement the DIVERGED branch.**
-  In `bin/seed-drift`, replace the `else` branch of `sd_verdict`:
+  In `bin/seed-drift`, replace the `else` branch of `sd_verdict_from_counts`:
 
   ```bash
     else
@@ -2300,10 +2344,16 @@ replacing it.
 *Consumes*
 - `sd_parse_doc DOCFILE` (Task 1) → `blockname<TAB>anchor`, one row per line.
 - `sd_extract FILE SCAN ANCHOR` (Task 4) → normalized lines on stdout; exit `4`
-  when the anchor is absent.
-- `sd_verdict TPL_NORM SEED_NORM`, `sd_diff_lines`, `sd_count_lines` (Task 5).
-- `SD_CANDIDATES` (bash array, set by Task 1's option parser), `SEED_DRIFT_ROOT`
-  (default `$HOME/workspace`).
+  when the anchor is absent, `3` when no window around it parses. Branch on the
+  two separately: `4` is MISSING (exit 1), `3` is ERROR (exit 2).
+- `sd_verdict_from_counts NB NA`, `sd_diff_lines`, `sd_count_lines`, `sd_tmp`
+  (Task 5). Use `sd_verdict_from_counts` on counts you already hold rather than
+  `verdict=$(sd_verdict ...)`, whose failure status would abort the run under
+  `set -e`. Call `sd_tmp NAME`, never `$(sd_tmp)`.
+- `SD_CANDIDATES` (bash array) and `SD_CANDIDATE_COUNT` (scalar), both set by
+  Task 1's option parser; `SEED_DRIFT_ROOT` (default `$HOME/workspace`). Branch
+  on the scalar — `${#SD_CANDIDATES[@]}` on an empty array is the bash 3.2
+  `set -u` hazard documented at `bin/common.sh:392`.
 
 *Produces*
 - `sd_check_seed SEED` → per-block report on stdout; returns `0` clean, `1` any
@@ -2454,19 +2504,20 @@ replacing it.
     # Each file is scanned exactly once. The template scan is built by sd_main
     # and reused across every seed; the seed scan is built here, once, and
     # reused across every block. sd_extract needs a scan path — passing "" would
-    # make awk fail to open its input on every call.
-    sscan="$(sd_tmp)"
+    # make awk fail to open its input on every call. `sd_tmp NAME`, never
+    # `$(sd_tmp)`: the subshell form deletes the temp dir on subshell exit.
+    sd_tmp sscan || return 2
     if ! sd_scan "$seed" >"$sscan"; then
       sd_report_block ERROR '(whole file)' 'seed could not be scanned'
       sd_report_action 'check the seed parses; see catch-up-local-seed.md Step 3'
       return 2
     fi
-    tnorm="$(sd_tmp)"
-    snorm="$(sd_tmp)"
+    sd_tmp tnorm || return 2
+    sd_tmp snorm || return 2
     while IFS=$'\t' read -r block anchor; do
       sd_extract "$SD_TEMPLATE" "$SD_TEMPLATE_SCAN" "$anchor" >"$tnorm" || continue
       sd_extract "$seed" "$sscan" "$anchor" >"$snorm" || continue
-      verdict=$(sd_verdict "$tnorm" "$snorm")
+      verdict=$(sd_verdict "$tnorm" "$snorm") || continue
       case "$verdict" in
         ok) sd_report_block ok "$block" '' ;;
       esac
@@ -2520,7 +2571,11 @@ replacing it.
     local blocks name anchor absent=0
     SD_TEMPLATE="$template"
     SD_DOC="$doc"
-    SD_TEMPLATE_SCAN="$(sd_tmp)"
+    SD_TEMPLATE_SCAN=""
+    if ! sd_tmp SD_TEMPLATE_SCAN; then
+      printf 'seed-drift: cannot create a temporary file\n' >&2
+      return 2
+    fi
     if ! sd_scan "$template" >"$SD_TEMPLATE_SCAN"; then
       printf 'seed-drift: cannot scan template %s\n' "$template" >&2
       return 2
@@ -2670,8 +2725,8 @@ replacing it.
       esac
       # Same file-not-substitution rule as sd_verdict: a removed blank line must
       # survive into the count and the samples.
-      behind="$(sd_tmp)"
-      ahead="$(sd_tmp)"
+      sd_tmp behind || return 2
+      sd_tmp ahead || return 2
       if ! sd_diff_lines "$tnorm" "$snorm" '<' >"$behind" ||
         ! sd_diff_lines "$tnorm" "$snorm" '>' >"$ahead"; then
         sd_report_block ERROR "$block" 'diff failed'
@@ -2680,7 +2735,11 @@ replacing it.
       fi
       nb=$(sd_count_lines "$behind")
       na=$(sd_count_lines "$ahead")
-      verdict=$(sd_verdict "$tnorm" "$snorm")
+      # From the counts just computed, not `verdict=$(sd_verdict ...)`: that
+      # form re-runs the same two diffs, and its non-zero status on a diff
+      # failure would abort the program under `set -e` — exiting 3 outside the
+      # public 0/1/2 contract and skipping every remaining project.
+      verdict=$(sd_verdict_from_counts "$nb" "$na")
       case "$verdict" in
         ok)
           sd_report_block ok "$block" ''
@@ -2765,7 +2824,11 @@ replacing it.
   ```bash
   sd_visit_candidates() {
     local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand rc=0
-    if [ "${#SD_CANDIDATES[@]}" -eq 0 ]; then
+    # The scalar, not `${#SD_CANDIDATES[@]}`: expanding an empty array under
+    # `set -u` errors on bash 3.2, still the system bash on macOS
+    # (bin/common.sh:392). The `"${SD_CANDIDATES[@]}"` below is reached only
+    # when the count is non-zero, so it is safe.
+    if [ "$SD_CANDIDATE_COUNT" -eq 0 ]; then
       shopt -s nullglob
       for cand in "$root"/*/; do
         cand="${cand%/}"
@@ -2943,8 +3006,8 @@ t7_run() {
 
 - [ ] **Step 1b: regression tests for the six integration defects.**
 
-These four pin bugs that a plan review caught before implementation. Each one
-fails *silently* if reintroduced — wrong verdict or false `ok`, never a crash —
+These pin bugs that plan reviews caught before implementation. Most of them
+fail *silently* if reintroduced — wrong verdict or false `ok`, never a crash —
 so they are the tests most worth having. Append to `tests/seed_drift.bats`:
 
 ```bash
@@ -2969,6 +3032,21 @@ so they are the tests most worth having. Append to `tests/seed_drift.bats`:
   [ "$output" = 3 ]
 }
 
+@test "a temp file from sd_tmp is still writable after the call returns" {
+  # `raw="$(sd_tmp)"` ran the whole thing in a subshell: the directory and its
+  # EXIT trap were created there, so the trap fired the moment the substitution
+  # closed and deleted the directory before the caller could write to the path
+  # it had just been handed. Every diff in the tool wrote into thin air.
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    sd_tmp f || exit 9
+    printf hello >"$f" || exit 8
+    cat "$f"
+  ' _ "$SEED_DRIFT"
+  [ "$status" -eq 0 ]
+  [ "$output" = hello ]
+}
+
 @test "a seed block that cannot be extracted is ERROR and exit 2, not MISSING" {
   t7_setup
   t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
@@ -2983,6 +3061,47 @@ so they are the tests most worth having. Append to `tests/seed_drift.bats`:
   # The bug this pins: `if ! sd_extract` collapsed 3 and 4, reporting a seed
   # that will not parse as merely behind the template.
   [[ "$output" != *MISSING* ]]
+}
+
+@test "sd_extract returns 3, not 4, when no window around the anchor parses" {
+  # The integration test above stops at sd_check_seed's whole-file `bash -n`
+  # gate and never reaches sd_extract, so it cannot tell 3 from 4 at the
+  # helper level. This does, by calling sd_extract directly. Since sd_window
+  # grows to the whole file before giving up, only a file that itself fails to
+  # parse can produce status 3 — hence the same unclosed `do`.
+  printf '#!/usr/bin/env bash\n\nfor x in a b; do\n  install_ts "$TREE_SITTER_VERSION"\n' \
+    >"$FIX/bad.sh"
+  sd_source sd_scan "$FIX/bad.sh"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" >"$FIX/bad.scan"
+
+  sd_source sd_extract "$FIX/bad.sh" "$FIX/bad.scan" TREE_SITTER_VERSION
+  [ "$status" -eq 3 ]
+
+  # And 4 really is reserved for the absent anchor, on the same inputs.
+  sd_source sd_extract "$FIX/bad.sh" "$FIX/bad.scan" NVIM_VERSION
+  [ "$status" -eq 4 ]
+}
+
+@test "privilege normalization is portable and keyword-boundary correct" {
+  # `\b` is a GNU sed extension; BSD sed (macOS, which this script supports)
+  # silently fails to match it, so every `if as_user ...` line would keep its
+  # privilege word and report as drift on a Mac and clean on Linux.
+  run grep -n '\\b' "$SEED_DRIFT"
+  [ "$status" -ne 0 ]
+
+  scan_line 1 1 C 'if as_user test -x /x; then'
+  scan_line 1 2 C 'foo || $SUDO chmod 0755 /x'
+  scan_line 1 3 C 'do runuser -u me -- npm i'
+  # The boundary the `\b` used to provide: a word merely ENDING in a keyword
+  # must not license the drop.
+  scan_line 1 4 C 'notif as_user keepme'
+  norm
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = 'if test -x /x; then' ]
+  [ "${lines[1]}" = 'foo || chmod 0755 /x' ]
+  [ "${lines[2]}" = 'do npm i' ]
+  [ "${lines[3]}" = 'notif as_user keepme' ]
 }
 
 @test "an anchor present only in a template comment fails validation" {

--- a/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
+++ b/docs/superpowers/plans/2026-08-03-seed-drift-detector.md
@@ -1,0 +1,3578 @@
+# Seed Drift Detector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `bin/seed-drift`, which compares each project's gitignored `.devcontainer/local-seed.sh` against the `project-claude-setup` template at block granularity and exits non-zero when any block has drifted.
+
+**Architecture:** A single self-contained Bash executable, following the repository's `bin/` convention. It parses the block table in `catch-up-local-seed.md` for anchors, so the documented model and the executable one cannot disagree. For each anchor it extracts the surrounding block from both files using a heredoc-aware paragraph scanner whose windows are grown until the extracted fragment parses under `bash -n`, normalizes away the known vocabulary differences between seeds while leaving heredoc payloads verbatim, and reports an order-preserving diff (Decision 1) as `ok` / `MISSING` / `BEHIND` / `AHEAD` / `DIVERGED`.
+
+**Tech Stack:** Bash 5, awk (the scanner), `diff`, `bats` for tests. No new dependencies.
+
+**Design spec:** `docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md`. Read it before starting; every decision below traces to a numbered Decision in that document.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `bin/seed-drift` (create) | The whole detector, sectioned: doc-table parsing, scanner, extraction, normalization, verdicts, discovery/reporting. Standalone, matching `bin/list-check-files`; the repo has no shared library for this and `bin/vekil-proxy` is 939 lines, so one file is idiomatic. |
+| `tests/seed_drift.bats` (create) | The full suite, fixture-driven. Never reads the real `~/workspace`. |
+| `bin/list-check-files` | **Unchanged.** Verified against a stub: `is_direct_bin_shell` already emits `bin/seed-drift` for both the `shellcheck` and `shfmt` classes. |
+
+### Why one file
+
+Each section has a clear boundary and the functions are pure filters with fixed
+stdout formats (see the interface contract in each task), so the units are
+independently testable even though they share a file. Splitting into a `lib/`
+would be the only instance of that pattern in the repository.
+
+---
+
+## Interface Contract
+
+Every task honors this. It is fixed; do not renegotiate it mid-implementation.
+
+**Scan format** — the scanner is the single source of truth for structure. Every
+consumer reads this 4-field, TAB-separated format, `text` last:
+
+```
+para <TAB> lineno <TAB> tag <TAB> text
+```
+
+- `para` — 1-based paragraph index (blank-line delimited, heredoc-aware)
+- `lineno` — 1-based line number in the source file
+- `tag` — `C` shell code (text is comment-stripped, may be empty) / `Hq` heredoc
+  body with a quoted delimiter (literal) / `Hu` heredoc body with an unquoted
+  delimiter (shell expands it). Heredoc delimiter lines themselves are `C`.
+- `text` — comment-stripped for `C`; **verbatim** for `Hq` and `Hu`
+
+**Functions**
+
+| Signature | Returns |
+|---|---|
+| `sd_scan FILE` | scan format on stdout; exit 3 on unrecognized `<<` |
+| `sd_parse_doc DOCFILE` | `blockname<TAB>anchor` per table row (Decision 2) |
+| `sd_paras_with_anchor SCAN ANCHOR` | paragraph indices, one per line (fixed-string match, `C` text only) |
+| `sd_para_range SCAN PARA` | `start end` file line numbers |
+| `sd_window FILE SCAN PARA` | `start end`, grown until it parses; exit 3 if it never does |
+| `sd_normalize` | filter: scan format on stdin -> normalized text lines on stdout |
+| `sd_extract FILE SCAN ANCHOR` | normalized lines for the union of windows, file order, deduped; exit 4 if the anchor is absent |
+| `sd_verdict TPL_NORM SEED_NORM` | prints `ok` \| `BEHIND` \| `AHEAD` \| `DIVERGED` |
+| `sd_check_seed SEED` | per-block report; returns 0 clean / 1 drift / 2 error |
+
+Exit codes 3 and 4 are internal to helpers so they never collide with the
+program's own 0/1/2.
+
+**CLI**
+
+```
+bin/seed-drift [--template PATH] [--doc PATH] [--help] [CANDIDATE...]
+env SEED_DRIFT_ROOT   default "$HOME/workspace"
+```
+
+`--template` and `--doc` exist so the suite can point at fixtures.
+
+**Sourcing guard.** Every test reaches the helper functions by sourcing
+`bin/seed-drift`, so main must not run on source. Use the repository's existing
+convention (`bin/bootstrap`, `bin/install`, `bin/vekil-proxy`, consumed by
+`tests/link_reconciliation.bats` and `tests/font_install.bats`) rather than a
+`BASH_SOURCE` comparison — the env-var form is what the suite already knows how
+to drive. The bottom of the file is:
+
+```bash
+if [[ "${SEED_DRIFT_SOURCE_ONLY:-0}" != 1 ]]; then
+  sd_main "$@"
+fi
+```
+
+Every source site in the tests **must** set `SEED_DRIFT_SOURCE_ONLY=1`. Omitting
+it runs the full detector before the function under test is even called.
+
+**Paragraph indices** are contiguous and 1-based.
+
+---
+
+## Global Constraints
+
+- `bin/seed-drift` is `shfmt -i 2 -ci` clean — verified by `bin/list-check-files shfmt | xargs -0 shfmt -d -i 2 -ci` (the `lint` target).
+- `bin/seed-drift` is `shellcheck -x -S warning -e SC1091` clean — verified by `bin/list-check-files shellcheck | xargs -0 shellcheck -x -S warning -e SC1091` (the `lint` target).
+- `bin/seed-drift` is executable (`chmod +x`) and lives directly in `bin/` with no extension.
+- Auto-discovery is already handled: `is_direct_bin_shell` in `bin/list-check-files:26-31` matches `bin/*` paths with no `/` after `bin/` and either no `.` or a `.sh` suffix, and it is applied by the `bash`, `shellcheck`, and `shfmt` cases (lines 54, 60, 63). `bin/seed-drift` matches, so **no `bin/list-check-files` change is required**.
+- `.bats` files are emitted for neither linter (`shfmt` takes only `tests/test_helper.bash`), so `tests/seed_drift.bats` is unlinted. That gap is deliberate, consistent with all 22 existing suites, and is left alone.
+- The detector is strictly **READ-ONLY**: seeds are gitignored, hand-owned files with no `git diff` and no revert path. Nothing in `bin/seed-drift` may open a seed for writing.
+- `SEED_VERSION` must never be compared, and must never appear as an anchor or in a comparison path.
+- `command make check` must pass — it runs `syntax lint test python-test validate`; baseline before this work is **323 passing bats tests**.
+- All bats tests use fixture `--template` / `--doc` files and a fixture `SEED_DRIFT_ROOT`; no test may depend on the real `~/workspace`.
+- `make` is shadowed by a zsh function in this environment; every make invocation is written `command make`.
+
+---
+
+---
+
+### Task 1: CLI skeleton, doc table parsing, template anchor validation
+
+**Files:**
+- Create: `bin/seed-drift` (executable, `chmod +x`)
+- Create: `tests/seed_drift.bats`
+
+**Interfaces:**
+
+*Consumes:* nothing — this is the first task.
+
+*Produces:*
+- `bin/seed-drift [--template PATH] [--doc PATH] [--help] [CANDIDATE...]` — `--help` prints usage on **stdout**, exit 0. Unknown flag, a flag missing its value, an unreadable `--template`, an unreadable `--doc`, a doc with no block table, or a doc anchor absent from the template all print to **stderr** and exit **2**.
+- `sd_parse_doc DOCFILE` — stdout, one line per table row: `blockname<TAB>anchor`. Backticks are stripped from *both* fields; the anchor keeps its inner quotes and asterisks verbatim (row 2 is exactly `Overlay-link gitignore<TAB>lname '*dotfiles/projects/*'`). Returns 3 if `DOCFILE` is unreadable, 1 if the file holds no table rows.
+- `SD_TEMPLATE_DEFAULT`, `SD_DOC_DEFAULT` — absolute paths resolved from `${BASH_SOURCE[0]}`, so the script works from any cwd.
+- `SD_CANDIDATES` — global array holding the positional arguments after flag parsing. Task 6 (discovery) reads this.
+- `SEED_DRIFT_SOURCE_ONLY=1` — sourcing guard (repo convention, mirrors `INSTALL_SOURCE_ONLY` in `bin/install`). When set, sourcing `bin/seed-drift` defines the functions without running `sd_main`. Every unit test in `tests/seed_drift.bats` uses the `sd_source` helper this task adds.
+
+All commands run from the repo root `/home/tng/.dotfiles/.claude/worktrees/seed-drift-detector`.
+
+---
+
+- [ ] **Step 1: Write the failing CLI tests.**
+
+Create `tests/seed_drift.bats`:
+
+```bash
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  SEED_DRIFT="$REPO_ROOT/bin/seed-drift"
+  SKILL_DIR="$REPO_ROOT/ai/marketplace/plugins/my/skills/project-claude-setup"
+  REAL_TEMPLATE="$SKILL_DIR/templates/local-seed.sh"
+  REAL_DOC="$SKILL_DIR/catch-up-local-seed.md"
+  FIX="$BATS_TEST_TMPDIR/fix"
+  mkdir -p "$FIX"
+}
+
+sd_source() {
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    shift
+    "$@"
+  ' _ "$SEED_DRIFT" "$@"
+}
+
+@test "seed-drift --help prints usage and exits 0" {
+  run "$SEED_DRIFT" --help
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: bin/seed-drift"* ]]
+}
+
+@test "seed-drift rejects an unknown flag with usage on exit 2" {
+  run "$SEED_DRIFT" --nope
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown option --nope"* ]]
+  [[ "$output" == *"Usage: bin/seed-drift"* ]]
+}
+
+@test "seed-drift rejects --template with no value" {
+  run "$SEED_DRIFT" --template
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--template needs a PATH"* ]]
+}
+
+@test "seed-drift exits 2 when the template is unreadable" {
+  run "$SEED_DRIFT" --template "$TEST_ROOT/missing.sh" --doc "$REAL_DOC"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"cannot read template"* ]]
+}
+
+@test "seed-drift exits 2 when the doc is unreadable" {
+  run "$SEED_DRIFT" --template "$REAL_TEMPLATE" --doc "$TEST_ROOT/missing.md"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"cannot read doc"* ]]
+}
+```
+
+- [ ] **Step 2: Run them and see them fail.**
+
+```
+bats tests/seed_drift.bats -f 'seed-drift'
+```
+
+Expected: `1..5`, all five `not ok`. `bin/seed-drift` does not exist, so `run` records status 127 and the first assertion in each test fails (`[ "$status" -eq 0 ]` / `-eq 2`).
+
+- [ ] **Step 3: Implement the CLI skeleton.**
+
+Create `bin/seed-drift` and `chmod +x bin/seed-drift`:
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SD_SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SD_REPO_ROOT="${SD_SELF_DIR%/bin}"
+SD_SKILL_DIR="$SD_REPO_ROOT/ai/marketplace/plugins/my/skills/project-claude-setup"
+SD_TEMPLATE_DEFAULT="$SD_SKILL_DIR/templates/local-seed.sh"
+SD_DOC_DEFAULT="$SD_SKILL_DIR/catch-up-local-seed.md"
+
+sd_usage() {
+  cat <<'SDUSAGE'
+Usage: bin/seed-drift [--template PATH] [--doc PATH] [--help] [CANDIDATE...]
+
+Reports, per project and per documented block, whether a project's
+.devcontainer/local-seed.sh is behind, ahead of, or diverged from the
+project-claude-setup template.
+
+  --template PATH  template to compare against
+  --doc PATH       catch-up doc holding the block table
+  --help           show this message
+
+With no CANDIDATE, candidates are ${SEED_DRIFT_ROOT:-$HOME/workspace}/*/.
+Exit: 0 clean, 1 drift, 2 usage/template/doc/extraction error.
+SDUSAGE
+}
+
+sd_main() {
+  local template="$SD_TEMPLATE_DEFAULT" doc="$SD_DOC_DEFAULT"
+  SD_CANDIDATES=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --template | --doc)
+        if [ $# -lt 2 ]; then
+          printf 'seed-drift: %s needs a PATH\n' "$1" >&2
+          sd_usage >&2
+          return 2
+        fi
+        if [ "$1" = --template ]; then template="$2"; else doc="$2"; fi
+        shift 2
+        ;;
+      --help | -h)
+        sd_usage
+        return 0
+        ;;
+      --)
+        shift
+        SD_CANDIDATES+=("$@")
+        break
+        ;;
+      -*)
+        printf 'seed-drift: unknown option %s\n' "$1" >&2
+        sd_usage >&2
+        return 2
+        ;;
+      *)
+        SD_CANDIDATES+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [ ! -r "$template" ]; then
+    printf 'seed-drift: cannot read template %s\n' "$template" >&2
+    return 2
+  fi
+  if [ ! -r "$doc" ]; then
+    printf 'seed-drift: cannot read doc %s\n' "$doc" >&2
+    return 2
+  fi
+
+  return 0
+}
+
+if [ "${SEED_DRIFT_SOURCE_ONLY:-0}" != 1 ]; then
+  sd_main "$@"
+fi
+```
+
+The two `-r` guards belong in this step, not a later one: without them `template` and `doc` are assigned and never read, and `shellcheck -S warning` reports SC2034 on both.
+
+- [ ] **Step 4: Run them and see them pass.**
+
+```
+bats tests/seed_drift.bats -f 'seed-drift'
+```
+
+Expected: `1..5` with all five `ok` — `ok 1 seed-drift --help prints usage and exits 0` through `ok 5 seed-drift exits 2 when the doc is unreadable`.
+
+Then confirm the linters, which discover `bin/seed-drift` automatically via `is_direct_bin_shell`:
+
+```
+shellcheck -x -S warning bin/seed-drift && shfmt -i 2 -ci -d bin/seed-drift
+```
+
+Expected: no output from either, exit 0.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: add bin/seed-drift CLI skeleton with flag and path validation"
+```
+
+- [ ] **Step 6: Write the failing `sd_parse_doc` tests.**
+
+Append to `tests/seed_drift.bats`, keeping the helper block together — insert `write_fixture_doc` directly below `sd_source`, and the two `@test` blocks at the end of the file:
+
+```bash
+write_fixture_doc() {
+  cat >"$1" <<'DOC'
+| Block | Anchor in template | Why it matters |
+|---|---|---|
+| Overlay-link gitignore | `lname '*dotfiles/projects/*'` | Adds overlay links. |
+| `core.excludesFile` | `core.excludesFile` | Points git at the seeded ignore file. |
+DOC
+}
+```
+
+```bash
+@test "sd_parse_doc emits blockname TAB anchor and keeps quotes in the anchor" {
+  local doc="$TEST_ROOT/doc.md"
+  write_fixture_doc "$doc"
+
+  sd_source sd_parse_doc "$doc"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf 'Overlay-link gitignore\tlname '"'"'*dotfiles/projects/*'"'"'')" ]
+  [ "${lines[1]}" = "$(printf 'core.excludesFile\tcore.excludesFile')" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "sd_parse_doc reads all nine blocks from the real catch-up doc" {
+  sd_source sd_parse_doc "$REAL_DOC"
+
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 9 ]
+  [[ "$output" == *"TREE_SITTER_VERSION"* ]]
+  [[ "$output" == *"lname '*dotfiles/projects/*'"* ]]
+}
+```
+
+- [ ] **Step 7: Run them and see them fail.**
+
+```
+bats tests/seed_drift.bats -f 'sd_parse_doc'
+```
+
+Expected: `1..2`, both `not ok`. `sd_parse_doc` is undefined, so the sourced subshell reports `sd_parse_doc: command not found` and `[ "$status" -eq 0 ]` fails at status 127.
+
+- [ ] **Step 8: Implement `sd_parse_doc`.**
+
+Insert into `bin/seed-drift` between `sd_usage()` and `sd_main()`:
+
+```bash
+SD_DOC_AWK=$(
+  cat <<'SDAWK'
+BEGIN { FS = "|" }
+/^\|/ && NF >= 4 {
+  name = $2
+  anchor = $3
+  gsub(/^[ \t]+|[ \t]+$/, "", name)
+  gsub(/^[ \t]+|[ \t]+$/, "", anchor)
+  if (name == "Block" || name ~ /^-+$/) next
+  if (anchor !~ /^`.*`$/) next
+  gsub(/`/, "", name)
+  sub(/^`/, "", anchor)
+  sub(/`$/, "", anchor)
+  printf("%s\t%s\n", name, anchor)
+  rows++
+}
+END { if (rows == 0) exit 1 }
+SDAWK
+)
+
+sd_parse_doc() {
+  local doc="$1"
+  if [ ! -r "$doc" ]; then
+    printf 'seed-drift: cannot read doc %s\n' "$doc" >&2
+    return 3
+  fi
+  awk "$SD_DOC_AWK" <"$doc"
+}
+```
+
+Three details are load-bearing. The guard requiring column 2 to be backtick-quoted skips the header and `|---|` separator rows without needing a row counter, and it also rejects any future table in the doc whose second column is not an anchor. The `gsub` on `name` removes *all* backticks rather than only a leading/trailing pair — three rows in the real doc (`core.excludesFile`, `~/.config/nvim` link, `load-custom.zsh` loader) would otherwise keep a stray backtick mid-name. The anchor uses `sub` for the outer pair only, so `lname '*dotfiles/projects/*'` survives with its single quotes and asterisks intact.
+
+- [ ] **Step 9: Run them and see them pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_parse_doc'
+```
+
+Expected: `1..2`, `ok 1 sd_parse_doc emits blockname TAB anchor and keeps quotes in the anchor` and `ok 2 sd_parse_doc reads all nine blocks from the real catch-up doc`.
+
+- [ ] **Step 10: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: parse the catch-up doc block table into blockname/anchor pairs"
+```
+
+- [ ] **Step 11: Write the failing anchor-validation tests.**
+
+Append to `tests/seed_drift.bats`:
+
+```bash
+@test "every anchor in the real doc table is present in the real template" {
+  run "$SEED_DRIFT" --template "$REAL_TEMPLATE" --doc "$REAL_DOC"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "a doc anchor the template lacks is a hard error" {
+  local doc="$TEST_ROOT/doc.md" template="$TEST_ROOT/tpl.sh"
+  write_fixture_doc "$doc"
+  printf '#!/usr/bin/env bash\ntrue\n' >"$template"
+
+  run "$SEED_DRIFT" --template "$template" --doc "$doc"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"is absent from"* ]]
+  [[ "$output" == *"core.excludesFile"* ]]
+}
+```
+
+- [ ] **Step 12: Run them and see them fail.**
+
+```
+bats tests/seed_drift.bats -f 'anchor'
+```
+
+Expected: `1..2` with `ok 1 every anchor in the real doc table is present in the real template` (it passes vacuously — `sd_main` returns 0 without validating anything yet) and `not ok 2 a doc anchor the template lacks is a hard error`, failing on `[ "$status" -eq 2 ]` because the run exits 0. Test 1 is the regression guard for the code added in Step 13; test 2 is the red one.
+
+- [ ] **Step 13: Implement the anchor check in `sd_main`.**
+
+In `bin/seed-drift`, replace the trailing `return 0` of `sd_main` (the last statement, after the two `-r` guards) with:
+
+```bash
+  local blocks
+  if ! blocks=$(sd_parse_doc "$doc"); then
+    printf 'seed-drift: no block table found in %s\n' "$doc" >&2
+    return 2
+  fi
+
+  local name anchor absent=0
+  while IFS=$'\t' read -r name anchor; do
+    if ! grep -qF -- "$anchor" "$template"; then
+      printf 'seed-drift: anchor %s (block: %s) is absent from %s\n' \
+        "$anchor" "$name" "$template" >&2
+      absent=1
+    fi
+  done <<<"$blocks"
+  if [ "$absent" -ne 0 ]; then
+    return 2
+  fi
+
+  return 0
+```
+
+`grep -qF --` is required, not optional: `-F` because `lname '*dotfiles/projects/*'` contains regex metacharacters, and `--` because an anchor could begin with `-`. The loop does not short-circuit on the first absent anchor, so one run reports every doc/template disagreement.
+
+- [ ] **Step 14: Run them and see them pass.**
+
+```
+bats tests/seed_drift.bats
+```
+
+Expected: `1..9`, all `ok`, ending `ok 9 a doc anchor the template lacks is a hard error`.
+
+```
+shellcheck -x -S warning bin/seed-drift && shfmt -i 2 -ci -d bin/seed-drift
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 15: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: fail with exit 2 when a doc anchor is absent from the template"
+```
+
+---
+
+### Task 2: heredoc-aware, quote-aware paragraph scanner (`sd_scan`)
+
+**Files:**
+- Modify: `bin/seed-drift`
+- Modify: `tests/seed_drift.bats`
+
+**Interfaces:**
+
+*Consumes (from Task 1):* `bin/seed-drift` with `set -euo pipefail`, the `SEED_DRIFT_SOURCE_ONLY=1` sourcing guard, and the `sd_source` bats helper.
+
+*Produces:*
+- `sd_scan FILE` — writes the contract scan format to stdout, one record per source line:
+
+  ```
+  para <TAB> lineno <TAB> tag <TAB> text
+  ```
+
+  `para` is a 1-based, blank-line-delimited, heredoc-aware paragraph index; `lineno` is the 1-based line number in `FILE`; `tag` is `C` (shell code, `text` comment-stripped, possibly empty), `Hq` (heredoc body, quoted delimiter — literal payload) or `Hu` (heredoc body, unquoted delimiter — the shell would expand it). `text` is verbatim for `Hq`/`Hu`. Both heredoc *delimiter* lines — the opener, which is ordinary code, and the closer — are tagged `C`. Blank lines outside a heredoc emit no record; blank lines inside a heredoc body do, and do not end the paragraph.
+
+  Returns **3** on any `<<` it cannot classify, on an unterminated heredoc-delimiter quote, on an unterminated heredoc body at EOF, and on an unreadable `FILE`. It never guesses.
+
+- `SD_SCAN_AWK` — the awk program, as a shell variable. Later tasks call `sd_scan`, not awk directly.
+
+Every consumer in Tasks 3-8 (`sd_paras_with_anchor`, `sd_para_range`, `sd_window`, `sd_normalize`, `sd_extract`) reads this exact 4-field format with `IFS=$'\t' read -r para lineno tag text` or `awk -F'\t'`. Because `text` is last, it may itself contain tabs without breaking field splitting.
+
+---
+
+- [ ] **Step 1: Write the failing paragraph-splitting test.**
+
+Append to `tests/seed_drift.bats`:
+
+```bash
+@test "sd_scan numbers every line and starts a new paragraph after a blank line" {
+  local f="$TEST_ROOT/paras.sh"
+  printf '%s\n' 'first=1' 'second=2' '' '   ' 'third=3' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\tfirst=1')" ]
+  [ "${lines[1]}" = "$(printf '1\t2\tC\tsecond=2')" ]
+  [ "${lines[2]}" = "$(printf '2\t5\tC\tthird=3')" ]
+  [ "${#lines[@]}" -eq 3 ]
+}
+```
+
+The whitespace-only line 4 must count as blank, and two consecutive blank lines must advance the paragraph index by one, not two.
+
+- [ ] **Step 2: Run it and see it fail.**
+
+```
+bats tests/seed_drift.bats -f 'numbers every line'
+```
+
+Expected: `1..1`, `not ok 1 sd_scan numbers every line and starts a new paragraph after a blank line`. `sd_scan` is undefined; the sourced subshell exits 127 and `[ "$status" -eq 0 ]` fails.
+
+- [ ] **Step 3: Implement paragraph splitting.**
+
+Insert into `bin/seed-drift`, between `sd_parse_doc` and `sd_main`:
+
+```bash
+SD_SCAN_AWK=$(
+  cat <<'SDAWK'
+function emit(tag, text) {
+  if (para == 0 || brk) {
+    para++
+    brk = 0
+  }
+  printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
+}
+{
+  if ($0 ~ /^[ \t]*$/) {
+    brk = 1
+    next
+  }
+  emit("C", $0)
+}
+SDAWK
+)
+
+sd_scan() {
+  local file="$1"
+  if [ ! -r "$file" ]; then
+    printf 'seed-drift: cannot read %s\n' "$file" >&2
+    return 3
+  fi
+  awk "$SD_SCAN_AWK" <"$file"
+}
+```
+
+The redirect `<"$file"` rather than passing the path as an awk operand is deliberate: an operand containing `=` would be parsed by awk as a variable assignment instead of a filename. `NR` is still the file's line number because exactly one stream is read.
+
+- [ ] **Step 4: Run it and see it pass.**
+
+```
+bats tests/seed_drift.bats -f 'numbers every line'
+```
+
+Expected: `1..1`, `ok 1 sd_scan numbers every line and starts a new paragraph after a blank line`.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: add sd_scan with blank-line paragraph splitting"
+```
+
+- [ ] **Step 6: Write the failing comment-stripping test.**
+
+Append to `tests/seed_drift.bats`:
+
+```bash
+@test "sd_scan strips comments quote-aware so a sed s#...#g program survives" {
+  local f="$TEST_ROOT/comments.sh"
+  cat >"$f" <<'FIX'
+# whole line comment
+links="$(find . | sed 's#^\./##')" # trailing note
+echo "kept # inside quotes"
+FIX
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\t')" ]
+  [ "${lines[1]}" = "$(printf '1\t2\tC\tlinks="$(find . | sed '"'"'s#^\\./##'"'"')" ')" ]
+  [ "${lines[2]}" = "$(printf '1\t3\tC\techo "kept # inside quotes"')" ]
+}
+```
+
+Line 2 is modelled on template line 261. Its `#` characters are inside a single-quoted `sed` program and must survive; the `# trailing note` after them must not. The expected text keeps the space before the stripped comment — trimming belongs to `sd_normalize`, not the scanner.
+
+- [ ] **Step 7: Run it and see it fail.**
+
+```
+bats tests/seed_drift.bats -f 'quote-aware'
+```
+
+Expected: `1..1`, `not ok 1 sd_scan strips comments quote-aware so a sed s#...#g program survives`, failing at `[ "${lines[0]}" = "$(printf '1\t1\tC\t')" ]` — line 1 is currently emitted verbatim as `1<TAB>1<TAB>C<TAB># whole line comment`.
+
+- [ ] **Step 8: Implement the quote-aware character scan.**
+
+Replace the whole `SD_SCAN_AWK` heredoc body in `bin/seed-drift` with:
+
+```awk
+function emit(tag, text) {
+  if (para == 0 || brk) {
+    para++
+    brk = 0
+  }
+  printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
+}
+function scan(line,   n, i, c) {
+  n = length(line)
+  i = 1
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (inq == "'") {
+      if (c == "'") inq = ""
+      i++
+      continue
+    }
+    if (inq == "\"") {
+      if (c == "\\") { i += 2; continue }
+      if (c == "\"") inq = ""
+      i++
+      continue
+    }
+    if (c == "\\") { i += 2; continue }
+    if (c == "'") { inq = "'"; i++; continue }
+    if (c == "\"") { inq = "\""; i++; continue }
+    if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t]/)) return substr(line, 1, i - 1)
+    i++
+  }
+  return line
+}
+{
+  if ($0 ~ /^[ \t]*$/ && inq == "") {
+    brk = 1
+    next
+  }
+  emit("C", scan($0))
+}
+```
+
+`inq` is intentionally **not** a local of `scan()`: it is a file-scope global, so an unterminated quote carries into the next line. That is what makes template lines 260-261 — a double-quoted string continued across a `\` line break — track correctly, and it is why the blank-line rule now also requires `inq == ""`. Backslash outside quotes and inside double quotes consumes the next character; inside single quotes it does not, matching the shell. A `#` counts as a comment only at column 1 or after whitespace, which is what keeps `sed 's#^\./##'` intact even before quote state is consulted.
+
+- [ ] **Step 9: Run it and see it pass.**
+
+```
+bats tests/seed_drift.bats -f 'quote-aware|numbers every line'
+```
+
+Expected: `1..2`, both `ok`.
+
+- [ ] **Step 10: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: strip shell comments quote-aware in sd_scan"
+```
+
+- [ ] **Step 11: Write the failing heredoc-body tests.**
+
+Append to `tests/seed_drift.bats`:
+
+```bash
+@test "sd_scan keeps a quoted heredoc body in one paragraph and tags it Hq" {
+  local f="$TEST_ROOT/hd.sh"
+  cat >"$f" <<'FIX'
+GITIGNORE="$HOME/.gitignore"
+tee "$GITIGNORE" <<'GITEOF'
+.DS_Store
+
+# Personal overlay shims.
+CLAUDE.local.md
+GITEOF
+git config --global core.excludesFile "$GITIGNORE"
+FIX
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[2]}" = "$(printf '1\t3\tHq\t.DS_Store')" ]
+  [ "${lines[3]}" = "$(printf '1\t4\tHq\t')" ]
+  [ "${lines[4]}" = "$(printf '1\t5\tHq\t# Personal overlay shims.')" ]
+  [ "${lines[6]}" = "$(printf '1\t7\tC\tGITEOF')" ]
+  [ "${lines[7]}" = "$(printf '1\t8\tC\tgit config --global core.excludesFile "$GITIGNORE"')" ]
+}
+
+@test "sd_scan does not treat << inside a double-quoted string as a heredoc" {
+  local f="$TEST_ROOT/quoted.sh"
+  cat >"$f" <<'FIX'
+GI_MARK_END="# <<< overlay symlinks (auto) <<<"
+echo done
+
+echo after
+FIX
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\tGI_MARK_END="# <<< overlay symlinks (auto) <<<"')" ]
+  [ "${lines[1]}" = "$(printf '1\t2\tC\techo done')" ]
+  [ "${lines[2]}" = "$(printf '2\t4\tC\techo after')" ]
+}
+
+@test "sd_scan fails closed on unrecognized heredoc syntax" {
+  local f="$TEST_ROOT/bad.sh"
+  printf 'cat << ;\n' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"unrecognized heredoc delimiter"* ]]
+}
+
+@test "sd_scan puts the real template core.excludesFile block in one paragraph" {
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    scan=$(sd_scan "$2")
+    para=$(printf "%s\n" "$scan" | awk -F"\t" "\$3 == \"C\" && index(\$4, \"core.excludesFile\") { print \$1 }")
+    printf "%s\n" "$scan" | awk -F"\t" -v p="$para" "\$1 == p { print \$2 }" |
+      awk "NR == 1 { first = \$0 } { last = \$0 } END { print first, last }"
+  ' _ "$SEED_DRIFT" "$REAL_TEMPLATE"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "204 236" ]
+}
+```
+
+The last test is the one Decision 3 turns on: the `core.excludesFile` code use at template line 236 must land in a paragraph running 204-236, spanning the comment preamble, the `GITIGNORE=` assignment, the whole `GITEOF` heredoc including its blank lines at 223 and 229, and the `git config` line. The third test pins the fail-closed rule. The second is the guard against a naive `<<` matcher: template line 255 sits inside the overlay-gitignore anchored block, and misreading it swallows the rest of the file — it passes already, and must keep passing.
+
+- [ ] **Step 12: Run them and see them fail.**
+
+```
+bats tests/seed_drift.bats -f 'Hq|as a heredoc|fails closed on unrecognized|one paragraph'
+```
+
+Expected: `1..4` with
+
+```
+not ok 1 sd_scan keeps a quoted heredoc body in one paragraph and tags it Hq
+ok 2 sd_scan does not treat << inside a double-quoted string as a heredoc
+not ok 3 sd_scan fails closed on unrecognized heredoc syntax
+not ok 4 sd_scan puts the real template core.excludesFile block in one paragraph
+```
+
+Test 1 fails at `[ "${lines[2]}" = "$(printf '1\t3\tHq\t.DS_Store')" ]` (the body is still tagged `C` and its blank line splits the paragraph); test 3 fails at `[ "$status" -eq 3 ]` (currently 0); test 4 fails at `[ "$output" = "204 236" ]`. Test 2 is green and is the regression guard for Step 13.
+
+- [ ] **Step 13: Implement heredoc openers, body tracking, and fail-closed errors.**
+
+Replace the whole `SD_SCAN_AWK` heredoc body with:
+
+```awk
+function fail(msg) {
+  printf("seed-drift: %s (line %d)\n", msg, NR) >"/dev/stderr"
+  failed = 1
+  exit 3
+}
+function emit(tag, text) {
+  if (para == 0 || brk) {
+    para++
+    brk = 0
+  }
+  printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
+}
+function delimword(line, i, n,   w, c) {
+  w = ""
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (c !~ /[A-Za-z0-9_.-]/) break
+    w = w c
+    i++
+  }
+  wend = i
+  return w
+}
+function scan(line,   n, i, c, j, w) {
+  n = length(line)
+  i = 1
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (inq == "'") {
+      if (c == "'") inq = ""
+      i++
+      continue
+    }
+    if (inq == "\"") {
+      if (c == "\\") { i += 2; continue }
+      if (c == "\"") inq = ""
+      i++
+      continue
+    }
+    if (c == "\\") { i += 2; continue }
+    if (c == "'") { inq = "'"; i++; continue }
+    if (c == "\"") { inq = "\""; i++; continue }
+    if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t]/)) return substr(line, 1, i - 1)
+    if (c != "<") { i++; continue }
+    if (substr(line, i, 2) != "<<") { i++; continue }
+    i += 2
+    c = substr(line, i, 1)
+    if (c == "'" || c == "\"") {
+      j = index(substr(line, i + 1), c)
+      if (j == 0) fail("unterminated heredoc delimiter quote")
+      hdelim = substr(line, i + 1, j - 1)
+      hquot = 1
+      opened = 1
+      i = i + j + 1
+      continue
+    }
+    w = delimword(line, i, n)
+    if (w == "") fail("unrecognized heredoc delimiter after <<")
+    hdelim = w
+    hquot = 0
+    opened = 1
+    i = wend
+  }
+  return line
+}
+{
+  if (hd) {
+    if ($0 == hdelim) {
+      emit("C", $0)
+      hd = 0
+    } else {
+      emit(hquot ? "Hq" : "Hu", $0)
+    }
+    next
+  }
+  if ($0 ~ /^[ \t]*$/ && inq == "") {
+    brk = 1
+    next
+  }
+  opened = 0
+  emit("C", scan($0))
+  if (opened) hd = 1
+}
+```
+
+Heredoc detection lives *inside* the same quote-state loop that already drives comment stripping, which is precisely why `GI_MARK_END="# <<< overlay symlinks (auto) <<<"` is inert: by the time the scanner reaches those `<<` characters, `inq` is `"` and the code never reaches the `c != "<"` branch. `delimword` returning the empty string is the fail-closed path — `<<` followed by anything that is not a quote and not a delimiter word is an error, never a shrug. `wend` is a deliberate global out-parameter (awk has no other way to return two values). Note that `fail()` calls `exit 3`, which still runs `END`, so `failed` is set for the guard added in Step 28.
+
+- [ ] **Step 14: Run them and see them pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_scan'
+```
+
+Expected: `1..6`, all `ok`, including `ok 4 sd_scan puts the real template core.excludesFile block in one paragraph`.
+
+- [ ] **Step 15: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: track heredoc bodies in sd_scan and fail closed on unknown <<"
+```
+
+- [ ] **Step 16: Write the failing delimiter-form test.**
+
+Append to `tests/seed_drift.bats`:
+
+```bash
+@test "sd_scan excludes herestrings and recognizes every delimiter form" {
+  local f="$TEST_ROOT/forms.sh"
+  printf '%s\n' \
+    'grep q <<<"$v"' \
+    'cat <<A' \
+    'u1' \
+    'A' \
+    "cat <<'B'" \
+    'q1' \
+    'B' \
+    'cat <<"C"' \
+    'q2' \
+    'C' \
+    'cat <<\D' \
+    'q3' \
+    'D' \
+    'cat <<-E' \
+    $'\tu2' \
+    $'\tE' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\tgrep q <<<"$v"')" ]
+  [ "${lines[2]}" = "$(printf '1\t3\tHu\tu1')" ]
+  [ "${lines[5]}" = "$(printf '1\t6\tHq\tq1')" ]
+  [ "${lines[8]}" = "$(printf '1\t9\tHq\tq2')" ]
+  [ "${lines[11]}" = "$(printf '1\t12\tHq\tq3')" ]
+  [ "${lines[14]}" = "$(printf '1\t15\tHu\t\tu2')" ]
+  [ "${lines[15]}" = "$(printf '1\t16\tC\t\tE')" ]
+}
+```
+
+`$'\t'` quoting is required for the two `<<-E` lines — a real tab, since `<<-` strips tabs only. The last two assertions check that the `<<-` body keeps its leading tab in `text` while the *closer* is still recognized after tab-stripping and tagged `C`.
+
+- [ ] **Step 17: Run it and see it fail.**
+
+```
+bats tests/seed_drift.bats -f 'delimiter form'
+```
+
+Expected: `1..1`, `not ok 1 sd_scan excludes herestrings and recognizes every delimiter form`, failing at `[ "${lines[2]}" = "$(printf '1\t3\tHu\tu1')" ]`. Line 1's `<<<` is currently read as `<<` followed by `<`, `delimword` returns empty, and the run dies with `unrecognized heredoc delimiter after <<` at status 3 — the fail-closed path doing exactly its job on a form it has not been taught yet.
+
+- [ ] **Step 18: Implement `<<<`, `<<\TAG`, and the `<<-` variants.**
+
+Replace the whole `SD_SCAN_AWK` heredoc body with:
+
+```awk
+function fail(msg) {
+  printf("seed-drift: %s (line %d)\n", msg, NR) >"/dev/stderr"
+  failed = 1
+  exit 3
+}
+function emit(tag, text) {
+  if (para == 0 || brk) {
+    para++
+    brk = 0
+  }
+  printf("%d\t%d\t%s\t%s\n", para, NR, tag, text)
+}
+function delimword(line, i, n,   w, c) {
+  w = ""
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (c !~ /[A-Za-z0-9_.-]/) break
+    w = w c
+    i++
+  }
+  wend = i
+  return w
+}
+function scan(line,   n, i, c, j, d, w) {
+  n = length(line)
+  i = 1
+  while (i <= n) {
+    c = substr(line, i, 1)
+    if (inq == "'") {
+      if (c == "'") inq = ""
+      i++
+      continue
+    }
+    if (inq == "\"") {
+      if (c == "\\") { i += 2; continue }
+      if (c == "\"") inq = ""
+      i++
+      continue
+    }
+    if (c == "\\") { i += 2; continue }
+    if (c == "'") { inq = "'"; i++; continue }
+    if (c == "\"") { inq = "\""; i++; continue }
+    if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t]/)) return substr(line, 1, i - 1)
+    if (c != "<") { i++; continue }
+    if (substr(line, i, 3) == "<<<") { i += 3; continue }
+    if (substr(line, i, 2) != "<<") { i++; continue }
+    i += 2
+    d = 0
+    if (substr(line, i, 1) == "-") { d = 1; i++ }
+    while (substr(line, i, 1) == " " || substr(line, i, 1) == "\t") i++
+    c = substr(line, i, 1)
+    if (c == "'" || c == "\"") {
+      j = index(substr(line, i + 1), c)
+      if (j == 0) fail("unterminated heredoc delimiter quote")
+      hdelim = substr(line, i + 1, j - 1)
+      hquot = 1
+      hdash = d
+      opened = 1
+      i = i + j + 1
+      continue
+    }
+    if (c == "\\") {
+      w = delimword(line, i + 1, n)
+      if (w == "") fail("unrecognized heredoc delimiter after <<")
+      hdelim = w
+      hquot = 1
+      hdash = d
+      opened = 1
+      i = wend
+      continue
+    }
+    w = delimword(line, i, n)
+    if (w == "") fail("unrecognized heredoc delimiter after <<")
+    hdelim = w
+    hquot = 0
+    hdash = d
+    opened = 1
+    i = wend
+  }
+  return line
+}
+{
+  if (hd) {
+    closer = $0
+    if (hdash) sub(/^\t+/, "", closer)
+    if (closer == hdelim) {
+      emit("C", $0)
+      hd = 0
+    } else {
+      emit(hquot ? "Hq" : "Hu", $0)
+    }
+    next
+  }
+  if ($0 ~ /^[ \t]*$/ && inq == "") {
+    brk = 1
+    next
+  }
+  opened = 0
+  emit("C", scan($0))
+  if (opened) hd = 1
+}
+```
+
+The `<<<` test must come before the `<<` test, or a herestring is consumed as a heredoc opener. `<<\TAG` sets `hquot = 1` because a backslash-escaped delimiter suppresses expansion exactly as quotes do — that matters downstream, where Decision 4 neutralizes `$HOME` in `Hu` bodies but not `Hq` ones. Tab-stripping is applied to a *copy* of the line for the closer comparison only, so the emitted `text` still carries the body's original leading whitespace.
+
+- [ ] **Step 19: Run it and see it pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_scan'
+```
+
+Expected: `1..7`, all `ok`, including `ok 3 sd_scan excludes herestrings and recognizes every delimiter form`.
+
+- [ ] **Step 20: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: recognize herestrings, escaped delimiters, and <<- in sd_scan"
+```
+
+- [ ] **Step 21: Write the failing multiple-heredoc test.**
+
+Append to `tests/seed_drift.bats`:
+
+```bash
+@test "sd_scan queues two heredocs opened on the same line" {
+  local f="$TEST_ROOT/two.sh"
+  printf '%s\n' 'cat <<A; cat <<-"B"' 'x' 'A' $'\ty' $'\tB' 'echo tail' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[1]}" = "$(printf '1\t2\tHu\tx')" ]
+  [ "${lines[2]}" = "$(printf '1\t3\tC\tA')" ]
+  [ "${lines[3]}" = "$(printf '1\t4\tHq\t\ty')" ]
+  [ "${lines[4]}" = "$(printf '1\t5\tC\t\tB')" ]
+  [ "${lines[5]}" = "$(printf '1\t6\tC\techo tail')" ]
+}
+```
+
+The two openers differ in every attribute — `A` is unquoted and undashed, `B` is quoted and dashed — so a queue that loses per-heredoc state, or pops in the wrong order, cannot pass.
+
+- [ ] **Step 22: Run it and see it fail.**
+
+```
+bats tests/seed_drift.bats -f 'queues two'
+```
+
+Expected: `1..1`, `not ok 1 sd_scan queues two heredocs opened on the same line`, failing at `[ "${lines[1]}" = "$(printf '1\t2\tHu\tx')" ]`. The single-slot state is overwritten by the second opener, so `hdelim` is `B` and `hquot` is 1: line 2 is emitted as `Hq` and line 3 (`A`) is swallowed as body rather than closing the first heredoc.
+
+- [ ] **Step 23: Replace the single-slot state with a FIFO queue.**
+
+In the `SD_SCAN_AWK` body, add these two functions immediately after `emit()`:
+
+```awk
+function push(delim, quoted, dash) {
+  nq++
+  qd[nq] = delim
+  qq[nq] = quoted
+  qs[nq] = dash
+}
+function popq() {
+  hdelim = qd[1]
+  hquot = qq[1]
+  hdash = qs[1]
+  hd = 1
+  for (k = 1; k < nq; k++) {
+    qd[k] = qd[k + 1]
+    qq[k] = qq[k + 1]
+    qs[k] = qs[k + 1]
+  }
+  nq--
+}
+```
+
+In `scan()`, replace each of the three four-line assignment groups
+
+```awk
+      hdelim = ...
+      hquot = ...
+      hdash = d
+      opened = 1
+```
+
+with a single `push(...)` call — `push(substr(line, i + 1, j - 1), 1, d)` for the quoted-delimiter branch, `push(w, 1, d)` for the `<<\TAG` branch, and `push(w, 0, d)` for the bare-word branch — deleting the now-unused `opened` assignments.
+
+Then replace the main rule with:
+
+```awk
+{
+  if (hd) {
+    closer = $0
+    if (hdash) sub(/^\t+/, "", closer)
+    if (closer == hdelim) {
+      emit("C", $0)
+      hd = 0
+      if (nq > 0) popq()
+    } else {
+      emit(hquot ? "Hq" : "Hu", $0)
+    }
+    next
+  }
+  if ($0 ~ /^[ \t]*$/ && inq == "") {
+    brk = 1
+    next
+  }
+  nq = 0
+  emit("C", scan($0))
+  if (nq > 0) popq()
+}
+```
+
+`nq = 0` before `scan()` replaces the `opened` flag: the queue is per-line, filled by `scan()` and drained as each body closes. Resetting it is safe because a code line is only reached when no heredoc is pending. Bash reads the bodies in opener order, which is what the FIFO shift in `popq()` reproduces.
+
+- [ ] **Step 24: Run it and see it pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_scan'
+```
+
+Expected: `1..8`, all `ok`, including `ok 4 sd_scan queues two heredocs opened on the same line`.
+
+- [ ] **Step 25: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: queue multiple heredocs opened on one line in sd_scan"
+```
+
+- [ ] **Step 26: Write the failing unterminated-heredoc test.**
+
+Append to `tests/seed_drift.bats`:
+
+```bash
+@test "sd_scan fails closed on an unterminated heredoc" {
+  local f="$TEST_ROOT/unterminated.sh"
+  printf "cat <<'E'\nbody\n" >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"unterminated heredoc E"* ]]
+}
+```
+
+A heredoc still open at EOF means the scanner's structural model of the file is wrong; per Decision 3 that is an extraction error, not a scan that happens to end.
+
+- [ ] **Step 27: Run it and see it fail.**
+
+```
+bats tests/seed_drift.bats -f 'unterminated heredoc'
+```
+
+Expected: `1..1`, `not ok 1 sd_scan fails closed on an unterminated heredoc`, failing at `[ "$status" -eq 3 ]` — awk currently reaches EOF and exits 0 after emitting `body` as `Hq`.
+
+- [ ] **Step 28: Add the `END` guard.**
+
+Append to the `SD_SCAN_AWK` body, after the main rule:
+
+```awk
+END {
+  if (failed) exit 3
+  if (hd) {
+    printf("seed-drift: unterminated heredoc %s\n", hdelim) >"/dev/stderr"
+    exit 3
+  }
+}
+```
+
+`if (failed) exit 3` must come first and is not redundant: `fail()`'s `exit 3` still runs `END`, and without this line an `END` block that falls through would reset the status to 0 — silently converting the fail-closed path from Step 13 into a clean scan.
+
+- [ ] **Step 29: Run the whole suite and see it pass.**
+
+```
+bats tests/seed_drift.bats
+```
+
+Expected: `1..18`, every line `ok`, ending `ok 18 seed-drift exits 2 when the doc is unreadable`.
+
+```
+shellcheck -x -S warning bin/seed-drift && shfmt -i 2 -ci -d bin/seed-drift
+```
+
+Expected: no output from either, exit 0.
+
+- [ ] **Step 30: Commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m "feat: treat an unterminated heredoc as an sd_scan extraction error"
+```
+
+---
+
+### Task 3: window growth — `sd_paras_with_anchor`, `sd_para_range`, `sd_window`
+
+**Files:**
+
+- modify `bin/seed-drift` (append the three functions after `sd_scan`)
+- modify `tests/seed_drift.bats` (append two test helpers and 9 `@test` blocks)
+
+**Interfaces:**
+
+*Consumes* (from Task 2)
+
+- `sd_scan FILE` -> stdout, one record per source line: `para<TAB>lineno<TAB>tag<TAB>text`, `tag` in `C|Hq|Hu`. Paragraph indices are 1-based and contiguous; `lineno` is strictly increasing.
+- `bin/seed-drift` guards its entry point with `if [[ "${SEED_DRIFT_SOURCE_ONLY:-0}" != 1 ]]; then sd_main "$@"; fi` (Task 1), so `SEED_DRIFT_SOURCE_ONLY=1 source bin/seed-drift` defines the functions without running anything. Every test in this task relies on that, and on the `sd_source` helper Task 1 added — do not add a second sourcing helper.
+
+*Produces*
+
+- `sd_paras_with_anchor SCAN ANCHOR` -> stdout, one paragraph index per line, ascending, deduped. Empty output (exit 0) when the anchor matches nothing. Match is `index($4, a)` — fixed string, against `$3 == "C"` rows only.
+- `sd_para_range SCAN PARA` -> stdout, one line, `start end` (space-separated source line numbers). Empty output when `PARA` does not exist.
+- `sd_window FILE SCAN PARA` -> stdout, one line, `start end`. Exit 3 if no grown window ever parses.
+
+Note for the implementer: the fenced blocks below are byte-exact. The multi-line
+`[ "$output" = "..." ]` assertions contain literal newlines and unindented
+continuation lines — copy them as written; adding indentation changes the
+expected string and the test will fail.
+
+---
+
+- [ ] **Step 1: write the failing tests for `sd_paras_with_anchor` and `sd_para_range`.**
+
+Append to `tests/seed_drift.bats`. `REPO_ROOT` is exported by `setup_dotfiles_test`; `SEED_DRIFT` and `FIX` are already set by the `setup()` Task 1 created.
+
+```bash
+# --- Task 3 helpers ---------------------------------------------------------
+# Sourcing goes through Task 1's `sd_source`, which sets SEED_DRIFT_SOURCE_ONLY=1.
+# make_scan needs its own form because it captures stdout to a file rather than
+# going through bats' `run`, but it sets the same guard.
+make_scan() {
+  env SEED_DRIFT_SOURCE_ONLY=1 bash -c \
+    'source "$1"; sd_scan "$2"' _ "$SEED_DRIFT" "$1" >"$1.scan"
+}
+
+@test "sd_paras_with_anchor matches C-tag text as a fixed string, every occurrence" {
+  printf 'A="lname '"'"'*dotfiles/projects/*'"'"'"\n\necho other\n\nB="lname '"'"'*dotfiles/projects/*'"'"'"\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_paras_with_anchor "$FIX/f.sh.scan" "lname '*dotfiles/projects/*'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1
+3" ]
+}
+
+@test "sd_paras_with_anchor ignores an anchor that appears only in a comment" {
+  printf 'echo hi # TREE_SITTER_VERSION is pinned\n\nTS=1\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_paras_with_anchor "$FIX/f.sh.scan" TREE_SITTER_VERSION
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "sd_para_range reports the first and last source line of a paragraph" {
+  printf 'a\nb\n\nc\nd\ne\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_para_range "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "4 6" ]
+}
+```
+
+The first test pins two contract properties at once: `*` and `'` in the anchor are literal (fixed-string, not regex), and both matching paragraphs are returned. The second pins that comment-only occurrences do not anchor — `sd_scan` already comment-strips C text, so this is a regression test on *using* `$4` rather than the raw line.
+
+- [ ] **Step 2: run the tests and watch them fail.**
+
+```
+bats tests/seed_drift.bats -f 'sd_paras_with_anchor|sd_para_range'
+```
+
+Expect 3 failures. Each reports `sd_paras_with_anchor: command not found` (or `sd_para_range`) in `$output`, with the `[ "$status" -eq 0 ]` assertion failing on exit 127.
+
+- [ ] **Step 3: implement `sd_paras_with_anchor` and `sd_para_range`.**
+
+Append to `bin/seed-drift` after `sd_scan`:
+
+```bash
+sd_paras_with_anchor() {
+  awk -F'\t' -v a="$2" '$3 == "C" && index($4, a) { if (!seen[$1]++) print $1 }' "$1"
+}
+
+sd_para_range() {
+  awk -F'\t' -v p="$2" '$1 == p { if (!s) s = $2; e = $2 } END { if (s) print s, e }' "$1"
+}
+```
+
+`index()` is awk's fixed-string search, so no anchor character is ever interpreted. `-v a=` passes the anchor as data, never as program text.
+
+- [ ] **Step 4: run the tests and watch them pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_paras_with_anchor|sd_para_range'
+```
+
+Expect `1..3` and three `ok` lines.
+
+- [ ] **Step 5: commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m 'feat(seed-drift): locate anchored paragraphs and their line ranges'
+```
+
+- [ ] **Step 6: write the characterization test that pins the `bash -n` asymmetry.**
+
+This is the empirical fact the entire growth rule rests on, so it gets its own test rather than living only in the spec. It is a characterization test of external behavior and is expected to pass on its first run — that is a deliberate departure from red-green, not an oversight.
+
+```bash
+@test "bash -n rejects a lone if header and accepts it split by a blank line" {
+  printf 'if [ -n "$x" ]; then\n' >"$FIX/lone.sh"
+  printf 'if [ -n "$x" ]; then\n\n  echo hi\nfi\n' >"$FIX/split.sh"
+  run bash -n "$FIX/lone.sh"
+  [ "$status" -eq 2 ]
+  run bash -n "$FIX/split.sh"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 7: run it and confirm it passes.**
+
+```
+bats tests/seed_drift.bats -f 'bash -n rejects a lone if header'
+```
+
+Expect `1..1` and `ok 1`. Verified directly: `bash -n` on the lone header prints `syntax error: unexpected end of file` and exits 2; the blank-line-split form exits 0. Truncation is therefore detectable, and a blank line between condition and body is legal input — both halves of the rule.
+
+- [ ] **Step 8: commit.**
+
+```
+git add tests/seed_drift.bats
+git commit -m 'test(seed-drift): pin the bash -n asymmetry that drives window growth'
+```
+
+- [ ] **Step 9: write the failing tests for `sd_window`.**
+
+```bash
+@test "sd_window grows forward past a blank line between an if condition and its body" {
+  printf 'if [ -n "$ANCHOR" ]; then\n\n  echo hi\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 4" ]
+}
+
+@test "sd_window grows backward when the anchor is in the body and the header is above" {
+  printf 'if [ -n "$x" ]; then\n\n  echo ANCHOR\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 4" ]
+}
+
+@test "sd_window returns a single paragraph unchanged when it already parses" {
+  printf 'echo one\n\necho ANCHOR\n\necho three\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "3 3" ]
+}
+
+@test "sd_window exits 3 when neither direction ever parses" {
+  printf 'echo ok\n\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 3 ]
+}
+
+@test "sd_window reads the raw fragment from the file, not the comment-stripped scan" {
+  printf 'if [ -n "$x" ]; then # start\n\n  echo hi\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 4" ]
+}
+```
+
+The backward case is the one that forces the two-direction rule: paragraph 2 is `echo ANCHOR`, which parses on its own, but appending paragraph 3 (`fi`) does not parse, so growth must fall through to prepending paragraph 1. The third test pins the residual limitation in the spec — an already-parsing window is not grown — so a future change cannot silently widen it. The last test pins that the fragment comes from `FILE` by line number: the trailing comment is absent from the scan text, so this is asserted as an explicit contract rather than left to chance.
+
+- [ ] **Step 10: run the tests and watch them fail.**
+
+```
+bats tests/seed_drift.bats -f 'sd_window'
+```
+
+Expect 5 failures, each with `sd_window: command not found` in `$output`.
+
+- [ ] **Step 11: implement `sd_window`.**
+
+```bash
+# Grows the window until the extracted fragment parses: forward first, then
+# backward once the end of file is reached. The fragment is read straight from
+# FILE by line number, because the scan text is comment-stripped and would not
+# parse the same way.
+sd_window() {
+  local file="$1" scan="$2" para="$3"
+  local first last lo hi start end range
+
+  first=$(awk -F'\t' 'NR == 1 { print $1; exit }' "$scan")
+  last=$(awk -F'\t' 'END { print $1 }' "$scan")
+  range=$(sd_para_range "$scan" "$para")
+  [ -n "$range" ] || return 3
+
+  lo="$para" hi="$para"
+  start="${range% *}" end="${range#* }"
+  while ! sed -n "${start},${end}p" "$file" | bash -n 2>/dev/null; do
+    if [ "$hi" -lt "$last" ]; then
+      hi=$((hi + 1))
+      range=$(sd_para_range "$scan" "$hi")
+      end="${range#* }"
+    elif [ "$lo" -gt "$first" ]; then
+      lo=$((lo - 1))
+      range=$(sd_para_range "$scan" "$lo")
+      start="${range% *}"
+    else
+      return 3
+    fi
+  done
+  printf '%s %s\n' "$start" "$end"
+}
+```
+
+`first`/`last` are read from the scan rather than assumed to be `1` and the paragraph count, so the loop terminates on any scan the scanner can produce. `sed -n "start,endp" | bash -n` is the parse check; stderr is discarded because a failing parse is expected control flow here, not an error to report.
+
+- [ ] **Step 12: run the tests and watch them pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_window'
+```
+
+Expect `1..5` and five `ok` lines.
+
+- [ ] **Step 13: commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m 'feat(seed-drift): grow the extraction window until the fragment parses'
+```
+
+---
+
+### Task 4: normalization — `sd_normalize`, then `sd_extract`
+
+**Files:**
+
+- modify `bin/seed-drift` (append `sd_neutralize_paths`, `sd_drop_priv_prefix`, `SD_OWNERSHIP_DROP`, `sd_normalize_code_line`, `sd_normalize`, `sd_extract`)
+- modify `tests/seed_drift.bats` (append two helpers and 12 `@test` blocks)
+
+**Interfaces:**
+
+*Consumes*
+
+- `sd_scan FILE` -> `para<TAB>lineno<TAB>tag<TAB>text` (Task 2); `sd_paras_with_anchor SCAN ANCHOR` -> paragraph indices one per line (Task 3); `sd_window FILE SCAN PARA` -> `start end` (Task 3).
+
+*Produces*
+
+- `sd_normalize` -> filter. Reads scan format (`para<TAB>lineno<TAB>tag<TAB>text`) on stdin, writes one normalized text line per surviving input line on stdout. C lines are joined/collapsed/trimmed/prefix-stripped/token-substituted and dropped when empty; `Hq` lines are copied byte-for-byte; `Hu` lines get path-token substitution and nothing else. Always exits 0.
+- `sd_extract FILE SCAN ANCHOR` -> normalized lines on stdout for the union of every matching paragraph's window, in file order, deduped by source line. Exit 4 if the anchor matches no paragraph; exit 3 if any window fails to parse (propagated from `sd_window`).
+
+---
+
+- [ ] **Step 1: write the failing tests for the C-line normalization rules.**
+
+Two more helpers, then four tests. `scan_line` builds the scan file one field at a time, which keeps every fixture readable and removes all tab-escaping ambiguity from the test source.
+
+```bash
+# --- Task 4 helpers ---------------------------------------------------------
+scan_line() {
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >>"$FIX/in.scan"
+}
+
+norm() {
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c \
+    'source "$1"; sd_normalize <"$2"' _ "$SEED_DRIFT" "$FIX/in.scan"
+}
+
+@test "sd_normalize joins backslash continuations and collapses whitespace" {
+  scan_line 1 1 C '  curl -fsSL   \'
+  scan_line 1 2 C '      -o out   url'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "curl -fsSL -o out url" ]
+}
+
+@test "sd_normalize drops privilege prefixes" {
+  scan_line 1 1 C 'as_user mkdir -p a'
+  scan_line 1 2 C '$SUDO mkdir -p b'
+  scan_line 1 3 C 'sudo -n mkdir -p c'
+  scan_line 1 4 C 'sudo mkdir -p d'
+  scan_line 1 5 C 'runuser -u node -- mkdir -p e'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "mkdir -p a
+mkdir -p b
+mkdir -p c
+mkdir -p d
+mkdir -p e" ]
+}
+
+@test "sd_normalize drops privilege words in command position, not just at line start" {
+  # Template line 218 vs wanderer's root-flavor equivalent: these must
+  # normalize identically or the spec's required "as_user vs direct
+  # invocation" false-positive guard fails on the core.excludesFile block.
+  scan_line 1 1 C 'if ! as_user test -f "$GITIGNORE"; then'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if ! test -f "$GITIGNORE"; then' ]
+}
+
+@test "sd_normalize drops privilege words after && and ||" {
+  # Template lines 390, 431 and 514 all stack privilege words mid-line.
+  scan_line 1 1 C 'if as_user test -x "$A" || as_user bash -lc "c"; then'
+  scan_line 1 2 C 'if as_user test -f "$N" && as_user test -x "$N"; then'
+  scan_line 1 3 C 'if as_user test -L "$C" || ! as_user test -e "$C"; then'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if test -x "$A" || bash -lc "c"; then
+if test -f "$N" && test -x "$N"; then
+if test -L "$C" || ! test -e "$C"; then' ]
+}
+
+@test "sd_normalize does not strip privilege words outside command position" {
+  # Over-broad stripping is the silent direction, so this guard matters more
+  # than the ones above: a genuine difference in an argument must survive.
+  scan_line 1 1 C 'grep as_user "$f"'
+  scan_line 1 2 C 'run_as_user_thing x'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'grep as_user "$f"
+run_as_user_thing x' ]
+}
+
+@test "sd_normalize substitutes the path token only and preserves surrounding quotes" {
+  scan_line 1 1 C '      TS_BIN="$SEED_HOME/.local/bin/tree-sitter"'
+  scan_line 1 2 C 'X="$HOME/a"'
+  scan_line 1 3 C 'Y="$DOTFILES_HOME/config"'
+  scan_line 1 4 C 'Z="$WORKSPACE/p"'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'TS_BIN="«HOME»/.local/bin/tree-sitter"
+X="«HOME»/a"
+Y="«HOME»/.dotfiles/config"
+Z="«WS»/p"' ]
+}
+
+@test "sd_normalize drops lines that normalize to empty" {
+  scan_line 1 1 C ''
+  scan_line 1 2 C '   '
+  scan_line 1 3 C 'echo keep'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "echo keep" ]
+}
+```
+
+The third test is the regression guard for the quote-eating bug an earlier prototype had: it asserts the *opening* `"` survives, so `TS_BIN="«HOME»/…"` and never `TS_BIN=«HOME»/…"`. The fourth covers the real source of empty C text — the scanner emits an empty C record for a full-line comment.
+
+- [ ] **Step 2: run the tests and watch them fail.**
+
+```
+bats tests/seed_drift.bats -f 'sd_normalize'
+```
+
+Expect 4 failures with `sd_normalize: command not found` in `$output`.
+
+- [ ] **Step 3: implement the C-line half of `sd_normalize`.**
+
+```bash
+sd_neutralize_paths() {
+  sed -e 's/\${SEED_HOME}/«HOME»/g' -e 's/\$SEED_HOME/«HOME»/g' \
+    -e 's/\${DOTFILES_HOME}/«HOME»\/.dotfiles/g' \
+    -e 's/\$DOTFILES_HOME/«HOME»\/.dotfiles/g' \
+    -e 's/\${WORKSPACE}/«WS»/g' -e 's/\$WORKSPACE/«WS»/g' \
+    -e 's/\${HOME}/«HOME»/g' -e 's/\$HOME/«HOME»/g'
+}
+
+sd_drop_priv_prefix() {
+  # Privilege words are dropped in COMMAND POSITION only: at line start, or
+  # right after an operator/keyword that begins a new command. `as_user` sits
+  # mid-line 8 times in the template (`if as_user test -x ...`,
+  # `... || as_user bash -lc ...`) and the live seeds split on it —
+  # wanderer-kills writes `if ! as_user test -f "$GITIGNORE"; then` where
+  # wanderer writes `if [ ! -f "$GITIGNORE" ]; then` — so a line-start-only
+  # rule would report every one of those shapes as drift.
+  local line="$1" prev=""
+  while [ "$line" != "$prev" ]; do
+    prev="$line"
+    line=$(printf '%s\n' "$line" | sed -E \
+      -e 's/(^|[{(|;!]|&&|\|\||\bif|\bthen|\bwhile|\buntil|\bdo|\belif)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2/g' \
+      -e 's/^(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+//' \
+      -e 's/(^|[{(|;!]|&&|\|\||\bif|\bthen|\bwhile|\buntil|\bdo|\belif)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2/g' \
+      -e 's/^runuser -u [^[:space:]]+ --[[:space:]]+//')
+  done
+  printf '%s' "$line"
+}
+
+sd_normalize_code_line() {
+  local line="$1"
+  line="${line//$'\t'/ }"
+  while [ "$line" != "${line//  / }" ]; do line="${line//  / }"; done
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [ -n "$line" ] || return 0
+  line=$(sd_drop_priv_prefix "$line")
+  [ -n "$line" ] || return 0
+  printf '%s\n' "$line" | sd_neutralize_paths
+}
+
+sd_normalize() {
+  local para lineno tag text pending="" joining=0
+  while IFS=$'\t' read -r para lineno tag text; do
+    if [ "$joining" = 1 ]; then
+      pending="$pending ${text#"${text%%[![:space:]]*}"}"
+    else
+      pending="$text"
+    fi
+    if [ "${pending%\\}" != "$pending" ]; then
+      pending="${pending%\\}"
+      joining=1
+      continue
+    fi
+    sd_normalize_code_line "$pending"
+    pending="" joining=0
+  done
+  [ "$joining" = 0 ] || sd_normalize_code_line "$pending"
+}
+```
+
+`$SEED_HOME` and `$DOTFILES_HOME` are substituted before `$HOME` so the longer names win; because the earlier expressions have already consumed them, the trailing `$HOME` rule cannot re-match their remnants. Substitution targets the bare token, so the quotes on either side are untouched. `sd_drop_priv_prefix` loops because `$SUDO runuser -u node -- cmd` stacks in the live seeds.
+
+`sd_drop_priv_prefix` matches in **command position** — line start, or after `{ ( | ; !`, `&&`, `||`, or one of `if then while until do elif`. Line-start-only matching was tried first and is wrong: the template puts `as_user` mid-line 8 times, and the seeds split on exactly those shapes.
+
+**Documented residual:** the rule is not quote-aware, so a privilege word inside a string that itself follows one of those separators — `echo "x; as_user y"` — would be stripped. No such line exists in the template or the five seeds. This is the same class of accepted residual as the literal workspace paths in Decision 4: narrow, documented, and not worth a quote-aware pass over normalized text.
+
+- [ ] **Step 4: run the tests and watch them pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_normalize'
+```
+
+Expect `1..4` and four `ok` lines.
+
+- [ ] **Step 5: commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m 'feat(seed-drift): normalize shell-code lines to comparable form'
+```
+
+- [ ] **Step 6: write the failing tests for heredoc-body handling.**
+
+```bash
+@test "sd_normalize passes Hq heredoc payload through verbatim" {
+  scan_line 1 1 Hq '# Personal docker-compose overrides.'
+  scan_line 1 2 Hq ''
+  scan_line 1 3 Hq '  keep   spacing'
+  scan_line 1 4 Hq 'trailing \'
+  scan_line 1 5 Hq '$HOME/literal'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '# Personal docker-compose overrides.
+
+  keep   spacing
+trailing \
+$HOME/literal' ]
+}
+
+@test "sd_normalize neutralizes paths in an Hu body but nothing else" {
+  scan_line 1 1 Hu '  $HOME/x   # not a comment'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '  «HOME»/x   # not a comment' ]
+}
+```
+
+The `Hq` test covers all four ways the C rules would corrupt payload, in one fixture: the `#` line is gitignore content (this is the real `GITEOF` body, template line 230) and must not be stripped; the blank line and the leading whitespace must survive; and the trailing `\` must not join the next line. The `Hu` test pins the shell-semantics carve-out — an unquoted delimiter means the shell itself expands `$HOME`, so the tool must too, while the whitespace and the `#` still pass through untouched.
+
+- [ ] **Step 7: run the tests and watch them fail.**
+
+```
+bats tests/seed_drift.bats -f 'heredoc payload|Hu body'
+```
+
+Expect 2 failures. Both currently take the C path, so the `#` line and `$HOME/literal` are deleted, whitespace is collapsed, and `trailing \` is joined onto the next line — the `[ "$output" = ... ]` assertions fail.
+
+- [ ] **Step 8: implement the heredoc branches in `sd_normalize`.**
+
+Replace the whole function:
+
+```bash
+sd_normalize() {
+  local para lineno tag text pending="" joining=0
+  while IFS=$'\t' read -r para lineno tag text; do
+    if [ "$tag" = C ]; then
+      if [ "$joining" = 1 ]; then
+        pending="$pending ${text#"${text%%[![:space:]]*}"}"
+      else
+        pending="$text"
+      fi
+      if [ "${pending%\\}" != "$pending" ]; then
+        pending="${pending%\\}"
+        joining=1
+        continue
+      fi
+      sd_normalize_code_line "$pending"
+      pending="" joining=0
+      continue
+    fi
+    # A heredoc body ends any pending continuation: a payload line is data and
+    # must never be folded into the shell line above it.
+    if [ "$joining" = 1 ]; then
+      sd_normalize_code_line "$pending"
+      pending="" joining=0
+    fi
+    if [ "$tag" = Hu ]; then
+      printf '%s\n' "$text" | sd_neutralize_paths
+    else
+      printf '%s\n' "$text"
+    fi
+  done
+  [ "$joining" = 0 ] || sd_normalize_code_line "$pending"
+}
+```
+
+- [ ] **Step 9: run the tests and watch them pass.**
+
+```
+bats tests/seed_drift.bats -f 'heredoc payload|Hu body'
+```
+
+Expect `1..2` and two `ok` lines. Then re-run `bats tests/seed_drift.bats -f 'sd_normalize'` and expect `1..6` with six `ok` lines — the C rules still hold.
+
+- [ ] **Step 10: commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m 'feat(seed-drift): compare heredoc payload verbatim, expanding only unquoted bodies'
+```
+
+- [ ] **Step 11: write the failing tests for the ownership rule.**
+
+The four literals below are the post-normalization form of template lines 491, 492, 594 and 595 — verified against the file, including the `-R` present on the neovim instance and absent on the tree-sitter one.
+
+```bash
+@test "sd_normalize drops the four exact ownership-verification lines" {
+  scan_line 1 1 C '      { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
+  scan_line 1 2 C '        [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+  scan_line 1 3 C '      { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||'
+  scan_line 1 4 C '        [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+  scan_line 1 5 C 'echo after'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "echo after" ]
+}
+
+@test "the ownership rule is exact: target, -R, identity, and unrelated chown all survive" {
+  scan_line 1 1 C '{ chown -R "$SEED_UID:$SEED_GID" "$OTHER.new" 2>/dev/null ||'
+  scan_line 1 2 C '{ chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
+  scan_line 1 3 C '{ chown -R "$SEED_UID:0" "$NVIM_DIST.new" 2>/dev/null ||'
+  scan_line 1 4 C 'chown -R node:node /app'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '{ chown -R "$SEED_UID:$SEED_GID" "$OTHER.new" 2>/dev/null ||
+{ chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+{ chown -R "$SEED_UID:0" "$NVIM_DIST.new" 2>/dev/null ||
+chown -R node:node /app' ]
+}
+```
+
+The second test is the whole point of the "nothing is free" rule, one line per way a broader match would have leaked: a changed target, the `-R` swapped between the two idioms, a changed identity, and an unrelated `chown`. Note line 2 is the tree-sitter idiom carrying the neovim target — literal matching keeps it, whereas a target-free rule would have silently dropped it.
+
+- [ ] **Step 12: run the tests and watch them fail.**
+
+```
+bats tests/seed_drift.bats -f 'ownership'
+```
+
+Expect 1 failure — the first test, whose `$output` is all five input lines rather than `echo after`. The second test passes already; it is the guard that the fix in Step 13 must not break.
+
+- [ ] **Step 13: implement the ownership drop.**
+
+Add the array beside the other constants:
+
+```bash
+# The non-root ownership-verification idiom, matched fully literally after
+# normalization: template lines 491-492 (chown -R, "$NVIM_DIST.new") and
+# 594-595 (plain chown, "$TS_BIN.new"). Two physical lines each, because the
+# first ends in `||` and the second in `; } &&`. Nothing in the match is free —
+# a changed flag, target or identity is drift, not vocabulary.
+SD_OWNERSHIP_DROP=(
+  '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
+  '[ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+  '{ chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||'
+  '[ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+)
+```
+
+Then replace `sd_normalize_code_line` in full:
+
+```bash
+sd_normalize_code_line() {
+  local line="$1" drop
+  line="${line//$'\t'/ }"
+  while [ "$line" != "${line//  / }" ]; do line="${line//  / }"; done
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [ -n "$line" ] || return 0
+  line=$(sd_drop_priv_prefix "$line")
+  [ -n "$line" ] || return 0
+  for drop in "${SD_OWNERSHIP_DROP[@]}"; do
+    [ "$line" = "$drop" ] && return 0
+  done
+  printf '%s\n' "$line" | sd_neutralize_paths
+}
+```
+
+The comparison runs after trimming and prefix-dropping but before path neutralization, which is why the literals still carry `$NVIM_DIST` and `$TS_BIN` — neither is a neutralized token.
+
+- [ ] **Step 14: run the tests and watch them pass.**
+
+```
+bats tests/seed_drift.bats -f 'ownership'
+```
+
+Expect `1..2` and two `ok` lines.
+
+- [ ] **Step 15: commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m 'feat(seed-drift): drop the four exact ownership-verification lines'
+```
+
+- [ ] **Step 16: write the failing tests for `sd_extract`.**
+
+```bash
+@test "sd_extract unions windows in file order, deduped, and normalizes" {
+  printf 'echo ANCHOR one\n\necho middle\n\nas_user echo ANCHOR two\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" ANCHOR
+  [ "$status" -eq 0 ]
+  [ "$output" = "echo ANCHOR one
+echo ANCHOR two" ]
+}
+
+@test "sd_extract deduplicates lines shared by two overlapping windows" {
+  printf 'if [ -n "$ANCHOR" ]; then\n\n  echo ANCHOR body\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" ANCHOR
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if [ -n "$ANCHOR" ]; then
+echo ANCHOR body
+fi' ]
+}
+
+@test "sd_extract drops comment-only lines and keeps the sed s#...#g idiom" {
+  printf '# reworded prose about ANCHOR\nsed '"'"'s#/app#/workspace#g'"'"' ANCHOR.txt # trailing\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" ANCHOR
+  [ "$status" -eq 0 ]
+  [ "$output" = "sed 's#/app#/workspace#g' ANCHOR.txt" ]
+}
+
+@test "sd_extract exits 4 when the anchor is absent" {
+  printf 'echo hi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" NOPE
+  [ "$status" -eq 4 ]
+}
+```
+
+The first fixture proves the union skips the non-matching middle paragraph and that the second paragraph is still normalized (`as_user` gone). The second is the overlap case: both paragraphs match `ANCHOR`, both grow to the same window `1 4`, and each source line must appear once. The third pins that the anchor's comment occurrence contributes nothing while `s#...#g` survives comment stripping.
+
+- [ ] **Step 17: run the tests and watch them fail.**
+
+```
+bats tests/seed_drift.bats -f 'sd_extract'
+```
+
+Expect 4 failures with `sd_extract: command not found` in `$output`.
+
+- [ ] **Step 18: implement `sd_extract`.**
+
+```bash
+sd_extract() {
+  local file="$1" scan="$2" anchor="$3" paras para window ranges=""
+
+  paras=$(sd_paras_with_anchor "$scan" "$anchor")
+  [ -n "$paras" ] || return 4
+
+  for para in $paras; do
+    window=$(sd_window "$file" "$scan" "$para") || return 3
+    ranges+="$window"$'\n'
+  done
+
+  # Union the windows by source line number: `sort -n -u` puts them in file
+  # order and collapses lines two overlapping windows both claim.
+  printf '%s' "$ranges" |
+    awk '{ for (i = $1; i <= $2; i++) print i }' | sort -n -u |
+    awk -F'\t' 'NR == FNR { keep[$1] = 1; next } keep[$2]' - "$scan" |
+    sd_normalize
+}
+```
+
+Deduplication is by *source line*, not by normalized text, so a genuinely repeated line inside one block is still compared twice — order-preserving comparison in Decision 5 depends on that. `$paras` is deliberately unquoted for word splitting; it holds only awk-printed integers. A window boundary can never cut a `\` continuation in half, because a fragment ending in a dangling `\` does not parse and `sd_window` would have grown past it.
+
+- [ ] **Step 19: run the tests and watch them pass.**
+
+```
+bats tests/seed_drift.bats -f 'sd_extract'
+```
+
+Expect `1..4` and four `ok` lines. Then run the full suite plus both linters:
+
+```
+bats tests/seed_drift.bats
+shfmt -i 2 -ci -d bin/seed-drift
+shellcheck -x -S warning bin/seed-drift
+```
+
+Expect every `@test` from Tasks 2-4 to pass, and both linters to produce no output.
+
+- [ ] **Step 20: commit.**
+
+```
+git add bin/seed-drift tests/seed_drift.bats
+git commit -m 'feat(seed-drift): extract normalized block text for every anchor match'
+```
+
+---
+
+### Task 5: verdicts (`sd_verdict`)
+
+Implements Decision 5. The comparison is an **order-preserving** `diff` of the two
+normalized line sequences, never a sorted/multiset comparison: statement order is
+behaviorally load-bearing (`catch-up-local-seed.md:83` requires the
+`load-custom.zsh` hook *before* the Vekil hook, because `ai/vekil/env.zsh` exports
+`ANTHROPIC_MODEL` and must get the last word). A pure reordering therefore
+produces differences in both directions and is reported `DIVERGED`.
+
+**Files:**
+- modify `bin/seed-drift`
+- modify `tests/seed_drift.bats`
+
+**Interfaces:**
+
+*Consumes*
+- `sd_extract FILE SCAN ANCHOR` (Task 4) — writes normalized lines to a file;
+  exits `4` when the anchor is absent. Task 5 consumes only its **output files**,
+  never its exit code; `MISSING` is raised by `sd_check_seed` in Task 6, because
+  the contract fixes `sd_verdict`'s signature at two file paths.
+- `sd_source` (bats helper added by Task 1) — `run env SEED_DRIFT_SOURCE_ONLY=1
+  bash -c 'source "$1"; shift; "$@"' _ "$SEED_DRIFT" "$@"`.
+
+*Produces*
+- `sd_diff_lines TPL_NORM SEED_NORM MARKER` → the differing lines, one per line,
+  on stdout. `MARKER` is `<` for template-only lines and `>` for seed-only lines.
+  Returns `3` if `diff` fails for a reason other than "files differ".
+- `sd_count_lines TEXT` → the number of non-empty lines in `TEXT`, on stdout.
+- `sd_verdict TPL_NORM SEED_NORM` → exactly one of `ok`, `BEHIND`, `AHEAD`,
+  `DIVERGED` on stdout, exit `0`.
+
+---
+
+- [ ] **Step 1: write the failing test for the diff primitive.**
+  Append to `tests/seed_drift.bats`:
+
+  ```bash
+  write_lines() {
+    local path="$1"
+    shift
+    printf '%s\n' "$@" >"$path"
+  }
+
+  @test "sd_diff_lines names the lines missing from each side" {
+    write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_old'
+    write_lines "$TEST_ROOT/seed" 'export A=1' 'run_new'
+
+    sd_source sd_diff_lines "$TEST_ROOT/tpl" "$TEST_ROOT/seed" '<'
+    [ "$status" -eq 0 ]
+    [ "$output" = "run_old" ]
+
+    sd_source sd_diff_lines "$TEST_ROOT/tpl" "$TEST_ROOT/seed" '>'
+    [ "$status" -eq 0 ]
+    [ "$output" = "run_new" ]
+  }
+  ```
+
+- [ ] **Step 2: run it and see it fail.**
+  `bats tests/seed_drift.bats -f 'sd_diff_lines names the lines'`
+  Expected: `not ok 1 sd_diff_lines names the lines missing from each side`, with
+  bats reporting `exited with code 127` (`sd_diff_lines: command not found`).
+
+- [ ] **Step 3: implement the diff primitive.**
+  Insert into `bin/seed-drift`, immediately above `sd_main()`:
+
+  ```bash
+  sd_diff_lines() {
+    # TPL_NORM SEED_NORM MARKER; MARKER is '<' for template-only lines and '>'
+    # for seed-only lines. The diff is ordered, so a pure reordering yields lines
+    # under both markers rather than comparing equal.
+    local out rc=0
+    out=$(diff -- "$1" "$2") || rc=$?
+    if [ "$rc" -gt 1 ]; then
+      printf 'seed-drift: diff failed comparing %s and %s\n' "$1" "$2" >&2
+      return 3
+    fi
+    printf '%s' "$out" | sed -n "s/^$3 //p"
+  }
+
+  sd_count_lines() {
+    printf '%s' "$1" | grep -c . || true
+  }
+  ```
+
+- [ ] **Step 4: run it and see it pass.**
+  `bats tests/seed_drift.bats -f 'sd_diff_lines names the lines'`
+  Expected: `ok 1 sd_diff_lines names the lines missing from each side`.
+
+- [ ] **Step 5: commit.**
+  `git add bin/seed-drift tests/seed_drift.bats && git commit -m 'feat: add ordered diff primitives for seed drift verdicts'`
+
+- [ ] **Step 6: write the failing tests for the three single-direction verdicts.**
+  Append to `tests/seed_drift.bats`:
+
+  ```bash
+  @test "sd_verdict reports ok for identical line sequences" {
+    write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_thing' 'export B=2'
+    write_lines "$TEST_ROOT/seed" 'export A=1' 'run_thing' 'export B=2'
+
+    sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ok" ]
+  }
+
+  @test "sd_verdict reports ok for two empty extractions" {
+    : >"$TEST_ROOT/tpl"
+    : >"$TEST_ROOT/seed"
+
+    sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "ok" ]
+  }
+
+  @test "sd_verdict reports BEHIND when only the template has extra lines" {
+    write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_thing' 'export B=2'
+    write_lines "$TEST_ROOT/seed" 'export A=1' 'export B=2'
+
+    sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "BEHIND" ]
+  }
+
+  @test "sd_verdict reports AHEAD when only the seed has extra lines" {
+    write_lines "$TEST_ROOT/tpl" 'export A=1' 'export B=2'
+    write_lines "$TEST_ROOT/seed" 'export A=1' 'run_thing' 'export B=2'
+
+    sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "AHEAD" ]
+  }
+  ```
+
+- [ ] **Step 7: run them and see them fail.**
+  `bats tests/seed_drift.bats -f 'sd_verdict reports'`
+  Expected: all four `not ok`, each reporting `exited with code 127`
+  (`sd_verdict: command not found`).
+
+- [ ] **Step 8: implement the single-direction verdicts.**
+  Insert into `bin/seed-drift`, immediately after `sd_count_lines`. The `else`
+  branch deliberately fails loudly rather than guessing — Step 13 supplies the
+  two-direction case, and an unclassified pair must never fall through to `ok`:
+
+  ```bash
+  sd_verdict() {
+    local behind ahead
+    behind=$(sd_count_lines "$(sd_diff_lines "$1" "$2" '<')")
+    ahead=$(sd_count_lines "$(sd_diff_lines "$1" "$2" '>')")
+    if [ "$behind" -eq 0 ] && [ "$ahead" -eq 0 ]; then
+      printf 'ok\n'
+    elif [ "$ahead" -eq 0 ]; then
+      printf 'BEHIND\n'
+    elif [ "$behind" -eq 0 ]; then
+      printf 'AHEAD\n'
+    else
+      return 1
+    fi
+  }
+  ```
+
+- [ ] **Step 9: run them and see them pass.**
+  `bats tests/seed_drift.bats -f 'sd_verdict reports'`
+  Expected: `ok` for all four (`ok for identical line sequences`,
+  `ok for two empty extractions`, `BEHIND when only the template has extra
+  lines`, `AHEAD when only the seed has extra lines`).
+
+- [ ] **Step 10: commit.**
+  `git add bin/seed-drift tests/seed_drift.bats && git commit -m 'feat: classify single-direction seed drift as ok, BEHIND or AHEAD'`
+
+- [ ] **Step 11: write the failing order test — mandatory, and a real fixture.**
+  The first assertion is the point of the test: the two files are identical when
+  sorted, so a multiset comparison would report `ok`. Append to
+  `tests/seed_drift.bats`:
+
+  ```bash
+  @test "sd_verdict reports DIVERGED for a pure reordering, never ok" {
+    write_lines "$TEST_ROOT/tpl" \
+      'printf "source «HOME»/.dotfiles/load-custom.zsh" >>«HOME»/.zshrc' \
+      'printf "source «HOME»/ai/vekil/env.zsh" >>«HOME»/.zshrc'
+    write_lines "$TEST_ROOT/seed" \
+      'printf "source «HOME»/ai/vekil/env.zsh" >>«HOME»/.zshrc' \
+      'printf "source «HOME»/.dotfiles/load-custom.zsh" >>«HOME»/.zshrc'
+
+    # Same lines, different order: a sorted comparison would call this clean.
+    run diff <(sort "$TEST_ROOT/tpl") <(sort "$TEST_ROOT/seed")
+    [ "$status" -eq 0 ]
+
+    sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "DIVERGED" ]
+  }
+
+  @test "sd_verdict reports DIVERGED when lines differ in both directions" {
+    write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_old'
+    write_lines "$TEST_ROOT/seed" 'export A=1' 'run_new'
+
+    sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "DIVERGED" ]
+  }
+  ```
+
+- [ ] **Step 12: run them and see them fail.**
+  `bats tests/seed_drift.bats -f 'DIVERGED'`
+  Expected: both `not ok`, failing on `[ "$status" -eq 0 ]` — `sd_verdict`
+  currently returns `1` with empty output for two-direction differences. The
+  `run diff <(sort ...)` assertion passes, confirming the fixture really is a
+  pure reordering.
+
+- [ ] **Step 13: implement the DIVERGED branch.**
+  In `bin/seed-drift`, replace the `else` branch of `sd_verdict`:
+
+  ```bash
+    else
+      printf 'DIVERGED\n'
+    fi
+  ```
+
+- [ ] **Step 14: run the whole verdict group and see it pass.**
+  `bats tests/seed_drift.bats -f 'sd_verdict'`
+  Expected: six `ok` lines, including
+  `ok N sd_verdict reports DIVERGED for a pure reordering, never ok`.
+
+- [ ] **Step 15: commit.**
+  `git add bin/seed-drift tests/seed_drift.bats && git commit -m 'feat: report reordered seed blocks as DIVERGED rather than clean'`
+
+---
+
+### Task 6: discovery, reporting, exit codes (`sd_check_seed` and main)
+
+Implements Decision 6 and the Output section. `sd_main` already exists from
+Task 1 with option parsing, `SD_CANDIDATES`, the template-readable check, and the
+doc/template anchor-agreement check (exit `2`); this task extends it rather than
+replacing it.
+
+**Files:**
+- modify `bin/seed-drift`
+- modify `tests/seed_drift.bats`
+
+**Interfaces:**
+
+*Consumes*
+- `sd_parse_doc DOCFILE` (Task 1) → `blockname<TAB>anchor`, one row per line.
+- `sd_extract FILE SCAN ANCHOR` (Task 4) → normalized lines on stdout; exit `4`
+  when the anchor is absent.
+- `sd_verdict TPL_NORM SEED_NORM`, `sd_diff_lines`, `sd_count_lines` (Task 5).
+- `SD_CANDIDATES` (bash array, set by Task 1's option parser), `SEED_DRIFT_ROOT`
+  (default `$HOME/workspace`).
+
+*Produces*
+- `sd_check_seed SEED` → per-block report on stdout; returns `0` clean, `1` any
+  drift, `2` the seed does not parse or a block is unextractable.
+- `sd_visit_dir DIR`, `sd_visit_candidates`, `sd_summary`, `sd_worst RC`,
+  `sd_report_block VERDICT BLOCK DETAIL`, `sd_report_samples` (filter),
+  `sd_report_action TEXT`.
+- Counters `SD_CHECKED SD_SKIPPED SD_BEHIND SD_AHEAD SD_DIVERGED SD_MISSING`
+  and `SD_WORST`. These are plain globals mutated in the caller's shell —
+  `sd_check_seed` reads the doc via `done < <(sd_parse_doc "$SD_DOC")` process
+  substitution, **not** a pipe, so the increments survive.
+- `sd_main` exit status: `0` clean (skips included), `1` any drift, `2` usage /
+  template / doc / extraction error — the maximum severity over all candidates.
+- Summary line: `4 checked, 1 skipped, 2 blocks drifted (1 behind, 1 ahead)`.
+  The parenthetical lists only non-zero categories in the order behind, ahead,
+  diverged, missing, and is omitted entirely when nothing drifted.
+
+---
+
+- [ ] **Step 1: write the failing discovery tests.**
+  Append to `tests/seed_drift.bats` (`write_drift_doc` is separate from Task 1's
+  `write_fixture_doc` so the two fixture sets do not collide):
+
+  ```bash
+  write_drift_template() {
+    cat >"$1" <<'TPL'
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  TREE_SITTER_VERSION=0.25.10
+  install_tree_sitter "$TREE_SITTER_VERSION"
+  echo "seed: tree-sitter ready"
+
+  GITIGNORE="$HOME/.gitignore_global"
+  git config --global core.excludesFile "$GITIGNORE"
+  TPL
+  }
+
+  write_drift_doc() {
+    cat >"$1" <<'DOC'
+  | Block | Anchor in template | Why it matters |
+  |---|---|---|
+  | tree-sitter CLI | `TREE_SITTER_VERSION` | pinned install |
+  | global gitignore | `core.excludesFile` | git config |
+  DOC
+  }
+
+  setup_drift_fixtures() {
+    export SEED_DRIFT_ROOT="$TEST_ROOT/workspace"
+    mkdir -p "$SEED_DRIFT_ROOT"
+    FIXTURE_TEMPLATE="$TEST_ROOT/template.sh"
+    FIXTURE_DOC="$TEST_ROOT/catch-up.md"
+    write_drift_template "$FIXTURE_TEMPLATE"
+    write_drift_doc "$FIXTURE_DOC"
+  }
+
+  make_project() { mkdir -p "$SEED_DRIFT_ROOT/$1/.devcontainer"; }
+  seed_path() { printf '%s\n' "$SEED_DRIFT_ROOT/$1/.devcontainer/local-seed.sh"; }
+  seed_from_template() { make_project "$1"; write_drift_template "$(seed_path "$1")"; }
+  sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DOC" "$@"; }
+
+  @test "a clean seed exits 0 and is counted as checked" {
+    setup_drift_fixtures
+    seed_from_template clean
+
+    sd_drift
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok       tree-sitter CLI"* ]]
+    [[ "$output" == *"1 checked, 0 skipped, 0 blocks drifted"* ]]
+  }
+
+  @test "a candidate with .devcontainer but no seed is skipped and a plain directory is silent" {
+    setup_drift_fixtures
+    seed_from_template clean
+    make_project noseed
+    mkdir -p "$SEED_DRIFT_ROOT/unrelated"
+
+    sd_drift
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"noseed  .devcontainer/ present, no local-seed.sh - skipped"* ]]
+    [[ "$output" != *"unrelated"* ]]
+    [[ "$output" == *"1 checked, 1 skipped, 0 blocks drifted"* ]]
+  }
+
+  @test "checked plus skipped equals the number of candidates" {
+    setup_drift_fixtures
+    seed_from_template one
+    seed_from_template two
+    make_project three
+    mkdir -p "$SEED_DRIFT_ROOT/not-a-candidate"
+
+    sd_drift
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"2 checked, 1 skipped"* ]]
+  }
+  ```
+
+- [ ] **Step 2: run them and see them fail.**
+  `bats tests/seed_drift.bats -f 'checked'`
+  Expected: all three `not ok`. `sd_main` returns `0` but prints nothing after
+  the anchor check, so each fails on its first `[[ "$output" == *...* ]]`
+  assertion.
+
+- [ ] **Step 3: implement the reporting primitives, the clean path, and discovery.**
+  Insert into `bin/seed-drift` immediately above `sd_main()`. `sd_check_seed`
+  handles only the `ok` verdict for now; Step 8 adds the drift branches:
+
+  ```bash
+  SD_TEMPLATE="" SD_DOC=""
+  SD_CHECKED=0 SD_SKIPPED=0
+  SD_BEHIND=0 SD_AHEAD=0 SD_DIVERGED=0 SD_MISSING=0
+  SD_WORST=0
+
+  sd_worst() {
+    [ "$1" -gt "$SD_WORST" ] && SD_WORST="$1"
+    return 0
+  }
+
+  sd_report_block() {
+    if [ -n "$3" ]; then
+      printf '  %-8s %-20s %s\n' "$1" "$2" "$3"
+    else
+      printf '  %-8s %s\n' "$1" "$2"
+    fi
+  }
+
+  sd_report_samples() {
+    local shown=0 line
+    while IFS= read -r line; do
+      [ "$shown" -lt 2 ] || break
+      [ "${#line}" -le 56 ] || line="${line:0:53}..."
+      printf '             - %s\n' "$line"
+      shown=$((shown + 1))
+    done
+  }
+
+  sd_report_action() {
+    printf '             -> %s\n' "$1"
+  }
+
+  sd_check_seed() {
+    local seed="$1" name rc=0 block anchor verdict tnorm snorm
+    name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
+    printf '%s  %s\n' "$name" "$seed"
+    tnorm="$(mktemp)"
+    snorm="$(mktemp)"
+    while IFS=$'\t' read -r block anchor; do
+      sd_extract "$SD_TEMPLATE" "" "$anchor" >"$tnorm"
+      sd_extract "$seed" "" "$anchor" >"$snorm"
+      verdict=$(sd_verdict "$tnorm" "$snorm")
+      case "$verdict" in
+        ok) sd_report_block ok "$block" '' ;;
+      esac
+    done < <(sd_parse_doc "$SD_DOC")
+    rm -f -- "$tnorm" "$snorm"
+    return "$rc"
+  }
+
+  sd_summary() {
+    local drifted=$((SD_BEHIND + SD_AHEAD + SD_DIVERGED + SD_MISSING)) parts="" pair
+    for pair in "behind:$SD_BEHIND" "ahead:$SD_AHEAD" \
+      "diverged:$SD_DIVERGED" "missing:$SD_MISSING"; do
+      [ "${pair#*:}" -gt 0 ] || continue
+      parts="${parts:+$parts, }${pair#*:} ${pair%%:*}"
+    done
+    printf '\n%d checked, %d skipped, %d blocks drifted%s\n' \
+      "$SD_CHECKED" "$SD_SKIPPED" "$drifted" "${parts:+ ($parts)}"
+  }
+
+  sd_visit_dir() {
+    local dir="$1" seed="$1/.devcontainer/local-seed.sh" rc=0
+    if [ ! -f "$seed" ]; then
+      printf '%s  .devcontainer/ present, no local-seed.sh - skipped\n' \
+        "$(basename -- "$dir")"
+      SD_SKIPPED=$((SD_SKIPPED + 1))
+      return 0
+    fi
+    SD_CHECKED=$((SD_CHECKED + 1))
+    sd_check_seed "$seed" || rc=$?
+    sd_worst "$rc"
+  }
+
+  sd_visit_candidates() {
+    local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand
+    shopt -s nullglob
+    for cand in "$root"/*/; do
+      cand="${cand%/}"
+      # A directory without .devcontainer/ is not a candidate: silent, not skipped.
+      [ -d "$cand/.devcontainer" ] || continue
+      sd_visit_dir "$cand"
+    done
+  }
+  ```
+
+  Then replace the trailing `return 0` of `sd_main` with:
+
+  ```bash
+    SD_TEMPLATE="$template"
+    SD_DOC="$doc"
+    sd_visit_candidates
+    sd_summary
+    return "$SD_WORST"
+  }
+  ```
+
+- [ ] **Step 4: run them and see them pass.**
+  `bats tests/seed_drift.bats -f 'checked'`
+  Expected: `ok` for `a clean seed exits 0 and is counted as checked`,
+  `a candidate with .devcontainer but no seed is skipped and a plain directory
+  is silent`, and `checked plus skipped equals the number of candidates`.
+
+- [ ] **Step 5: commit.**
+  `git add bin/seed-drift tests/seed_drift.bats && git commit -m 'feat: discover seed candidates and report clean projects with a summary'`
+
+- [ ] **Step 6: write the failing drift-reporting tests.**
+  Each asserts the project, the block, and the direction; the `AHEAD` and
+  `DIVERGED` cases assert the promotion / inspect wording and assert the output
+  never suggests overwriting. Append to `tests/seed_drift.bats`:
+
+  ```bash
+  @test "a behind seed exits 1 and the finding names project, block and direction" {
+    setup_drift_fixtures
+    seed_from_template behindp
+    sed -i '/tree-sitter ready/d' "$(seed_path behindp)"
+
+    sd_drift
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"behindp  $(seed_path behindp)"* ]]
+    [[ "$output" == *"BEHIND   tree-sitter CLI      1 template lines absent from seed"* ]]
+    [[ "$output" == *'- echo "seed: tree-sitter ready"'* ]]
+    [[ "$output" == *"port from template; see catch-up-local-seed.md Step 2"* ]]
+    [[ "$output" == *"1 checked, 0 skipped, 1 blocks drifted (1 behind)"* ]]
+  }
+
+  @test "an ahead seed is a promotion candidate and never suggests overwriting" {
+    setup_drift_fixtures
+    seed_from_template aheadp
+    sed -i '/tree-sitter ready/a echo "seed: project extra"' "$(seed_path aheadp)"
+
+    sd_drift
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AHEAD    tree-sitter CLI      1 seed lines absent from template"* ]]
+    [[ "$output" == *"promotion candidate; do NOT overwrite the seed"* ]]
+    [[ "$output" != *"overwrite the seed with"* ]]
+  }
+
+  @test "a reordered seed is DIVERGED and told to inspect by hand" {
+    setup_drift_fixtures
+    seed_from_template reorder
+    sed -i '5d' "$(seed_path reorder)"
+    sed -i '/tree-sitter ready/a install_tree_sitter "$TREE_SITTER_VERSION"' \
+      "$(seed_path reorder)"
+
+    sd_drift
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"DIVERGED tree-sitter CLI"* ]]
+    [[ "$output" == *"inspect by hand; do NOT overwrite the seed"* ]]
+  }
+
+  @test "an anchor absent from the seed is MISSING" {
+    setup_drift_fixtures
+    seed_from_template gone
+    sed -i '/core.excludesFile/d' "$(seed_path gone)"
+
+    sd_drift
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"MISSING  global gitignore     anchor absent from seed"* ]]
+    [[ "$output" == *"1 blocks drifted (1 missing)"* ]]
+  }
+  ```
+
+- [ ] **Step 7: run them and see them fail.**
+  `bats tests/seed_drift.bats -f 'seed is|seed exits 1|absent from the seed'`
+  Expected: all four `not ok`. The `BEHIND`, `AHEAD` and `DIVERGED` cases fall
+  through the `case` silently and exit `0`, so each fails on
+  `[ "$status" -eq 1 ]`; the `MISSING` case fails on the unhandled exit `4` from
+  `sd_extract`.
+
+- [ ] **Step 8: implement the drift branches.**
+  In `bin/seed-drift`, replace the body of `sd_check_seed` between the `tnorm`/
+  `snorm` assignments and the `rm -f` line:
+
+  ```bash
+    while IFS=$'\t' read -r block anchor; do
+      if ! sd_extract "$SD_TEMPLATE" "" "$anchor" >"$tnorm"; then
+        sd_report_block ERROR "$block" 'anchor absent from template'
+        rc=2
+        continue
+      fi
+      if ! sd_extract "$seed" "" "$anchor" >"$snorm"; then
+        sd_report_block MISSING "$block" 'anchor absent from seed'
+        sd_report_action 'port the block; see catch-up-local-seed.md Step 2'
+        SD_MISSING=$((SD_MISSING + 1))
+        [ "$rc" -ge 1 ] || rc=1
+        continue
+      fi
+      behind=$(sd_diff_lines "$tnorm" "$snorm" '<')
+      ahead=$(sd_diff_lines "$tnorm" "$snorm" '>')
+      nb=$(sd_count_lines "$behind")
+      na=$(sd_count_lines "$ahead")
+      verdict=$(sd_verdict "$tnorm" "$snorm")
+      case "$verdict" in
+        ok)
+          sd_report_block ok "$block" ''
+          ;;
+        BEHIND)
+          sd_report_block BEHIND "$block" "$nb template lines absent from seed"
+          printf '%s\n' "$behind" | sd_report_samples
+          sd_report_action 'port from template; see catch-up-local-seed.md Step 2'
+          SD_BEHIND=$((SD_BEHIND + 1))
+          [ "$rc" -ge 1 ] || rc=1
+          ;;
+        AHEAD)
+          sd_report_block AHEAD "$block" "$na seed lines absent from template"
+          printf '%s\n' "$ahead" | sd_report_samples
+          sd_report_action 'promotion candidate; do NOT overwrite the seed'
+          SD_AHEAD=$((SD_AHEAD + 1))
+          [ "$rc" -ge 1 ] || rc=1
+          ;;
+        DIVERGED)
+          sd_report_block DIVERGED "$block" \
+            "$nb template lines absent from seed, $na seed lines absent from template"
+          sd_report_action 'inspect by hand; do NOT overwrite the seed'
+          SD_DIVERGED=$((SD_DIVERGED + 1))
+          [ "$rc" -ge 1 ] || rc=1
+          ;;
+      esac
+    done < <(sd_parse_doc "$SD_DOC")
+  ```
+
+  and widen the function's `local` line to declare the new variables:
+
+  ```bash
+    local seed="$1" name rc=0 block anchor verdict tnorm snorm behind ahead nb na
+  ```
+
+- [ ] **Step 9: run them and see them pass.**
+  `bats tests/seed_drift.bats -f 'seed is|seed exits 1|absent from the seed'`
+  Expected: four `ok` lines, including `a reordered seed is DIVERGED and told to
+  inspect by hand`.
+
+- [ ] **Step 10: commit.**
+  `git add bin/seed-drift tests/seed_drift.bats && git commit -m 'feat: report BEHIND, AHEAD, DIVERGED and MISSING blocks per project'`
+
+- [ ] **Step 11: write the failing argument-classification tests.**
+  Append to `tests/seed_drift.bats`:
+
+  ```bash
+  @test "a nonexistent argument is skipped and named, exit 0" {
+    setup_drift_fixtures
+
+    sd_drift "$SEED_DRIFT_ROOT/absent-project"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent-project - not present on this machine - skipped"* ]]
+    [[ "$output" == *"0 checked, 1 skipped, 0 blocks drifted"* ]]
+  }
+
+  @test "an argument is accepted as a project directory or as a direct seed path" {
+    setup_drift_fixtures
+    seed_from_template clean
+
+    sd_drift "$SEED_DRIFT_ROOT/clean"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1 checked, 0 skipped"* ]]
+
+    sd_drift "$(seed_path clean)"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1 checked, 0 skipped"* ]]
+  }
+  ```
+
+- [ ] **Step 12: run them and see them fail.**
+  `bats tests/seed_drift.bats -f 'argument'`
+  Expected: both `not ok`. `sd_visit_candidates` ignores `SD_CANDIDATES` and
+  globs `$SEED_DRIFT_ROOT` regardless, so both report `0 checked, 0 skipped` and
+  fail their first `[[ "$output" == *...* ]]` assertion.
+
+- [ ] **Step 13: honour explicit candidates.**
+  In `bin/seed-drift`, replace `sd_visit_candidates` with:
+
+  ```bash
+  sd_visit_candidates() {
+    local root="${SEED_DRIFT_ROOT:-$HOME/workspace}" cand rc=0
+    if [ "${#SD_CANDIDATES[@]}" -eq 0 ]; then
+      shopt -s nullglob
+      for cand in "$root"/*/; do
+        cand="${cand%/}"
+        # A directory without .devcontainer/ is not a candidate: silent, not skipped.
+        [ -d "$cand/.devcontainer" ] || continue
+        sd_visit_dir "$cand"
+      done
+      return 0
+    fi
+    for cand in "${SD_CANDIDATES[@]}"; do
+      if [ -d "$cand" ]; then
+        [ -d "$cand/.devcontainer" ] || continue
+        sd_visit_dir "$cand"
+      elif [ -e "$cand" ]; then
+        # An existing file is a direct local-seed.sh path.
+        SD_CHECKED=$((SD_CHECKED + 1))
+        rc=0
+        sd_check_seed "$cand" || rc=$?
+        sd_worst "$rc"
+      else
+        # Not checked out here. A skip, so the same project list works on every
+        # machine; it names the path and is counted, so a typo stays visible.
+        printf '%s - not present on this machine - skipped\n' "$cand"
+        SD_SKIPPED=$((SD_SKIPPED + 1))
+      fi
+    done
+  }
+  ```
+
+- [ ] **Step 14: run them and see them pass.**
+  `bats tests/seed_drift.bats -f 'argument'`
+  Expected: `ok N a nonexistent argument is skipped and named, exit 0` and
+  `ok N an argument is accepted as a project directory or as a direct seed path`.
+
+- [ ] **Step 15: commit.**
+  `git add bin/seed-drift tests/seed_drift.bats && git commit -m 'feat: classify seed-drift arguments as project, seed path or absent skip'`
+
+- [ ] **Step 16: write the failing parse-failure and severity tests.**
+  The malformed-seed test uses `aaa-`/`zzz-` prefixes so the broken seed is
+  visited *first* under the glob's sort order — that is what makes it a real
+  guard against aborting on the first bad seed. Append to
+  `tests/seed_drift.bats`:
+
+  ```bash
+  @test "a malformed seed exits 2 without suppressing drift in the others" {
+    setup_drift_fixtures
+    seed_from_template aaa-broken
+    printf 'if true; then\nTREE_SITTER_VERSION=1\n' >"$(seed_path aaa-broken)"
+    seed_from_template zzz-behind
+    sed -i '/tree-sitter ready/d' "$(seed_path zzz-behind)"
+
+    sd_drift
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"does not parse (bash -n)"* ]]
+    [[ "$output" == *"BEHIND   tree-sitter CLI"* ]]
+    [[ "$output" == *"2 checked, 0 skipped, 1 blocks drifted (1 behind)"* ]]
+  }
+
+  @test "an unparseable template is exit 2 before any verdict" {
+    setup_drift_fixtures
+    seed_from_template clean
+    printf 'if true; then\n' >"$FIXTURE_TEMPLATE"
+
+    sd_drift
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"template does not parse"* ]]
+    [[ "$output" != *"ok       tree-sitter CLI"* ]]
+  }
+
+  @test "the detector never writes to a seed" {
+    setup_drift_fixtures
+    seed_from_template clean
+    local before after
+    before=$(cksum <"$(seed_path clean)")
+
+    sd_drift
+
+    after=$(cksum <"$(seed_path clean)")
+    [ "$before" = "$after" ]
+  }
+  ```
+
+- [ ] **Step 17: run them and see them fail.**
+  `bats tests/seed_drift.bats -f 'malformed|unparseable|never writes'`
+  Expected: `a malformed seed exits 2 without suppressing drift in the others`
+  and `an unparseable template is exit 2 before any verdict` both `not ok`,
+  failing on `[ "$status" -eq 2 ]`; `the detector never writes to a seed` already
+  passes and stays green as a regression guard.
+
+- [ ] **Step 18: add the two `bash -n` gates.**
+  In `bin/seed-drift`, insert at the top of `sd_check_seed`, directly after the
+  `printf '%s  %s\n' "$name" "$seed"` line:
+
+  ```bash
+    if ! bash -n "$seed" 2>/dev/null; then
+      sd_report_block ERROR "$name" 'does not parse (bash -n)'
+      return 2
+    fi
+  ```
+
+  In `sd_main`, insert immediately **before** the `local blocks` / `sd_parse_doc`
+  block — ahead of the anchor-agreement check, because a template that does not
+  parse makes every anchor verdict derived from it meaningless:
+
+  ```bash
+    if ! bash -n "$template" 2>/dev/null; then
+      printf 'seed-drift: template does not parse: %s\n' "$template" >&2
+      return 2
+    fi
+  ```
+
+- [ ] **Step 19: run the full suite and see it pass.**
+  `bats tests/seed_drift.bats`
+  Expected: every test `ok`, including
+  `a malformed seed exits 2 without suppressing drift in the others`,
+  `an unparseable template is exit 2 before any verdict`, and
+  `the detector never writes to a seed`. Then confirm the linters:
+  `shfmt -i 2 -ci -d bin/seed-drift && shellcheck -x -S warning bin/seed-drift`
+  Expected: no output from either, exit `0`.
+
+- [ ] **Step 20: commit.**
+  `git add bin/seed-drift tests/seed_drift.bats && git commit -m 'feat: fail closed on unparseable templates and seeds without hiding drift'`
+
+---
+
+### Task 7: full regression suite, read-only guarantee, and verification
+
+**Files:**
+- `tests/seed_drift.bats` (append; 25 new tests)
+- No production file changes expected. If a test in this task fails, `bin/seed-drift` has a real gap and must be fixed before the task continues — these tests are the specification, not decoration.
+
+**Interfaces:** (from CONTRACT.md, unchanged by this task)
+- `bin/seed-drift [--template PATH] [--doc PATH] [--help] [CANDIDATE...]`
+- exit `0` clean (skips included) | `1` any drift | `2` usage/template/doc/extraction error
+- verdict tokens printed per block: `ok` | `MISSING` | `BEHIND` | `AHEAD` | `DIVERGED`
+- doc table row shape: `| Block name | \`anchor\` | why |`
+
+---
+
+- [ ] **Step 1: add the Task-7 fixture helpers.**
+
+Append to `tests/seed_drift.bats`. Names are `t7_`-prefixed so they cannot collide with helpers introduced in Tasks 1-6.
+
+```bash
+# ── Task 7 fixture helpers ───────────────────────────────────────────────────
+
+t7_setup() {
+  TPL="$BATS_TEST_TMPDIR/template.sh"
+  DOC="$BATS_TEST_TMPDIR/catch-up.md"
+  WS="$TEST_ROOT/ws"
+  PROJ="$WS/demo"
+  SEED="$PROJ/.devcontainer/local-seed.sh"
+  mkdir -p "$PROJ/.devcontainer"
+  export SEED_DRIFT_ROOT="$WS"
+}
+
+# t7_doc "Block name" anchor [ "Block name" anchor ... ]
+t7_doc() {
+  {
+    printf '| Block | Anchor in template | Why it matters |\n'
+    printf '|---|---|---|\n'
+    while [ "$#" -gt 0 ]; do
+      printf '| %s | `%s` | fixture row |\n' "$1" "$2"
+      shift 2
+    done
+  } >"$DOC"
+}
+
+t7_run() {
+  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC" "$@"
+}
+```
+
+- [ ] **Step 2: the MOTIVATING test — anchor present, surrounding block outdated.**
+
+This is the case the whole tool exists for: all five live seeds carried `TREE_SITTER_VERSION` while the block around it was the pre-#38 shape. A detector that passes the current five without this test proves nothing.
+
+```bash
+@test "anchor present but surrounding block outdated reports BEHIND with exit 1" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+  if curl -fsSL -o "$TS_TMP/tree-sitter.gz" "$TS_URL" &&
+    gunzip -c "$TS_TMP/tree-sitter.gz" >"$TS_TMP/tree-sitter" &&
+    chmod 0755 "$TS_BIN.new" &&
+    as_user "$TS_BIN.new" --version >/dev/null 2>&1 &&
+    as_user mv "$TS_BIN.new" "$TS_BIN"; then
+    echo "seed: tree-sitter ready"
+  elif [ -f "$TS_BIN.new" ] && ! TS_ERR="$(as_user "$TS_BIN.new" --version 2>&1 >/dev/null)"; then
+    echo "seed: tree-sitter binary unusable: $TS_ERR" >&2
+  elif sh -c 'command -v tree-sitter >/dev/null 2>&1'; then
+    echo "seed: tree-sitter already present (image-provided)"
+  else
+    echo "seed: tree-sitter install failed" >&2
+  fi
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+  if curl -fsSL -o "$TS_TMP/tree-sitter.gz" "$TS_URL" &&
+    gunzip -c "$TS_TMP/tree-sitter.gz" >"$TS_TMP/tree-sitter" &&
+    chmod 0755 "$TS_BIN.new" &&
+    as_user "$TS_BIN.new" --version >/dev/null 2>&1 &&
+    as_user mv "$TS_BIN.new" "$TS_BIN"; then
+    echo "seed: tree-sitter ready"
+  else
+    echo "seed: tree-sitter install failed" >&2
+  fi
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+  [[ "$output" == *"tree-sitter CLI"* ]]
+  [[ "$output" != *MISSING* ]]
+}
+```
+
+- [ ] **Step 3: run the motivating test.**
+
+From `/home/tng/.dotfiles/.claude/worktrees/seed-drift-detector`:
+
+`bats tests/seed_drift.bats`
+
+Expected: every test passes, including `ok ... anchor present but surrounding block outdated reports BEHIND with exit 1`. A `MISSING` verdict here means anchor matching is running against un-stripped text or against heredoc bodies; an `ok` verdict means extraction collapsed to the anchor line and the tool is reproducing the bug it exists to fix.
+
+- [ ] **Step 4: a change confined to a block's NON-anchor lines is reported.**
+
+Modelled on `core.excludesFile` (template lines 204-236): the anchor sits on the final `git config` line, and the substance of the block is the heredoc above it.
+
+```bash
+@test "change confined to non-anchor lines of the block is reported" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITIGNORE="$SEED_HOME/.gitignore"
+if ! as_user test -f "$GITIGNORE"; then
+  as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*~
+*.swp
+
+# Personal Claude Code overlay shims (symlinked in from ~/.dotfiles/projects/).
+CLAUDE.local.md
+AGENTS.local.md
+
+# Personal docker-compose overrides.
+docker-compose.override.yml
+GITEOF
+  echo "seed: wrote container-local ~/.gitignore"
+fi
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITIGNORE="$SEED_HOME/.gitignore"
+if ! as_user test -f "$GITIGNORE"; then
+  as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*~
+
+# Personal Claude Code overlay shims (symlinked in from ~/.dotfiles/projects/).
+CLAUDE.local.md
+AGENTS.local.md
+
+# Personal docker-compose overrides.
+docker-compose.override.yml
+GITEOF
+  echo "seed: wrote container-local ~/.gitignore"
+fi
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+  [[ "$output" == *core.excludesFile* ]]
+}
+```
+
+- [ ] **Step 5: heredoc payload is compared verbatim — four tests.**
+
+Every normalization rule corrupts payload. These pin that none of them runs inside a body.
+
+```bash
+@test "changed # line inside a quoted heredoc body is drift, not stripped as a comment" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+# Personal Claude Code overlay shims (symlinked in from ~/.dotfiles/projects/).
+CLAUDE.local.md
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+# Personal overlay shims.
+CLAUDE.local.md
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "changed leading whitespace inside a heredoc body is drift" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+    *.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "removed blank line inside a heredoc body is drift" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+
+*.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+}
+
+@test "trailing backslash inside a heredoc body is not a line continuation" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+literal-backslash \
+second-payload-line
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+literal-backslash second-payload-line
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+```
+
+- [ ] **Step 6: run the heredoc-payload tests.**
+
+`bats tests/seed_drift.bats`
+
+Expected: all pass. A clean verdict on the `#`-line test means comment stripping is leaking into `Hq` bodies; a clean verdict on the backslash test means continuation joining is.
+
+- [ ] **Step 7: unquoted delimiters get path neutralization, quoted ones do not.**
+
+```bash
+@test "unquoted heredoc delimiter gets path neutralization" {
+  t7_setup
+  t7_doc "unquoted body" HEREDOC_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=unquoted
+tee "$OUT" >/dev/null <<UNQ
+$SEED_HOME/.local/bin
+UNQ
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=unquoted
+tee "$OUT" >/dev/null <<UNQ
+$HOME/.local/bin
+UNQ
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "quoted heredoc delimiter does not get path neutralization" {
+  t7_setup
+  t7_doc "quoted body" HEREDOC_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=quoted
+tee "$OUT" >/dev/null <<'QUO'
+$SEED_HOME/.local/bin
+QUO
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=quoted
+tee "$OUT" >/dev/null <<'QUO'
+$HOME/.local/bin
+QUO
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+```
+
+- [ ] **Step 8: heredoc opener recognition — four tests.**
+
+A scanner keying on a bare `<<` swallows the rest of the file at template line 255, which sits inside the overlay-gitignore anchored block.
+
+```bash
+@test "<< inside a double-quoted string is not a heredoc opener" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+GI_MARK_BEGIN="# >>> overlay symlinks (auto, do not edit) >>>"
+GI_MARK_END="# << overlay symlinks (auto) <<"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+GI_MARK_BEGIN="# >>> overlay symlinks (auto, do not edit) >>>"
+GI_MARK_END="# << overlay symlinks (auto) <<"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*/.dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Overlay-link gitignore"* ]]
+  [[ "$output" != *MISSING* ]]
+}
+
+@test "<<< herestrings are not heredoc openers" {
+  t7_setup
+  t7_doc "herestring block" HERESTRING_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+HERESTRING_ANCHOR=1
+read -r first_word <<<"$SEED_HOME/.local/bin"
+echo "template says $first_word"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+HERESTRING_ANCHOR=1
+read -r first_word <<<"$SEED_HOME/.local/bin"
+echo "seed says $first_word"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+  [[ "$output" != *MISSING* ]]
+}
+
+@test "each heredoc delimiter form is recognized and tracks its body" {
+  t7_setup
+  t7_doc "form block" FORM_ANCHOR
+  local open
+  for open in "<<TAG" "<<'TAG'" '<<"TAG"' '<<\TAG' "<<-TAG"; do
+    {
+      printf '#!/usr/bin/env bash\n\n'
+      printf 'FORM_ANCHOR=1\n'
+      printf 'tee "$OUT" >/dev/null %s\n' "$open"
+      printf 'payload-one\n\npayload-two\nTAG\n'
+    } >"$TPL"
+    {
+      printf '#!/usr/bin/env bash\n\n'
+      printf 'FORM_ANCHOR=1\n'
+      printf 'tee "$OUT" >/dev/null %s\n' "$open"
+      printf 'payload-one\n\npayload-CHANGED\nTAG\n'
+    } >"$SEED"
+    t7_run "$SEED"
+    [ "$status" -eq 1 ] || {
+      echo "form $open: expected drift, got status $status: $output" >&2
+      return 1
+    }
+    [[ "$output" == *DIVERGED* ]] || {
+      echo "form $open: expected DIVERGED, got: $output" >&2
+      return 1
+    }
+  done
+}
+
+@test "unrecognized heredoc syntax is an error, not a silent fallback" {
+  t7_setup
+  t7_doc "form block" FORM_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+FORM_ANCHOR=1
+TAG=EOFWORD
+cat <<$TAG
+payload
+EOFWORD
+TPLEOF
+  cp "$TPL" "$SEED"
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" != *ok* ]]
+}
+```
+
+- [ ] **Step 9: run the heredoc-recognition tests.**
+
+`bats tests/seed_drift.bats`
+
+Expected: all pass. A `MISSING` in the first two tests means a bare `<<` matched and the scanner ate the remainder of the file. A `0` or `1` in the last test means unrecognized syntax degraded to "probably not a heredoc" — the silent failure mode the spec forbids.
+
+- [ ] **Step 10: the ownership rule is exact — four tests.**
+
+The idiom is dropped only when matched fully literally post-normalization; nothing is free.
+
+```bash
+t7_own_tpl() {
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+TPLEOF
+}
+
+@test "ownership idiom with a changed target is drift, not dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_CACHE.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_CACHE.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "ownership idiom with -R removed is drift, not dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "ownership idiom with a changed identity is drift, not dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "0:0" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "an unrelated chown line is compared normally" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+  chown -R "$SEED_UID:$SEED_GID" "$SEED_HOME/.cache"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *AHEAD* ]]
+  [[ "$output" != *overwrite* ]]
+}
+```
+
+- [ ] **Step 11: false-positive guards — six tests, one per normalization rule.**
+
+```bash
+@test "false-positive guard: as_user prefix vs direct invocation" {
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user git config --global core.hooksPath "$DOTFILES_HOME/git/hooks"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$DOTFILES_HOME/git/hooks"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: SEED_HOME vs HOME" {
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$SEED_HOME/.dotfiles/git/hooks"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: DOTFILES_HOME vs HOME/.dotfiles" {
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$DOTFILES_HOME/git/hooks"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: restyled line continuations" {
+  t7_setup
+  t7_doc "codex guard" local/bin/codex
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then
+  as_user npm install -g \
+    --prefix "$SEED_HOME/.local" \
+    @openai/codex
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then
+  as_user npm install -g --prefix "$SEED_HOME/.local" @openai/codex
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: reworded comments" {
+  t7_setup
+  t7_doc "codex guard" local/bin/codex
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+# Guard the reinstall on the binary, not ~/.codex/config.toml: the installer
+# writes config even when it fails to produce a binary.
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then # binary, not config
+  as_user npm install -g @openai/codex
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+# Check for the codex binary itself; a config-based guard latches shut.
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then # check the binary
+  as_user npm install -g @openai/codex
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: both exact ownership idiom forms are dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST "tree-sitter CLI" TS_BIN
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+
+TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+if [ -f "$TS_BIN.new" ]; then
+  { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||
+    [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+
+TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+if [ -f "$TS_BIN.new" ]; then
+  as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *BEHIND* ]]
+  [[ "$output" != *DIVERGED* ]]
+}
+```
+
+- [ ] **Step 12: `sed 's#...#g'` survives comment stripping.**
+
+Trailing-comment stripping must run only when quotes balance before the `#`.
+
+```bash
+@test "sed substitution with # delimiters survives comment stripping" {
+  t7_setup
+  t7_doc "plugin repair" PLUGIN_REPAIR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+PLUGIN_REPAIR=1
+sed -i 's#/opt/dotfiles#/home/seed/.dotfiles#g' "$f" # rewrite the stable root
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+PLUGIN_REPAIR=1
+sed -i 's#/opt/dotfiles#/home/seed/.dotfiles#g' "$f" # fix up the link root
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+PLUGIN_REPAIR=1
+sed -i 's#/opt/dotfiles#/home/seed/OTHER#g' "$f" # rewrite the stable root
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+```
+
+- [ ] **Step 13: run the ownership, guard, and sed tests.**
+
+`bats tests/seed_drift.bats`
+
+Expected: all pass. A drift verdict in any of the six guards means a normalization rule is missing; a clean verdict in any ownership test means a rule is too broad — the silent direction, which must be fixed, not tolerated.
+
+- [ ] **Step 14: READ-ONLY guarantee — seeds are byte-identical after a run.**
+
+Safety-critical: seeds are gitignored with no revert path.
+
+```bash
+@test "seeds are byte-identical after a run (read-only)" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+  as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+fi
+SEEDEOF
+  # a drifted seed, a clean seed, and a candidate with no seed at all
+  mkdir -p "$WS/clean/.devcontainer" "$WS/noseed/.devcontainer"
+  cp "$TPL" "$WS/clean/.devcontainer/local-seed.sh"
+
+  local before after
+  before="$(find "$WS" -type f -exec sha256sum {} + | sort)"
+  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC"
+  [ "$status" -eq 1 ]
+  after="$(find "$WS" -type f -exec sha256sum {} + | sort)"
+  [ "$before" = "$after" ]
+}
+```
+
+- [ ] **Step 15: a malformed seed does not suppress drift reporting for the others.**
+
+```bash
+@test "a malformed seed does not suppress drift reporting for the others" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+  as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+TPLEOF
+  mkdir -p "$WS/broken/.devcontainer"
+  cat >"$WS/broken/.devcontainer/local-seed.sh" <<'BROKENEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "unterminated"
+BROKENEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+fi
+SEEDEOF
+  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *broken* ]]
+  [[ "$output" == *demo* ]]
+  [[ "$output" == *BEHIND* ]]
+}
+```
+
+- [ ] **Step 16: run the whole suite file.**
+
+`bats tests/seed_drift.bats`
+
+Expected: 0 failures, and the 25 tests added in this task all report `ok` alongside everything from Tasks 1-6.
+
+- [ ] **Step 17: real-world smoke against the five live seeds — read-only.**
+
+Run from the repo root, capturing checksums so the read-only guarantee is confirmed on the real files as well as on fixtures:
+
+```
+before=$(sha256sum ~/workspace/*/.devcontainer/local-seed.sh)
+bin/seed-drift; echo "exit=$?"
+after=$(sha256sum ~/workspace/*/.devcontainer/local-seed.sh)
+[ "$before" = "$after" ] && echo "READ-ONLY OK"
+```
+
+Expected: `exit=1`; a `BEHIND` line for the `tree-sitter CLI` block under each of `wanderer`, `wanderer-kills`, `wanderer-notifier`, `double-holo-ui`, and `slabledger` (the five seeds present at `~/workspace/*/.devcontainer/local-seed.sh`); a summary line reading `5 checked, 0 skipped` with at least 5 blocks drifted; and `READ-ONLY OK`. If any of the five reports `ok` on tree-sitter, the detector has reproduced the original false-clean bug and must not be committed.
+
+- [ ] **Step 18: full verification.**
+
+`command make check` from the repo root (`make` is shadowed by a zsh function here, so `command make` is required). This runs `syntax`, `lint`, `test`, `python-test`, `validate`.
+
+Expected: `bin/list-check-files bash|shellcheck|shfmt` all include `bin/seed-drift` with no findings and no shfmt diff; `bats tests` reports the 323 baseline tests plus every test from Tasks 1-6 and the 25 from this task, 0 failures; `python-test` and `validate` unchanged.
+
+- [ ] **Step 19: commit.**
+
+```
+git add tests/seed_drift.bats
+git commit -m "test: pin seed-drift normalization, heredoc, and read-only behavior"
+```
+
+If Step 16 or 17 required a fix to `bin/seed-drift`, stage it in the same commit and use `fix(seed-drift):` instead. Confirm `git status` is clean afterwards.

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -301,7 +301,6 @@ Applied to **shell code only**, narrowest first:
 | Collapse whitespace runs, trim | reindentation is noise |
 | Drop `as_user`, `$SUDO`, `sudo [-n]`, `runuser -u X --` prefixes | privilege vocabulary |
 | `$SEED_HOME` / `$HOME` -> `«HOME»`; `$DOTFILES_HOME` -> `«HOME»/.dotfiles`; `$WORKSPACE` -> `«WS»` | path vocabulary; substitute the token only, preserving surrounding quotes |
-| Drop the two **fully literal** ownership-verification lines listed below | that idiom exists only in the non-root flavor |
 
 ### Heredoc bodies are payload and are compared verbatim
 
@@ -324,33 +323,53 @@ exactly when the shell itself expands the variable. A quoted delimiter
 `$HOME` there would rewrite text the container will see. Both template heredocs
 are quoted, so both are compared byte-for-byte after extraction.
 
-### The ownership rule takes exact arguments, with nothing free
+### The ownership-verification idiom is not special-cased (removed)
 
-The rule is deliberately **not** "drop every `chown`/`chgrp` line". An earlier
-draft said that, and a later one narrowed it to two forms with the target path
-left free — which still hid the thing the surrounding paragraph says must stay
-visible: template and seed could name different targets and both lines would
-vanish.
+Three fix rounds tried to special-case the non-root ownership-verification
+idiom — `{ chown ... || find ... -uid ... -gid ... }` — so that a root-flavored
+seed which skips it entirely would not report the idiom's template lines as
+drift. Each version failed a different way:
 
-The idiom occurs exactly twice in the template, and the two instances differ in
-both flag and target:
+- **Per-file asymmetry** (Task 6 draft): dropped the idiom during
+  normalization, one file at a time, which could not tell "seed omits it" from
+  "seed relocated it" — a seed that moved the check elsewhere would silently
+  lose both copies.
+- **Blindness to a rewritten idiom half** (Task 7 review, I-1): a guard keyed
+  on `chown`/`chgrp` tokens in the seed-only lines missed a seed that left the
+  chown half untouched and rewrote only the find half's identity check — the
+  guard saw no token, dropped the idiom anyway, and reported AHEAD
+  ("promotion candidate") for a seed whose check no longer verified what it
+  claimed to.
+- **Diff hunk adjacency** (fix round 2): a hunk-aware rewrite tried to drop a
+  template line only when GNU diff's own hunk header marked it as a pure
+  delete (never a change), so a rewrite could no longer be mistaken for an
+  omission. This failed on a real seed: a genuinely-omitted idiom sitting
+  immediately next to an unrelated, independently-edited line left diff with
+  no unchanged anchor line between them, so diff merged both into a single
+  change hunk. The rule then refused to drop lines that really had been
+  omitted, and the general case is worse than a count discrepancy — a seed
+  that cleanly omits the idiom and edits anything on the adjacent line would
+  flip a correct AHEAD into a false DIVERGED, the exact failure mode round 2
+  was meant to retire.
 
-```
-{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
-  [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+Before committing to a fourth attempt, the cost of removing the rule entirely
+was measured against the real five-project corpus (`8c780a0` baseline vs. the
+rule disabled): every DIVERGED block stayed DIVERGED, **no verdict changed
+anywhere in the corpus**, and the summary line
+(`5 checked, 2 skipped, 28 blocks drifted (4 behind, 1 ahead, 23 diverged)`)
+was identical either way. The only effect was inflated BEHIND counts on the
+two root-flavored seeds that omit the idiom (`slabledger`, `wanderer`), 2 extra
+lines each on both idiom-bearing blocks (neovim install, tree-sitter CLI) — a
+cosmetic reporting difference, not a wrong verdict, on already-DIVERGED
+blocks.
 
-{ chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||
-  [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
-```
-
-Both are matched **fully literally, post-normalization** — the `-R` on the first
-and its absence on the second are part of the match, as are the two target
-paths. Nothing is free. (The previous draft wrote both without `-R`, so it would
-not have matched the neovim instance at all.)
-
-Any other `chown` or `chgrp` line is compared normally. Tests assert that a
-changed target, a changed `-R`, a changed identity, and an unrelated `chown`
-each produce drift.
+Given three independent failure modes and a measured cost of "some inflated
+line counts on already-drifted blocks, zero verdict changes," the rule was
+removed rather than attempted a fourth time. `BEHIND` now reports whatever the
+plain diff produces for these lines, same as any other template content a
+seed happens not to carry. A root-flavored seed that verifies no ownership at
+all correctly reports the idiom's template lines as `BEHIND` — this is the
+documented, intended output now, not a bug to fix.
 
 Known residual false-positive source, accepted and documented rather than
 normalized: **literal** workspace paths (`/app` vs `/workspace`). Only the
@@ -515,10 +534,13 @@ Required cases:
 - differences both directions -> `DIVERGED`
 - false-positive guards, one test each: `as_user` vs direct invocation,
   `$SEED_HOME` vs `$HOME`, `$DOTFILES_HOME` vs `$HOME/.dotfiles`, restyled line
-  continuations, reworded comments, the two exact ownership-idiom forms
-- **the ownership rule is exact**, four cases: a changed target, a changed `-R`,
-  a changed `$SEED_UID:$SEED_GID` identity, and an unrelated `chown` line each
-  produce drift rather than being dropped.
+  continuations, reworded comments
+- **the ownership-verification idiom is not special-cased**: a changed target,
+  a changed `-R`, a changed `$SEED_UID:$SEED_GID` identity (on either physical
+  half of the idiom), and an unrelated `chown` line each produce ordinary
+  drift, the same as any other differing line; a root-flavored seed that
+  carries no ownership check at all correctly reports the idiom's two
+  template lines as `BEHIND`
 - `sed 's#...#g'` survives comment stripping
 - an anchor appearing only in a comment does not anchor a block
 - candidate with `.devcontainer/` but no seed -> skipped, exit 0, counted as

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -43,10 +43,31 @@ gives.
 
 ## Decision 1 — representation
 
-**Chosen: normalized per-block line-multiset diff.**
+**Chosen: normalized per-block, order-preserving line-sequence diff.**
 
 Extract the block around each documented anchor from both files, normalize both
-sides, and compare as sorted line multisets.
+sides, and diff the resulting line **sequences** — preserving order.
+
+### Order is load-bearing; multisets discard it
+
+An earlier draft compared *sorted* line multisets. That is a false-clean bug of
+exactly the class this tool exists to eliminate, because statement order in
+these seeds is behaviorally significant and sometimes explicitly specified.
+
+`catch-up-local-seed.md:83` requires the `load-custom.zsh` loader to be appended
+**before** the Vekil hook, because `ai/vekil/env.zsh` exports `ANTHROPIC_MODEL`,
+which outranks `settings.json` and must get the last word. The template devotes a
+long comment to this, including the instruction to *compare positions* rather
+than merely detect presence, precisely because an already-seeded volume can carry
+both hooks in the wrong order.
+
+Under a sorted comparison, a seed with the two hooks inverted contains the same
+lines as the template and reports clean — while the container silently runs on
+the wrong model. Sorting is therefore abandoned: comparison is an ordered diff.
+
+A pure reordering surfaces as differences in **both** directions, and so is
+reported as `DIVERGED` — correctly, since the tool cannot know which order was
+intended without reading the doc.
 
 ### Evidence
 
@@ -66,6 +87,10 @@ It finds the motivating drift on all five. `ahead=0` confirms the vocabulary
 neutralization is not manufacturing phantom differences. The reported lines are
 the genuine #38 change — the two-guard `--version` probe and the image-provided
 branch.
+
+(The prototype used sorted comparison; the counts above are unaffected, since
+these differences are insertions rather than reorderings. The order defect it
+would have missed is a separate class, described above.)
 
 ### Alternative considered and rejected: per-block fingerprints
 
@@ -124,27 +149,92 @@ hard error (exit 2), not a per-block verdict.
 
 ## Decision 3 — block extraction
 
-A block is the **union of every top-level statement whose non-comment text
-contains the anchor**, matched as a **fixed string**.
+**An anchor locates a block; it does not define its membership.**
 
-Three findings drove this:
+A block is the **union of every blank-line-delimited paragraph whose non-comment
+text contains the anchor**, matched as a **fixed string**. Paragraph detection is
+**heredoc-aware**: a blank line inside a heredoc body does not end a paragraph.
+
+### Why not "the enclosing top-level statement"
+
+That was the first rule proposed, and it is wrong. `core.excludesFile` occurs in
+code exactly once, at template line 236, as a standalone top-level command:
+
+```sh
+as_user git config --global core.excludesFile "$GITIGNORE"
+```
+
+The enclosing-statement rule captures that one line and nothing else. The
+`GITIGNORE=` assignment and the entire `if ! as_user test -f "$GITIGNORE"` block
+that writes the file — template lines 217-235, which is the whole substance of
+the block — fall outside it. The seeded gitignore contents could be rewritten
+wholesale and the detector would report clean. That is the same false-clean class
+as the anchor grep this tool exists to replace, so the rule is disqualified.
+
+The overlay-gitignore block fails the same way: its workspace and marker
+assignments sit outside the statement holding the anchor.
+
+### Why paragraphs work
+
+The template separates blocks with a blank line and separates *comment*
+paragraphs within a block using a bare `#` line rather than a blank. So the
+blank-line paragraph is already the semantic unit. For `core.excludesFile` it
+yields lines 204-236 — comment preamble, assignment, heredoc block, and the
+`git config` line together.
+
+Verified: blank line at 203, contiguous content 204-236, blank line at 237.
+
+Heredoc awareness is required, not optional: lines 223 and 229 are blank lines
+*inside* the `GITEOF` heredoc, and a naive splitter would cut the block in three.
+The scanner tracks `<<TAG`, `<<'TAG'`, and `<<-TAG` to its closing delimiter.
+
+### Why fixed-string matching, and why comments are excluded from matching
 
 - Anchors are not unique. `config/nvim` occurs 9 times in the template (5 in
-  code), `NVIM_VERSION` 5, `DOTFILES_LOAD_HOOK` 5, `core.hooksPath` 3. "First
-  occurrence" is arbitrary.
+  code), `NVIM_VERSION` 5, `DOTFILES_LOAD_HOOK` 5, `core.hooksPath` 3. Hence the
+  union over all matching paragraphs rather than a first-occurrence pick.
 - `TREE_SITTER_VERSION`'s first occurrence is a *comment* (template line 530);
-  its first code use is line 568. Matching must ignore comments.
-- One anchor, `lname '*dotfiles/projects/*'`, contains `*` and quotes, so
-  matching must be fixed-string, not regex.
-
-Boundaries: walk up from the matched line to the nearest column-0 statement
-start, down to its matching column-0 `fi` / `done` / `esac` / `}`. Valid because
-template and seeds are `shfmt -i 2 -ci` clean. Comment separators are ignored
-entirely — they are inconsistent across seeds and unusable as boundaries.
+  its first code use is line 568. Matching that counted comments would anchor on
+  prose.
+- `lname '*dotfiles/projects/*'` contains `*` and quotes, so matching must be
+  fixed-string, not regex.
 
 Because the rule is applied identically to both sides, overlapping blocks are
 symmetric. Overlap means a drifted region may be reported under more than one
 block name: noise, not silence, which is the correct direction.
+
+### Formatting independence
+
+Paragraph boundaries depend on blank lines and heredoc structure, not on
+indentation, so extraction does **not** assume `shfmt`-clean input. This is a
+deliberate change from the first draft, which assumed column-0 boundaries and
+then proposed to validate that assumption with `bash -n` — a check that passes
+on syntactically valid but unformatted shell, so it would not have validated the
+assumption at all.
+
+All five live seeds and the template are in fact `shfmt -i 2 -ci` clean today
+(verified), so an shfmt precondition would have been viable. It is not adopted,
+because a formatting-independent extractor is strictly better than a formatting
+dependency plus a gate enforcing it.
+
+### Residual limitation
+
+A semantic block that spans two paragraphs where only one contains the anchor is
+compared only in part. This is far narrower than the enclosing-statement failure
+above — the paragraph always carries the anchor's full statement group and its
+comment preamble — but it is not zero, and it is not detectable from inside the
+tool.
+
+### Alternative considered and deferred: whole-file paragraph matching
+
+Normalize both files into paragraphs, match them by similarity, name matched
+paragraphs from the doc table, and report unmatched ones. This would eliminate
+the residual limitation above *and* the novel-block limitation in Decision 5.
+
+Deferred, not rejected: unmatched paragraphs include every legitimately
+project-specific block, so the promotion-candidate report would be dominated by
+noise — which constraint 3 rules out. Revisit if the anchored version proves too
+narrow in practice.
 
 ## Decision 4 — normalization
 
@@ -157,11 +247,24 @@ Applied to both sides, narrowest first:
 | Collapse whitespace runs, trim | reindentation is noise |
 | Drop `as_user`, `$SUDO`, `sudo [-n]`, `runuser -u X --` prefixes | privilege vocabulary |
 | `$SEED_HOME` / `$HOME` -> `«HOME»`; `$DOTFILES_HOME` -> `«HOME»/.dotfiles`; `$WORKSPACE` -> `«WS»` | path vocabulary; substitute the token only, preserving surrounding quotes |
-| Drop `chown` / `chgrp` lines and the `{ chown ... \|\| [ -z "$(find ... -uid ...)" ]; }` idiom | ownership verification exists only in the non-root flavor |
+| Drop the two **exact** ownership-verification lines listed below | that idiom exists only in the non-root flavor |
 
-The ownership rule is not ad hoc: that idiom exists solely because the template
-targets a non-root remoteUser. A root-user seed correctly omits it, and the
-prototype showed it as the single largest source of false "behind" lines.
+The ownership rule is deliberately **not** "drop every `chown`/`chgrp` line".
+An earlier draft said that, and it was too broad in exactly the direction this
+design calls dangerous: it would hide a genuine change to the target path, the
+recursion flag, the identity, or the failure handling of any ownership repair
+anywhere in a block.
+
+Instead the rule matches two literal normalized forms, and nothing else:
+
+```
+{ chown "$SEED_UID:$SEED_GID" <arg> 2>/dev/null ||
+[ -z "$(find <arg> \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+```
+
+`<arg>` is the only free element. Any other `chown` or `chgrp` line is compared
+normally. Each form gets its own test, and a test asserts that an *unrelated*
+`chown` line is **not** dropped.
 
 Known residual false-positive source, accepted and documented rather than
 normalized: **literal** workspace paths (`/app` vs `/workspace`). Only the
@@ -170,15 +273,15 @@ configuration and risks over-broad matching.
 
 ## Decision 5 — drift direction
 
-Per (project, block), on normalized line multisets:
+Per (project, block), on the ordered diff of normalized line sequences:
 
 | Verdict | Condition | Reported action |
 |---|---|---|
-| `ok` | equal | — |
+| `ok` | sequences identical | — |
 | `MISSING` | anchor absent from seed | port the block (catch-up Step 2) |
 | `BEHIND` | template-only lines | port the change |
 | `AHEAD` | seed-only lines | promotion candidate — do **not** overwrite the seed |
-| `DIVERGED` | lines in both directions | inspect by hand; direction is genuinely unclear |
+| `DIVERGED` | lines in both directions, **including pure reordering** | inspect by hand; direction is genuinely unclear |
 
 `AHEAD` and `DIVERGED` messages never suggest overwriting.
 
@@ -201,30 +304,46 @@ tool states this in its output rather than implying full coverage.
 
 ## Decision 6 — discovery, exit codes, safety
 
-**Discovery.** No arguments: glob `${SEED_DRIFT_ROOT:-$HOME/workspace}/*/.devcontainer/local-seed.sh`.
-With arguments: check exactly those paths. A glob is self-maintaining as
-projects are added; a hand-maintained list goes stale silently, which is the
-same failure class as the bug being fixed.
+**Discovery.** A **candidate** is a directory containing `.devcontainer/`. A
+candidate with no `.devcontainer/local-seed.sh` is a **skip**; a candidate with
+one is **checked**.
 
-**Skips.** A project without a seed is skipped with a note and does not affect
+- No arguments: candidates are `${SEED_DRIFT_ROOT:-$HOME/workspace}/*/`.
+- With arguments: each argument is a candidate. A project directory and a direct
+  path to a `local-seed.sh` are both accepted; the tool distinguishes them by
+  testing whether the argument is a directory.
+
+An earlier draft globbed `*/.devcontainer/local-seed.sh` directly. That is
+inconsistent with the skip requirement: globbing seed files enumerates only
+projects that *have* one, so a project missing its seed is invisible rather than
+skipped — and the sample output claimed a skip that the discovery rule could not
+have produced. Globbing candidate directories and then testing for the seed makes
+the skip real.
+
+Directories without `.devcontainer/` are not candidates at all, so unrelated
+entries under `~/workspace` are silent rather than reported as skips.
+
+A glob is self-maintaining as projects are added; a hand-maintained list goes
+stale silently, which is the same failure class as the bug being fixed.
+
+**Skips.** A candidate without a seed is reported with a note and does not affect
 the exit code.
 
 **Exit codes.** `0` clean (skips included); `1` any drift, in any direction; `2`
 usage error, unreadable template, doc/template disagreement, or a seed whose
 block boundaries cannot be resolved.
 
-A run does not abort on the first bad seed. It reports every project, then exits
-with the highest severity encountered (`2` outranks `1` outranks `0`), so one
-malformed seed cannot hide drift in the other four.
+A run does not abort on the first bad seed. It reports every candidate, then
+exits with the highest severity encountered (`2` outranks `1` outranks `0`), so
+one malformed seed cannot hide drift in the other four.
 
-**Extraction failure must never read as clean.** The column-0 boundary rule
-assumes a `shfmt`-clean file. A seed hand-edited since its last catch-up may not
-be. Both sides are checked with `bash -n` — the template as well as each seed,
-since a broken template would otherwise silently produce empty blocks that
-compare equal to everything. If a block's enclosing statement cannot be
-resolved, or either file fails `bash -n`, the tool errors rather than falling
-through to `ok`: a silent pass here would reproduce the exact false-clean bug
-being fixed.
+**Extraction failure must never read as clean.** Paragraph extraction is
+formatting-independent (Decision 3), so there is no `shfmt` precondition. Both
+files are still checked with `bash -n` — the template as well as each seed, since
+a broken template would otherwise silently produce empty blocks that compare
+equal to everything. An anchor that the template does not contain, or a block
+that extracts to nothing on the template side, is an error rather than an `ok`:
+a silent pass here would reproduce the exact false-clean bug being fixed.
 
 **Read-only.** The detector never writes to a seed. These are gitignored,
 hand-owned files with no revert path. Asserted by test.
@@ -240,10 +359,13 @@ slabledger  /home/tng/workspace/slabledger/.devcontainer/local-seed.sh
   AHEAD    codex guard          2 seed lines absent from template
              -> promotion candidate; do NOT overwrite the seed
   ok       neovim install
-double-holo-ui  no seed - skipped
+double-holo-ui  .devcontainer/ present, no local-seed.sh - skipped
 
-5 checked, 0 skipped, 2 blocks drifted (1 behind, 1 ahead)
+4 checked, 1 skipped, 2 blocks drifted (1 behind, 1 ahead)
 ```
+
+Counts are consistent by construction: `checked + skipped` equals the number of
+candidates, and a skipped candidate contributes no verdicts.
 
 Every finding names the project, the block, and the direction.
 
@@ -258,15 +380,28 @@ Required cases:
 - **anchor present, surrounding block outdated -> `BEHIND`, exit 1.** The case
   that motivated the work. A detector that passes the current five without this
   test proves nothing.
+- **reordered lines -> `DIVERGED`, exit 1, never `ok`.** Guards the order defect
+  in Decision 1. Modelled on the real constraint: a seed with the
+  `load-custom.zsh` hook placed *after* the Vekil hook must not report clean.
+- **a change confined to a block's non-anchor lines -> reported.** Guards the
+  extraction defect in Decision 3, using the `core.excludesFile` shape: edit the
+  seeded gitignore heredoc, leave the `git config` line untouched, expect drift.
+- **a blank line inside a heredoc does not split the block.** Guards heredoc
+  awareness directly.
 - anchor absent -> `MISSING`
 - extra seed lines -> `AHEAD`, wording is promotion, not overwrite
 - differences both directions -> `DIVERGED`
 - false-positive guards, one test each: `as_user` vs direct invocation,
   `$SEED_HOME` vs `$HOME`, `$DOTFILES_HOME` vs `$HOME/.dotfiles`, restyled line
-  continuations, reworded comments, ownership idiom present vs absent
+  continuations, reworded comments, the two exact ownership-idiom forms
+- **an unrelated `chown` line is NOT dropped.** Guards against the over-broad
+  ownership rule rejected in Decision 4.
 - `sed 's#...#g'` survives comment stripping
-- absent project -> skipped, exit 0
-- malformed / non-`shfmt` seed -> exit 2, never `ok`
+- an anchor appearing only in a comment does not anchor a block
+- candidate with `.devcontainer/` but no seed -> skipped, exit 0, counted as
+  skipped; a directory with no `.devcontainer/` is not reported at all
+- argument accepted both as a project directory and as a direct seed path
+- unparseable seed (`bash -n` fails) -> exit 2, never `ok`
 - a malformed seed does not suppress drift reporting for the others
 - doc table anchor missing from template -> exit 2
 - seeds unmodified after a run (read-only)

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -554,9 +554,16 @@ stale silently, which is the same failure class as the bug being fixed.
 not exist, are both reported with a note and do not affect the exit code.
 
 **Exit codes.** `0` clean (skips included); `1` any drift, in any direction; `2`
-usage error, unreadable template, doc/template disagreement, or a block that
+usage error, unreadable template, doc/template disagreement, auto-discovery
+finding no candidate directory under `$SEED_DRIFT_ROOT`, or a block that
 cannot be extracted — a window that never parses, or unrecognized heredoc
 syntax.
+
+Zero discovered projects is an error rather than a clean run because the
+detector could not do its job at all; a `0 checked` report would read as a clean
+bill of health. This is scoped to discovery only — an *explicitly named* project
+that is absent on this machine remains a skip at exit `0`, so one project list
+works on every machine.
 
 A run does not abort on the first bad seed. It reports every candidate, then
 exits with the highest severity encountered (`2` outranks `1` outranks `0`), so
@@ -664,14 +671,21 @@ Required cases:
 
 - `bin/seed-drift`, executable. Auto-discovered by both linter targets via
   `is_direct_bin_shell` in `bin/list-check-files` — verified against a stub, so
-  **no `list-check-files` change is required**.
+  the tool itself needs no discovery change.
 - Must be `shfmt -i 2 -ci` and `shellcheck -x -S warning` clean.
 
-### Deliberate exclusion
+### Bats suites under shfmt
 
-`bin/list-check-files` does not emit `.bats` files for either linter, so
-`tests/seed_drift.bats` will be unlinted. This is consistent with all 20 existing
-suites and is left as-is. Closing the gap would surface roughly 6 shellcheck
-findings and shfmt reformatting requests across files unrelated to this change;
-it deserves its own evaluation against all 20 suites rather than being smuggled
-in here.
+**Superseded during implementation.** This section originally recorded that
+`bin/list-check-files` emits no `.bats` files for any linter, that
+`tests/seed_drift.bats` would therefore be unlinted, and that closing the gap
+deserved its own evaluation rather than being smuggled in here.
+
+That was reversed. `bin/list-check-files` now emits `tests/*.bats` for the
+**shfmt** class; `bash`, `shellcheck`, and `zsh` continue to exclude them,
+because neither `bash -n` nor shellcheck can parse the `@test "name" { ... }`
+form. The deciding evidence was that two suites had already drifted unformatted
+under the old exclusion — the gap was not theoretical. Scope stayed contained
+because shfmt alone does not surface the shellcheck findings that made the
+original evaluation look expensive. `tests/check_file_discovery.bats` pins both
+halves: `.bats` present for shfmt, absent for the other three classes.

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -279,6 +279,44 @@ This is narrower than it sounds — several anchors (`TREE_SITTER_VERSION`,
 paragraphs are covered from the other side — but it is real, and it is not
 detectable from inside the tool.
 
+### Thin-window warning (informational, Task 8)
+
+A window that already parses is not grown further (see above), so a genuinely
+small paragraph — one that happens to parse standalone — yields a small window,
+and a small window compares very little. A "clean" verdict on a two-line window
+is close to meaningless: the tool would be silently wrong in exactly the one
+place everything else here is designed to be loud instead.
+
+Measured on the real five-seed corpus: 95 windows, 94 of which never grew past
+their starting paragraph (growth is near-inert), sizes ranging from **9 to 138
+lines**, median ~30. None fell at or below 8 lines. An earlier design proposed
+warning whenever the growth loop did not iterate; that was rejected because it
+would fire on 94 of the 95 windows — including a 109-line one — training the
+reader to ignore it. The concern (a window that proves too little) is real; the
+proxy (did it grow) was not measuring that. Warn on **size**, directly.
+
+The tool now emits a note whenever an extracted window — template or seed,
+independently — is fewer than **`SD_THIN_WINDOW` (5) raw, pre-normalization
+lines**. Calibrated against the corpus above: the smallest window measured
+there is 9 lines, so 5 leaves headroom against ordinary variation while still
+catching a window degenerate enough to matter.
+
+The note:
+
+- Names which side is thin (`template` or `seed`) — a thin template window
+  means the anchor is weakly defined for *every* project; a thin seed window
+  means *this* seed's block is degenerate. Different problems, so the reader
+  is told which.
+- Fires regardless of verdict, including `ok` — an `ok` block is exactly the
+  case a thin window makes untrustworthy, so suppressing the note there would
+  defeat the point.
+- Never affects the exit code or the drift tallies. The tool does not know the
+  thin block is wrong, only that it checked very little of it; turning that
+  uncertainty into a drift signal would be a false positive by construction.
+- Is not counted in the summary line. It fired zero times across the real
+  corpus; if that changes, it is a signal to revisit the design, not to add a
+  tally.
+
 ### Alternative considered and deferred: whole-file paragraph matching
 
 Normalize both files into paragraphs, match them by similarity, name matched

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -158,11 +158,52 @@ A window starts as one blank-line-delimited paragraph — heredoc-aware, so a bl
 line inside a heredoc body does not end a paragraph — and is then **grown until
 the extracted text parses on its own**:
 
-1. Take the paragraph whose non-comment text contains the anchor.
-2. While `bash -n` on the extracted fragment fails, append the next paragraph;
-   if that reaches end of file, prepend the preceding paragraph instead.
-3. If both directions are exhausted without parsing, the block is an
+1. Take the paragraph whose non-comment text contains the anchor; call it `para`.
+2. Search **paragraph pairs** `(lo, hi)`, with `lo` walking down from `para` to
+   the first paragraph and, for each `lo`, `hi` walking up from `para` to the
+   last. Extract lines `[start of lo .. end of hi]` and test it with `bash -n`.
+   The first pair that parses is the window. `(para, para)` is tried first, so a
+   paragraph that already parses standalone is returned unchanged.
+3. The search is capped at **400 parse attempts** per anchor. If no pair parses
+   before the cap, or the pairs are exhausted first, the block is an
    **extraction error** (exit 2), never `ok`.
+
+### The search is two-dimensional; the original one-dimensional rule was wrong (amended)
+
+Step 2 originally read: "while `bash -n` fails, append the next paragraph; if
+that reaches end of file, prepend the preceding paragraph instead." That rule is
+wrong in two ways, and the implementation faithfully reproduced both.
+
+**It cannot express the common case.** An anchor in the middle of a
+multi-paragraph function body needs the window grown *back* to `funcname() {`
+**and** *forward* to the closing `}` at the same time. A walk that only ever
+moves one edge, and only moves the second edge after the first has run out of
+file, never visits that pair.
+
+**It leaves the window end at EOF.** Once forward growth reached the last
+paragraph, nothing restored `end` before backward growth began — so *any* block
+needing upward growth extracted `[lo's start .. end of file]`. The whole tail of
+the file was then normalized and diffed as if it belonged to that block,
+reporting other blocks' drift, and drift in undocumented code, under the wrong
+block's name.
+
+This was not hypothetical. On the real five-seed corpus it fired once, on
+`wanderer-notifier`'s `DOTFILES_LOAD_HOOK` anchor: the window ran 582–719
+(to EOF) instead of 582–649 (the enclosing `seed_self_check()` function),
+inflating that block's `AHEAD` count from 41 to 87 seed lines. The
+138-line maximum in the original window measurement was this bug, not a real
+block. Correcting it leaves 58 of 59 corpus windows byte-identical and the
+summary line unchanged.
+
+The pair search fixes both: it visits every `(lo, hi)` combination, and each
+candidate's `end` is derived from `hi` rather than left over from a previous
+iteration.
+
+**Why the cap.** The failing path is now O(paragraphs²) `bash -n` invocations
+rather than O(paragraphs). The cap bounds the *error* path only — a window that
+parses exits on its first success, and 58 of 59 corpus windows parse at the very
+first pair — so it costs a passing anchor nothing. It reports the same status
+the exhaustion path already did, so it needs no new handling downstream.
 
 ### Blank lines are formatting; the parse check is what makes extraction sound
 
@@ -294,6 +335,11 @@ warning whenever the growth loop did not iterate; that was rejected because it
 would fire on 94 of the 95 windows — including a 109-line one — training the
 reader to ignore it. The concern (a window that proves too little) is real; the
 proxy (did it grow) was not measuring that. Warn on **size**, directly.
+
+Re-measured after the pair-search correction above: the 138-line maximum was the
+runaway-to-EOF window, and the true maximum is 109. The **minimum is unchanged
+at 9**, which is the number `SD_THIN_WINDOW` is calibrated against, so the
+threshold is unaffected.
 
 The tool now emits a note whenever an extracted window — template or seed,
 independently — is fewer than **`SD_THIN_WINDOW` (5) raw, pre-normalization
@@ -554,7 +600,10 @@ Required cases:
   must still be reported when the anchor is in the condition.
 - **a window that never parses -> exit 2**, and a block requiring *upward*
   growth (anchor in the body, `if` header in the preceding paragraph) is
-  extracted whole.
+  extracted whole — including when paragraphs follow the enclosing statement,
+  which is the case the pair search exists for and the case the original
+  one-dimensional rule got wrong. A block needing growth in *both* directions
+  at once, and the parse-attempt cap, are covered too.
 - **heredoc payload is compared verbatim**, three cases: a changed `#` line
   inside the `GITEOF` body is drift (not stripped as a comment); a changed blank
   line or leading whitespace inside a body is drift; a trailing `\` in a body is

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -164,7 +164,7 @@ the extracted text parses on its own**:
    last. Extract lines `[start of lo .. end of hi]` and test it with `bash -n`.
    The first pair that parses is the window. `(para, para)` is tried first, so a
    paragraph that already parses standalone is returned unchanged.
-3. The search is capped at **400 parse attempts** per anchor. If no pair parses
+3. The search is capped at **2000 parse attempts** per anchor. If no pair parses
    before the cap, or the pairs are exhausted first, the block is an
    **extraction error** (exit 2), never `ok`.
 
@@ -204,6 +204,20 @@ rather than O(paragraphs). The cap bounds the *error* path only — a window tha
 parses exits on its first success, and 58 of 59 corpus windows parse at the very
 first pair — so it costs a passing anchor nothing. It reports the same status
 the exhaustion path already did, so it needs no new handling downstream.
+
+**Why 2000 rather than a tight multiple of the measurement.** The worst
+plausible real shape measures ~280 attempts. The cap is set roughly 7x above
+that on purpose, because the two failure directions are not symmetric:
+exceeding the cap turns a *legitimate* block into a hard exit-2 ERROR, while
+overshooting costs only wasted `bash -n` invocations on a block that was going
+to fail anyway. The margin also absorbs the fact that the sweep is **not
+strictly smallest-window-first** — the inner loop always runs `hi` to `last`,
+so `(para, last)` is tried before `(para-1, para)`, and a backward-only case
+burns a full forward sweep per step. A diagonal by-window-size ordering would
+be more elegant and was deliberately declined: reordering changes which window
+an ambiguous anchor resolves to, and this ordering was verified against the real
+corpus by exhaustive old-vs-new comparison. Raising the cap is the cheap,
+behavior-preserving lever; reordering is not.
 
 ### Blank lines are formatting; the parse check is what makes extraction sound
 
@@ -328,18 +342,24 @@ and a small window compares very little. A "clean" verdict on a two-line window
 is close to meaningless: the tool would be silently wrong in exactly the one
 place everything else here is designed to be loud instead.
 
-Measured on the real five-seed corpus: 95 windows, 94 of which never grew past
-their starting paragraph (growth is near-inert), sizes ranging from **9 to 138
-lines**, median ~30. None fell at or below 8 lines. An earlier design proposed
-warning whenever the growth loop did not iterate; that was rejected because it
-would fire on 94 of the 95 windows — including a 109-line one — training the
-reader to ignore it. The concern (a window that proves too little) is real; the
-proxy (did it grow) was not measuring that. Warn on **size**, directly.
+Measured on the real five-seed corpus: **59 distinct windows** (the template's
+9 plus 50 across the five seeds), 58 of which parse at the very first pair the
+search tries — growth is near-inert — with sizes ranging from **9 to 109
+lines**, median **29**. None fell at or below 8 lines. An earlier design
+proposed warning whenever the growth loop did not iterate; that was rejected
+because it would fire on 58 of the 59 windows — including a 109-line one —
+training the reader to ignore it. The concern (a window that proves too little)
+is real; the proxy (did it grow) was not measuring that. Warn on **size**,
+directly.
 
-Re-measured after the pair-search correction above: the 138-line maximum was the
-runaway-to-EOF window, and the true maximum is 109. The **minimum is unchanged
-at 9**, which is the number `SD_THIN_WINDOW` is calibrated against, so the
-threshold is unaffected.
+Two figures in the project's history reconcile to those numbers. The count was
+first recorded as **95**, which counted window *comparisons* rather than
+distinct windows: the template's 9 windows were re-counted once per seed
+(9 x 5 = 45, plus the 50 seed windows). And the maximum was first recorded as
+**138 lines** — that was the runaway-to-EOF window described above, an artifact
+of the one-dimensional search, not a real block. The **minimum is unchanged at
+9**, which is the number `SD_THIN_WINDOW` is actually calibrated against, so
+neither correction moves the threshold.
 
 The tool now emits a note whenever an extracted window — template or seed,
 independently — is fewer than **`SD_THIN_WINDOW` (5) raw, pre-normalization

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -1,0 +1,289 @@
+# Seed drift detector — design
+
+Date: 2026-08-03
+Status: approved for planning
+
+## Problem
+
+`.devcontainer/local-seed.sh` is gitignored and hand-owned in every project, so
+it drifts from
+`ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh`
+the moment the template changes. The only existing detector is the Step 1 audit
+in `catch-up-local-seed.md`, which someone has to remember to run, per project,
+by hand.
+
+It has already failed. All five seeds sat on the pre-#38 tree-sitter error
+routing for weeks while the audit reported them clean, because the audit only
+checks that `TREE_SITTER_VERSION` *appears* — not that the block around it
+matches. Anchor presence is necessary and nowhere near sufficient.
+
+## Goal
+
+`bin/seed-drift` reports, per project and per documented block, whether a seed is
+behind, ahead of, or diverged from the template, and exits non-zero on any drift
+so it can gate.
+
+Non-goal: fixing drift. Porting stays the human, one-project-per-session
+procedure in `catch-up-local-seed.md`, for the reasons that document already
+gives.
+
+## Constraints from the request
+
+1. `SEED_VERSION` is not a drift signal and must not be compared. Always-run
+   blocks correctly do not bump it, so two seeds can report the same version and
+   differ. Confirmed live: versions are 7/8/8/8/9 and all five are behind on the
+   same block.
+2. Anchor presence is too coarse — it is the bug being fixed.
+3. Whole-file diffing is too noisy — seeds legitimately diverge in vocabulary,
+   line-continuation style, and project-specific blocks.
+4. Drift runs both ways. A block present in a seed but absent from the template
+   is a promotion candidate, not an error, and the output must never imply the
+   fix is always to overwrite the seed.
+5. A project absent on a given machine is a skip, not a failure.
+
+## Decision 1 — representation
+
+**Chosen: normalized per-block line-multiset diff.**
+
+Extract the block around each documented anchor from both files, normalize both
+sides, and compare as sorted line multisets.
+
+### Evidence
+
+Prototyped against the real template and all five live seeds, on the
+tree-sitter block:
+
+```
+template normalized lines: 47
+wanderer           behind=7  ahead=0
+wanderer-kills     behind=5  ahead=0
+wanderer-notifier  behind=5  ahead=0
+double-holo-ui     behind=5  ahead=0
+slabledger         behind=7  ahead=0
+```
+
+It finds the motivating drift on all five. `ahead=0` confirms the vocabulary
+neutralization is not manufacturing phantom differences. The reported lines are
+the genuine #38 change — the two-guard `--version` probe and the image-provided
+branch.
+
+### Alternative considered and rejected: per-block fingerprints
+
+Record a hash per block in the template; stamp each seed with the hash it was
+ported from; compare stamps. Exact, vocabulary-blind, and cheap.
+
+Rejected on two grounds:
+
+- **Structurally blind to the "ahead" direction.** A stamp is a provenance
+  claim, not a fact about content. This document's own premise is that seeds get
+  hand-fixed locally first — wanderer carried a pinned neovim install and the
+  `load-custom.zsh` loader before the template did. A block written directly
+  into a seed has no stamp to compare, and a block hand-edited *after* porting
+  still carries its old stamp and reads clean. That is the same false-clean
+  failure as the anchor grep, relocated.
+- **Bootstrap cost.** Five seeds x nine blocks = 45 unstamped blocks on day one,
+  all reporting "unknown" until a manual pass that this tool exists to replace.
+
+The bootstrap cost alone would be tolerable; the ahead-blindness is not,
+because constraint 4 is a hard requirement.
+
+### Alternative considered and rejected: aligning separator style across seeds
+
+The five seeds use three different comment-separator styles. Normalizing them
+would enable marker-based block boundaries.
+
+Rejected: the design deliberately does not need it (comments are stripped;
+boundaries come from shell structure). It would require a mechanical sweep
+across five gitignored files with no `git diff` to review and no revert, and
+`catch-up-local-seed.md` explicitly warns against batching operations across
+seeds. If alignment ever happens it should be incremental, inside a single
+project's catch-up session.
+
+### Accepted tradeoff
+
+Normalization rules are a maintained allowlist, and the two error directions are
+not symmetric:
+
+- a **missing** rule yields a false positive — noise, annoying, self-announcing;
+- a **too-broad** rule yields a false negative — silent, and it recreates
+  exactly the bug being fixed.
+
+Therefore: normalize narrowly, prefer noise over silence, and pin every rule
+with a test. No rule gets added without one.
+
+## Decision 2 — the block list lives in the doc
+
+`bin/seed-drift` parses the Step 1 table in `catch-up-local-seed.md`, taking the
+Block name from column 1 and the backtick-quoted anchor from column 2. The
+documented model becomes the executable one: adding a table row extends the
+detector, and the two cannot disagree.
+
+A test asserts every parsed anchor is present in the template. An anchor in the
+table that the template lacks means doc and template have diverged — that is a
+hard error (exit 2), not a per-block verdict.
+
+## Decision 3 — block extraction
+
+A block is the **union of every top-level statement whose non-comment text
+contains the anchor**, matched as a **fixed string**.
+
+Three findings drove this:
+
+- Anchors are not unique. `config/nvim` occurs 9 times in the template (5 in
+  code), `NVIM_VERSION` 5, `DOTFILES_LOAD_HOOK` 5, `core.hooksPath` 3. "First
+  occurrence" is arbitrary.
+- `TREE_SITTER_VERSION`'s first occurrence is a *comment* (template line 530);
+  its first code use is line 568. Matching must ignore comments.
+- One anchor, `lname '*dotfiles/projects/*'`, contains `*` and quotes, so
+  matching must be fixed-string, not regex.
+
+Boundaries: walk up from the matched line to the nearest column-0 statement
+start, down to its matching column-0 `fi` / `done` / `esac` / `}`. Valid because
+template and seeds are `shfmt -i 2 -ci` clean. Comment separators are ignored
+entirely — they are inconsistent across seeds and unusable as boundaries.
+
+Because the rule is applied identically to both sides, overlapping blocks are
+symmetric. Overlap means a drifted region may be reported under more than one
+block name: noise, not silence, which is the correct direction.
+
+## Decision 4 — normalization
+
+Applied to both sides, narrowest first:
+
+| Step | Rationale |
+|---|---|
+| Join `\` line continuations into logical lines | continuation style is a legitimate divergence |
+| Strip full-line comments; strip trailing comments only when quotes balance before the `#` | naive stripping mangles `sed 's#...#g'` in the plugin-repair block |
+| Collapse whitespace runs, trim | reindentation is noise |
+| Drop `as_user`, `$SUDO`, `sudo [-n]`, `runuser -u X --` prefixes | privilege vocabulary |
+| `$SEED_HOME` / `$HOME` -> `«HOME»`; `$DOTFILES_HOME` -> `«HOME»/.dotfiles`; `$WORKSPACE` -> `«WS»` | path vocabulary; substitute the token only, preserving surrounding quotes |
+| Drop `chown` / `chgrp` lines and the `{ chown ... \|\| [ -z "$(find ... -uid ...)" ]; }` idiom | ownership verification exists only in the non-root flavor |
+
+The ownership rule is not ad hoc: that idiom exists solely because the template
+targets a non-root remoteUser. A root-user seed correctly omits it, and the
+prototype showed it as the single largest source of false "behind" lines.
+
+Known residual false-positive source, accepted and documented rather than
+normalized: **literal** workspace paths (`/app` vs `/workspace`). Only the
+variable form is neutralized. Mapping literals would require per-project
+configuration and risks over-broad matching.
+
+## Decision 5 — drift direction
+
+Per (project, block), on normalized line multisets:
+
+| Verdict | Condition | Reported action |
+|---|---|---|
+| `ok` | equal | — |
+| `MISSING` | anchor absent from seed | port the block (catch-up Step 2) |
+| `BEHIND` | template-only lines | port the change |
+| `AHEAD` | seed-only lines | promotion candidate — do **not** overwrite the seed |
+| `DIVERGED` | lines in both directions | inspect by hand; direction is genuinely unclear |
+
+`AHEAD` and `DIVERGED` messages never suggest overwriting.
+
+### Stated limitation
+
+A wholly novel block in a seed, for which the template has no anchor, is not
+auto-discoverable — anchor iteration is template-rooted. **`AHEAD` is therefore
+line-level only: additions inside a block the doc already lists.**
+
+Note this is a genuine limit, not a gap to be patched by widening `AHEAD`. The
+adjacent case — a seed carrying an anchor the *template* has dropped — is not
+reachable as `AHEAD` either, because Decision 2 classifies a doc/template
+mismatch as a hard error (exit 2) before any per-block verdict is computed. That
+ordering is deliberate: if the doc and the template disagree, every verdict
+derived from them is untrustworthy, so the run must stop rather than emit
+verdicts that look authoritative.
+
+Discovering entirely new blocks remains the human step in catch-up Step 2. The
+tool states this in its output rather than implying full coverage.
+
+## Decision 6 — discovery, exit codes, safety
+
+**Discovery.** No arguments: glob `${SEED_DRIFT_ROOT:-$HOME/workspace}/*/.devcontainer/local-seed.sh`.
+With arguments: check exactly those paths. A glob is self-maintaining as
+projects are added; a hand-maintained list goes stale silently, which is the
+same failure class as the bug being fixed.
+
+**Skips.** A project without a seed is skipped with a note and does not affect
+the exit code.
+
+**Exit codes.** `0` clean (skips included); `1` any drift, in any direction; `2`
+usage error, unreadable template, doc/template disagreement, or a seed whose
+block boundaries cannot be resolved.
+
+A run does not abort on the first bad seed. It reports every project, then exits
+with the highest severity encountered (`2` outranks `1` outranks `0`), so one
+malformed seed cannot hide drift in the other four.
+
+**Extraction failure must never read as clean.** The column-0 boundary rule
+assumes a `shfmt`-clean file. A seed hand-edited since its last catch-up may not
+be. Both sides are checked with `bash -n` — the template as well as each seed,
+since a broken template would otherwise silently produce empty blocks that
+compare equal to everything. If a block's enclosing statement cannot be
+resolved, or either file fails `bash -n`, the tool errors rather than falling
+through to `ok`: a silent pass here would reproduce the exact false-clean bug
+being fixed.
+
+**Read-only.** The detector never writes to a seed. These are gitignored,
+hand-owned files with no revert path. Asserted by test.
+
+## Output
+
+```
+slabledger  /home/tng/workspace/slabledger/.devcontainer/local-seed.sh
+  BEHIND   tree-sitter CLI      7 template lines absent from seed
+             - elif sh -c 'command -v tree-sitter >/dev/null 2>&1 && ...
+             - echo "seed: tree-sitter already present (image-provided)"
+             -> port from template; see catch-up-local-seed.md Step 2
+  AHEAD    codex guard          2 seed lines absent from template
+             -> promotion candidate; do NOT overwrite the seed
+  ok       neovim install
+double-holo-ui  no seed - skipped
+
+5 checked, 0 skipped, 2 blocks drifted (1 behind, 1 ahead)
+```
+
+Every finding names the project, the block, and the direction.
+
+## Testing
+
+`tests/seed_drift.bats`, fixtures only — no dependency on the real `~/workspace`,
+so the suite is machine-independent. Follows `setup_dotfiles_test` and
+`stub_command` from `tests/test_helper.bash`.
+
+Required cases:
+
+- **anchor present, surrounding block outdated -> `BEHIND`, exit 1.** The case
+  that motivated the work. A detector that passes the current five without this
+  test proves nothing.
+- anchor absent -> `MISSING`
+- extra seed lines -> `AHEAD`, wording is promotion, not overwrite
+- differences both directions -> `DIVERGED`
+- false-positive guards, one test each: `as_user` vs direct invocation,
+  `$SEED_HOME` vs `$HOME`, `$DOTFILES_HOME` vs `$HOME/.dotfiles`, restyled line
+  continuations, reworded comments, ownership idiom present vs absent
+- `sed 's#...#g'` survives comment stripping
+- absent project -> skipped, exit 0
+- malformed / non-`shfmt` seed -> exit 2, never `ok`
+- a malformed seed does not suppress drift reporting for the others
+- doc table anchor missing from template -> exit 2
+- seeds unmodified after a run (read-only)
+- exit codes: 0 clean, 1 drift, 2 error
+
+## Repository integration
+
+- `bin/seed-drift`, executable. Auto-discovered by both linter targets via
+  `is_direct_bin_shell` in `bin/list-check-files` — verified against a stub, so
+  **no `list-check-files` change is required**.
+- Must be `shfmt -i 2 -ci` and `shellcheck -x -S warning` clean.
+
+### Deliberate exclusion
+
+`bin/list-check-files` does not emit `.bats` files for either linter, so
+`tests/seed_drift.bats` will be unlinted. This is consistent with all 20 existing
+suites and is left as-is. Closing the gap would surface roughly 6 shellcheck
+findings and shfmt reformatting requests across files unrelated to this change;
+it deserves its own evaluation against all 20 suites rather than being smuggled
+in here.

--- a/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
+++ b/docs/superpowers/specs/2026-08-03-seed-drift-detector-design.md
@@ -151,9 +151,41 @@ hard error (exit 2), not a per-block verdict.
 
 **An anchor locates a block; it does not define its membership.**
 
-A block is the **union of every blank-line-delimited paragraph whose non-comment
-text contains the anchor**, matched as a **fixed string**. Paragraph detection is
-**heredoc-aware**: a blank line inside a heredoc body does not end a paragraph.
+A block is the **union of every parse-complete window containing the anchor**,
+matched as a **fixed string**.
+
+A window starts as one blank-line-delimited paragraph — heredoc-aware, so a blank
+line inside a heredoc body does not end a paragraph — and is then **grown until
+the extracted text parses on its own**:
+
+1. Take the paragraph whose non-comment text contains the anchor.
+2. While `bash -n` on the extracted fragment fails, append the next paragraph;
+   if that reaches end of file, prepend the preceding paragraph instead.
+3. If both directions are exhausted without parsing, the block is an
+   **extraction error** (exit 2), never `ok`.
+
+### Blank lines are formatting; the parse check is what makes extraction sound
+
+An earlier draft claimed paragraph extraction was formatting-independent. That
+was wrong: blank lines *are* formatting. Valid Bash permits a blank line between
+a condition and its body, and `bash -n` accepts it:
+
+```sh
+if [ -n "$x" ]; then
+
+  echo hi        # <- a separate paragraph
+fi
+```
+
+An anchor in the condition would have extracted the condition alone. Verified:
+`bash -n` exits 2 on `if [ -n "$x" ]; then` by itself and 0 on the full form
+above. So the split is legal input, the truncation was real, and the assertion
+that a paragraph always carries the full statement group did not hold.
+
+The same asymmetry supplies the remedy. A truncated window is *detectable* —
+that is exactly what `bash -n` reports — so the window is grown until it parses.
+Extraction is now **formatting-tolerant and verified**, rather than
+formatting-independent by assertion.
 
 ### Why not "the enclosing top-level statement"
 
@@ -186,7 +218,25 @@ Verified: blank line at 203, contiguous content 204-236, blank line at 237.
 
 Heredoc awareness is required, not optional: lines 223 and 229 are blank lines
 *inside* the `GITEOF` heredoc, and a naive splitter would cut the block in three.
-The scanner tracks `<<TAG`, `<<'TAG'`, and `<<-TAG` to its closing delimiter.
+
+### Heredoc recognition must be complete and must fail closed
+
+The scanner recognizes every Bash heredoc delimiter form — `<<TAG`, `<<'TAG'`,
+`<<"TAG"`, `<<\TAG`, and each with the `<<-` tab-stripping variant — and tracks
+it to its closing delimiter. Two constructs must be excluded rather than
+misread:
+
+- **Herestrings.** `<<<` is not a heredoc.
+- **`<<` inside quotes.** Template line 255 is
+  `GI_MARK_END="# <<< overlay symlinks (auto) <<<"` — and it sits inside the
+  overlay-gitignore anchored block. A scanner keying on a bare `<<` would look
+  for a heredoc delimiter here and swallow the rest of the file. Quote tracking
+  is required, and is shared with the trailing-comment rule in Decision 4.
+
+Any `<<` that is neither excluded nor matched by a recognized form is an
+**extraction error** (exit 2). Unrecognized heredoc syntax must never degrade to
+"probably not a heredoc" — that failure mode is silent, and silence is the class
+of bug this tool exists to remove.
 
 ### Why fixed-string matching, and why comments are excluded from matching
 
@@ -203,27 +253,31 @@ Because the rule is applied identically to both sides, overlapping blocks are
 symmetric. Overlap means a drifted region may be reported under more than one
 block name: noise, not silence, which is the correct direction.
 
-### Formatting independence
+### Formatting tolerance
 
-Paragraph boundaries depend on blank lines and heredoc structure, not on
-indentation, so extraction does **not** assume `shfmt`-clean input. This is a
-deliberate change from the first draft, which assumed column-0 boundaries and
-then proposed to validate that assumption with `bash -n` — a check that passes
-on syntactically valid but unformatted shell, so it would not have validated the
-assumption at all.
+Extraction does not assume `shfmt`-clean input: window growth is driven by
+`bash -n`, not by indentation or blank-line placement. All five live seeds and
+the template are in fact `shfmt -i 2 -ci` clean today (verified), so an shfmt
+precondition would also have been viable — but a parse-verified extractor is
+strictly better than a formatting dependency plus a gate enforcing it, because
+it stays correct on input the gate never sees.
 
-All five live seeds and the template are in fact `shfmt -i 2 -ci` clean today
-(verified), so an shfmt precondition would have been viable. It is not adopted,
-because a formatting-independent extractor is strictly better than a formatting
-dependency plus a gate enforcing it.
+The first draft proposed to validate its column-0 boundary assumption with
+`bash -n` on the *whole file*, which passes on syntactically valid but
+unformatted shell and therefore validated nothing. The check is only meaningful
+applied to the extracted fragment, which is what the rule above does.
 
 ### Residual limitation
 
-A semantic block that spans two paragraphs where only one contains the anchor is
-compared only in part. This is far narrower than the enclosing-statement failure
-above — the paragraph always carries the anchor's full statement group and its
-comment preamble — but it is not zero, and it is not detectable from inside the
-tool.
+A window that already parses is not grown further, so a syntactically complete
+command sitting inside a larger conditional is extracted without that
+conditional. If the anchor is in the body and the guarding condition lives in a
+separate paragraph, a change to the condition alone is missed.
+
+This is narrower than it sounds — several anchors (`TREE_SITTER_VERSION`,
+`NVIM_VERSION`, `core.hooksPath`) appear in the conditions themselves, so those
+paragraphs are covered from the other side — but it is real, and it is not
+detectable from inside the tool.
 
 ### Alternative considered and deferred: whole-file paragraph matching
 
@@ -238,7 +292,7 @@ narrow in practice.
 
 ## Decision 4 — normalization
 
-Applied to both sides, narrowest first:
+Applied to **shell code only**, narrowest first:
 
 | Step | Rationale |
 |---|---|
@@ -247,24 +301,56 @@ Applied to both sides, narrowest first:
 | Collapse whitespace runs, trim | reindentation is noise |
 | Drop `as_user`, `$SUDO`, `sudo [-n]`, `runuser -u X --` prefixes | privilege vocabulary |
 | `$SEED_HOME` / `$HOME` -> `«HOME»`; `$DOTFILES_HOME` -> `«HOME»/.dotfiles`; `$WORKSPACE` -> `«WS»` | path vocabulary; substitute the token only, preserving surrounding quotes |
-| Drop the two **exact** ownership-verification lines listed below | that idiom exists only in the non-root flavor |
+| Drop the two **fully literal** ownership-verification lines listed below | that idiom exists only in the non-root flavor |
 
-The ownership rule is deliberately **not** "drop every `chown`/`chgrp` line".
-An earlier draft said that, and it was too broad in exactly the direction this
-design calls dangerous: it would hide a genuine change to the target path, the
-recursion flag, the identity, or the failure handling of any ownership repair
-anywhere in a block.
+### Heredoc bodies are payload and are compared verbatim
 
-Instead the rule matches two literal normalized forms, and nothing else:
+None of the above applies inside a heredoc body. A heredoc body is output data,
+not shell code, and every rule in the table corrupts data:
+
+- The `GITEOF` body (template 219-233) contains **two `#` lines that are
+  gitignore payload**, not shell comments — `# Personal Claude Code overlay
+  shims...` and `# Personal docker-compose overrides.`. Comment stripping would
+  delete real content from the seeded file, in the very block the
+  non-anchor-line regression test targets.
+- That body also contains blank lines and leading-whitespace-sensitive patterns.
+- A trailing `\` in a payload line is literal text, not a continuation.
+
+So heredoc bodies are carried through **verbatim**, with one exception, which
+follows shell semantics rather than adding a rule: path-token neutralization is
+applied only when the delimiter is **unquoted** (`<<TAG`), because that is
+exactly when the shell itself expands the variable. A quoted delimiter
+(`<<'GITEOF'`, `<<"TAG"`, `<<\TAG`) means the body is literal, so neutralizing
+`$HOME` there would rewrite text the container will see. Both template heredocs
+are quoted, so both are compared byte-for-byte after extraction.
+
+### The ownership rule takes exact arguments, with nothing free
+
+The rule is deliberately **not** "drop every `chown`/`chgrp` line". An earlier
+draft said that, and a later one narrowed it to two forms with the target path
+left free — which still hid the thing the surrounding paragraph says must stay
+visible: template and seed could name different targets and both lines would
+vanish.
+
+The idiom occurs exactly twice in the template, and the two instances differ in
+both flag and target:
 
 ```
-{ chown "$SEED_UID:$SEED_GID" <arg> 2>/dev/null ||
-[ -z "$(find <arg> \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+  [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+
+{ chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||
+  [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
 ```
 
-`<arg>` is the only free element. Any other `chown` or `chgrp` line is compared
-normally. Each form gets its own test, and a test asserts that an *unrelated*
-`chown` line is **not** dropped.
+Both are matched **fully literally, post-normalization** — the `-R` on the first
+and its absence on the second are part of the match, as are the two target
+paths. Nothing is free. (The previous draft wrote both without `-R`, so it would
+not have matched the neovim instance at all.)
+
+Any other `chown` or `chgrp` line is compared normally. Tests assert that a
+changed target, a changed `-R`, a changed identity, and an unrelated `chown`
+each produce drift.
 
 Known residual false-positive source, accepted and documented rather than
 normalized: **literal** workspace paths (`/app` vs `/workspace`). Only the
@@ -309,9 +395,24 @@ candidate with no `.devcontainer/local-seed.sh` is a **skip**; a candidate with
 one is **checked**.
 
 - No arguments: candidates are `${SEED_DRIFT_ROOT:-$HOME/workspace}/*/`.
-- With arguments: each argument is a candidate. A project directory and a direct
-  path to a `local-seed.sh` are both accepted; the tool distinguishes them by
-  testing whether the argument is a directory.
+- With arguments: each argument is a candidate, classified by what it is on
+  disk:
+  - a **directory** -> a project directory;
+  - an **existing file** -> a direct path to a `local-seed.sh`;
+  - **nonexistent** -> a **skip**, noted as "not present on this machine".
+
+The nonexistent case was undefined in an earlier draft, which distinguished
+arguments solely by `test -d`. That silently conflated "this project is not
+checked out here" with "this seed path does not exist", and contradicted the
+skip requirement, which is not qualified to auto-discovery: the intended use is
+a gate that names the same project list on every machine.
+
+The cost is that a typo'd path skips instead of failing. That is mitigated, not
+ignored: a skip prints the path it skipped and is counted in the summary line,
+so `5 checked` silently becoming `4 checked, 1 skipped` is visible in the output
+a gate captures. The alternative — erroring on a missing project — would make
+the tool unusable on any machine that does not have all five checked out, which
+is the case the requirement exists to cover.
 
 An earlier draft globbed `*/.devcontainer/local-seed.sh` directly. That is
 inconsistent with the skip requirement: globbing seed files enumerates only
@@ -326,24 +427,27 @@ entries under `~/workspace` are silent rather than reported as skips.
 A glob is self-maintaining as projects are added; a hand-maintained list goes
 stale silently, which is the same failure class as the bug being fixed.
 
-**Skips.** A candidate without a seed is reported with a note and does not affect
-the exit code.
+**Skips.** A candidate without a seed, and an argument naming a path that does
+not exist, are both reported with a note and do not affect the exit code.
 
 **Exit codes.** `0` clean (skips included); `1` any drift, in any direction; `2`
-usage error, unreadable template, doc/template disagreement, or a seed whose
-block boundaries cannot be resolved.
+usage error, unreadable template, doc/template disagreement, or a block that
+cannot be extracted — a window that never parses, or unrecognized heredoc
+syntax.
 
 A run does not abort on the first bad seed. It reports every candidate, then
 exits with the highest severity encountered (`2` outranks `1` outranks `0`), so
 one malformed seed cannot hide drift in the other four.
 
-**Extraction failure must never read as clean.** Paragraph extraction is
-formatting-independent (Decision 3), so there is no `shfmt` precondition. Both
-files are still checked with `bash -n` — the template as well as each seed, since
-a broken template would otherwise silently produce empty blocks that compare
-equal to everything. An anchor that the template does not contain, or a block
-that extracts to nothing on the template side, is an error rather than an `ok`:
-a silent pass here would reproduce the exact false-clean bug being fixed.
+**Extraction failure must never read as clean.** Extraction is verified by
+parsing the extracted fragment (Decision 3), so there is no `shfmt`
+precondition. Both files are additionally checked with `bash -n` as a whole —
+the template as well as each seed, since a broken template would otherwise
+silently produce empty blocks that compare equal to everything. An anchor the
+template does not contain, a block that extracts to nothing on the template
+side, a window that never parses, and unrecognized heredoc syntax are all errors
+rather than `ok`: a silent pass in any of them reproduces the exact false-clean
+bug being fixed.
 
 **Read-only.** The detector never writes to a seed. These are gitignored,
 hand-owned files with no revert path. Asserted by test.
@@ -388,18 +492,38 @@ Required cases:
   seeded gitignore heredoc, leave the `git config` line untouched, expect drift.
 - **a blank line inside a heredoc does not split the block.** Guards heredoc
   awareness directly.
+- **a blank line between an `if` condition and its body does not truncate the
+  block.** Guards the window-growth rule in Decision 3; a change in the body
+  must still be reported when the anchor is in the condition.
+- **a window that never parses -> exit 2**, and a block requiring *upward*
+  growth (anchor in the body, `if` header in the preceding paragraph) is
+  extracted whole.
+- **heredoc payload is compared verbatim**, three cases: a changed `#` line
+  inside the `GITEOF` body is drift (not stripped as a comment); a changed blank
+  line or leading whitespace inside a body is drift; a trailing `\` in a body is
+  not treated as a continuation.
+- **an unquoted-delimiter heredoc gets path neutralization, a quoted one does
+  not.** Pins the shell-semantics rule in Decision 4.
+- **`<<` inside a double-quoted string is not a heredoc opener.** Modelled on
+  template line 255 (`GI_MARK_END="# <<< overlay symlinks (auto) <<<"`); a
+  regression here swallows the rest of the file.
+- **`<<<` herestrings are not heredoc openers**, and each of `<<TAG`,
+  `<<'TAG'`, `<<"TAG"`, `<<\TAG`, `<<-TAG` is recognized.
+- **unrecognized heredoc syntax -> exit 2**, never a silent fallback.
 - anchor absent -> `MISSING`
 - extra seed lines -> `AHEAD`, wording is promotion, not overwrite
 - differences both directions -> `DIVERGED`
 - false-positive guards, one test each: `as_user` vs direct invocation,
   `$SEED_HOME` vs `$HOME`, `$DOTFILES_HOME` vs `$HOME/.dotfiles`, restyled line
   continuations, reworded comments, the two exact ownership-idiom forms
-- **an unrelated `chown` line is NOT dropped.** Guards against the over-broad
-  ownership rule rejected in Decision 4.
+- **the ownership rule is exact**, four cases: a changed target, a changed `-R`,
+  a changed `$SEED_UID:$SEED_GID` identity, and an unrelated `chown` line each
+  produce drift rather than being dropped.
 - `sed 's#...#g'` survives comment stripping
 - an anchor appearing only in a comment does not anchor a block
 - candidate with `.devcontainer/` but no seed -> skipped, exit 0, counted as
   skipped; a directory with no `.devcontainer/` is not reported at all
+- **a nonexistent argument -> skipped, exit 0**, and the skip names the path
 - argument accepted both as a project directory and as a direct seed path
 - unparseable seed (`bash -n` fails) -> exit 2, never `ok`
 - a malformed seed does not suppress drift reporting for the others

--- a/tests/check_file_discovery.bats
+++ b/tests/check_file_discovery.bats
@@ -62,6 +62,25 @@ list_files() {
   [[ "$output" == *"ai/claude/install.sh"* ]]
 }
 
+@test "shfmt discovery covers Bats suites" {
+  # The suites were format-checked by nothing for either linter, so they drifted
+  # silently: two of them were already unformatted when this gate was added.
+  # shfmt only — bash -n and shellcheck cannot parse @test block syntax, so the
+  # other classes deliberately still exclude .bats.
+  list_files shfmt
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tests/check_file_discovery.bats"* ]]
+  [[ "$output" == *"tests/seed_drift.bats"* ]]
+
+  local class
+  for class in bash shellcheck zsh; do
+    list_files "$class"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *".bats"* ]]
+  done
+}
+
 @test "project seed template is covered by every bash source gate" {
   local expected="ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh"
   local class

--- a/tests/nvim_treesitter_guard.bats
+++ b/tests/nvim_treesitter_guard.bats
@@ -36,7 +36,10 @@ guard_verdict() {
   # Fail loudly rather than silently testing an empty chunk if the surrounding
   # code is reindented or the function renamed.
   grep -q 'function tree_sitter_cli_works' "$guard" ||
-    { echo "could not extract tree_sitter_cli_works from $INIT_LUA" >&2; return 2; }
+    {
+      echo "could not extract tree_sitter_cli_works from $INIT_LUA" >&2
+      return 2
+    }
   echo 'io.write(tostring(tree_sitter_cli_works()))' >>"$guard"
 
   PATH="$STUB_BIN:/usr/bin:/bin" "$NVIM_BIN" --clean --headless \
@@ -53,13 +56,19 @@ guard_verdict() {
   for v in 0.26.1 0.26.11 0.27.0 1.0.0; do
     stub_command tree-sitter "echo 'tree-sitter $v'"
     run guard_verdict
-    [ "$output" = true ] || { echo "expected $v accepted, got: $output"; false; }
+    [ "$output" = true ] || {
+      echo "expected $v accepted, got: $output"
+      false
+    }
   done
 
   for v in 0.20.8 0.25.9 0.26.0; do
     stub_command tree-sitter "echo 'tree-sitter $v'"
     run guard_verdict
-    [ "$output" = false ] || { echo "expected $v rejected, got: $output"; false; }
+    [ "$output" = false ] || {
+      echo "expected $v rejected, got: $output"
+      false
+    }
   done
 }
 
@@ -121,8 +130,14 @@ guard_verdict() {
   ' "$INIT_LUA"
 
   [ "$status" -eq 0 ]
-  [[ "$output" != *UNGATED* ]] || { echo "$output"; false; }
+  [[ "$output" != *UNGATED* ]] || {
+    echo "$output"
+    false
+  }
   # Pin the count: a new, unnoticed call site should fail here rather than be
   # silently accepted by a check that only looks at the ones it knows about.
-  [[ "$output" == *"sites=2"* ]] || { echo "expected 2 install sites, got: $output"; false; }
+  [[ "$output" == *"sites=2"* ]] || {
+    echo "expected 2 install sites, got: $output"
+    false
+  }
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -467,3 +467,37 @@ $HOME/literal' ]
 { chown -R "$SEED_UID:0" "$NVIM_DIST.new" 2>/dev/null ||
 chown -R node:node /app' ]
 }
+
+@test "sd_extract unions windows in file order, deduped, and normalizes" {
+  printf 'echo ANCHOR one\n\necho middle\n\nas_user echo ANCHOR two\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" ANCHOR
+  [ "$status" -eq 0 ]
+  [ "$output" = "echo ANCHOR one
+echo ANCHOR two" ]
+}
+
+@test "sd_extract deduplicates lines shared by two overlapping windows" {
+  printf 'if [ -n "$ANCHOR" ]; then\n\n  echo ANCHOR body\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" ANCHOR
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if [ -n "$ANCHOR" ]; then
+echo ANCHOR body
+fi' ]
+}
+
+@test "sd_extract drops comment-only lines and keeps the sed s#...#g idiom" {
+  printf '# reworded prose about ANCHOR\nsed '"'"'s#/app#/workspace#g'"'"' ANCHOR.txt # trailing\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" ANCHOR
+  [ "$status" -eq 0 ]
+  [ "$output" = "sed 's#/app#/workspace#g' ANCHOR.txt" ]
+}
+
+@test "sd_extract exits 4 when the anchor is absent" {
+  printf 'echo hi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" NOPE
+  [ "$status" -eq 4 ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -906,6 +906,25 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   [[ "$output" != *"unbound variable"* ]]
 }
 
+@test "sd_visit_candidates can be called directly without sd_main having run" {
+  # Same contract as the test above, on the other pair of sd_main-assigned
+  # globals: sd_visit_candidates reads SD_CANDIDATE_COUNT to decide between
+  # discovery and the explicit list. Undeclared, a bare `source` plus a direct
+  # call dies with "unbound variable" (exit 1) before discovery runs at all,
+  # which the public contract would read as drift. Declared empty, the empty
+  # workspace correctly reports the zero-projects error at exit 2.
+  setup_drift_fixtures
+
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    sd_visit_candidates
+  ' _ "$SEED_DRIFT"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" != *"unbound variable"* ]]
+  [[ "$output" == *"no projects found under"* ]]
+}
+
 @test "an explicit candidate directory with no .devcontainer is named and skipped, exit 0" {
   setup_drift_fixtures
   mkdir -p "$SEED_DRIFT_ROOT/nodev"

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -20,6 +20,15 @@ sd_source() {
   ' _ "$SEED_DRIFT" "$@"
 }
 
+write_fixture_doc() {
+  cat >"$1" <<'DOC'
+| Block | Anchor in template | Why it matters |
+|---|---|---|
+| Overlay-link gitignore | `lname '*dotfiles/projects/*'` | Adds overlay links. |
+| `core.excludesFile` | `core.excludesFile` | Points git at the seeded ignore file. |
+DOC
+}
+
 @test "seed-drift --help prints usage and exits 0" {
   run "$SEED_DRIFT" --help
 
@@ -54,4 +63,25 @@ sd_source() {
 
   [ "$status" -eq 2 ]
   [[ "$output" == *"cannot read doc"* ]]
+}
+
+@test "sd_parse_doc emits blockname TAB anchor and keeps quotes in the anchor" {
+  local doc="$TEST_ROOT/doc.md"
+  write_fixture_doc "$doc"
+
+  sd_source sd_parse_doc "$doc"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf 'Overlay-link gitignore\tlname '"'"'*dotfiles/projects/*'"'"'')" ]
+  [ "${lines[1]}" = "$(printf 'core.excludesFile\tcore.excludesFile')" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "sd_parse_doc reads all nine blocks from the real catch-up doc" {
+  sd_source sd_parse_doc "$REAL_DOC"
+
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 9 ]
+  [[ "$output" == *"TREE_SITTER_VERSION"* ]]
+  [[ "$output" == *"lname '*dotfiles/projects/*'"* ]]
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -376,21 +376,24 @@ sd_cap_fixture() {
 }
 
 @test "sd_window finds a far window while the search stays under the parse-attempt cap" {
-  # 9 * 9 + 1 = 82 attempts, well under the cap: the window is found.
-  sd_cap_fixture 8 8
-  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 10
+  # 41 * 41 + 1 = 1682 attempts, just under SD_MAX_PARSE_ATTEMPTS=2000: the
+  # window is still found. Sized to bracket the cap from below rather than to
+  # sit comfortably away from it, so a reduction of the cap fails this test
+  # instead of passing silently.
+  sd_cap_fixture 40 40
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 42
   [ "$status" -eq 0 ]
-  [ "$output" = "1 20" ]
+  [ "$output" = "1 84" ]
 }
 
 @test "sd_window gives up with status 3 once the parse-attempt cap is reached" {
-  # Identical shape, only bigger: 21 * 21 + 1 = 442 attempts, so the winning
-  # pair sits past SD_MAX_PARSE_ATTEMPTS=400 and is never reached. The cap —
+  # Identical shape, only bigger: 45 * 45 + 1 = 2026 attempts, so the winning
+  # pair sits past SD_MAX_PARSE_ATTEMPTS=2000 and is never reached. The cap —
   # not exhaustion — is what ends this search, and it reports the same
   # status 3 the exhaustion path already uses, so it needs no new handling in
   # sd_extract or sd_check_seed.
-  sd_cap_fixture 20 20
-  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 22
+  sd_cap_fixture 44 44
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 46
   [ "$status" -eq 3 ]
 }
 
@@ -2061,9 +2064,9 @@ PYEOF
   } >"$TPL"
   {
     printf 'if true; then\n\n'
-    for n in $(seq 20); do printf '  echo p%s\n\n' "$n"; done
+    for n in $(seq 44); do printf '  echo p%s\n\n' "$n"; done
     printf '  ANCHOR=1\nfi\n\n'
-    for n in $(seq 20); do printf '  echo q%s\n\n' "$n"; done
+    for n in $(seq 44); do printf '  echo q%s\n\n' "$n"; done
   } >"$SEED"
 
   t7_run

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -588,3 +588,11 @@ write_lines() {
   [ "$status" -eq 0 ]
   [ "$output" = "DIVERGED" ]
 }
+
+@test "sd_verdict reports BEHIND when the only difference is a removed blank line" {
+  printf 'export A=1\n\nexport B=2\n' >"$TEST_ROOT/tpl"
+  printf 'export A=1\nexport B=2\n' >"$TEST_ROOT/seed"
+  sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+  [ "$status" -eq 0 ]
+  [ "$output" = "BEHIND" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -462,85 +462,6 @@ $HOME/literal' ]
   [ "$output" = '  «HOME»/x   # not a comment' ]
 }
 
-# Fix round 3 (Task 7, group 2): the ownership drop moved out of per-file
-# normalization into sd_apply_ownership_rule at the comparison stage, because
-# the rule is inherently cross-file ("does the OTHER side still show a chown
-# difference?") and per-file dropping hid a changed target/flag/identity as
-# AHEAD instead of DIVERGED. sd_normalize on its own must now pass these
-# lines through unchanged; see the sd_apply_ownership_rule unit test below
-# for the actual dropping behavior.
-@test "sd_normalize no longer drops the ownership-verification lines itself" {
-  scan_line 1 1 C '      { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
-  scan_line 1 2 C '        [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
-  scan_line 1 3 C '      { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||'
-  scan_line 1 4 C '        [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
-  scan_line 1 5 C 'echo after'
-  norm
-  [ "$status" -eq 0 ]
-  [ "$output" = '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
-[ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
-{ chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||
-[ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
-echo after' ]
-}
-
-# sd_apply_ownership_rule BEHIND_FILE AHEAD_FILE: drops the exact idiom lines
-# from BEHIND_FILE only when AHEAD_FILE has no chown/chgrp line of its own —
-# the root-flavored-seed-omits-it-entirely case the rule exists for.
-@test "sd_apply_ownership_rule drops the idiom from behind when ahead is silent about ownership" {
-  local behind="$FIX/behind" ahead="$FIX/ahead"
-  printf '%s\n%s\n' \
-    '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||' \
-    '[ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&' \
-    >"$behind"
-  : >"$ahead"
-  sd_source sd_apply_ownership_rule "$behind" "$ahead"
-  [ "$status" -eq 0 ]
-  [ ! -s "$behind" ]
-}
-
-# The counterpart: any chown/chgrp line on the ahead side blocks the drop, so
-# a changed target/flag/identity keeps the idiom's original lines in behind
-# and the block reports DIVERGED rather than AHEAD.
-@test "sd_apply_ownership_rule keeps behind untouched when ahead mentions chown" {
-  local behind="$FIX/behind" ahead="$FIX/ahead"
-  printf '%s\n' \
-    '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||' \
-    >"$behind"
-  printf '%s\n' 'chown -R "0:0" "$NVIM_DIST.new"' >"$ahead"
-  sd_source sd_apply_ownership_rule "$behind" "$ahead"
-  [ "$status" -eq 0 ]
-  [ "$(cat "$behind")" = '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||' ]
-}
-
-# Fix round 1 (Task 7 review, I-1): pins SD_OWNERSHIP_GUARD_PATTERN to
-# SD_OWNERSHIP_DROP so the two cannot drift apart silently. The guard exists
-# to recognize when AHEAD_FILE still carries a trace of an idiom line; if a
-# future idiom entry is added to the array whose distinguishing tokens the
-# guard doesn't cover, this is exactly the class of bug the find-half
-# regression test (below, in the Task 7 end-to-end block) caught — and it
-# would recur silently, one entry at a time, without this test.
-@test "SD_OWNERSHIP_GUARD_PATTERN matches every SD_OWNERSHIP_DROP entry" {
-  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
-    source "$1"
-    for line in "${SD_OWNERSHIP_DROP[@]}"; do
-      grep -qE "$SD_OWNERSHIP_GUARD_PATTERN" <<<"$line" || printf "MISS: %s\n" "$line"
-    done
-  ' _ "$SEED_DRIFT"
-  [ -z "$output" ]
-}
-
-# Fix round 1 (Task 7 review, M-2): this test used to claim to cover "the
-# ownership rule" but only ever exercised sd_normalize passthrough — it would
-# pass identically with no ownership rule at all, since sd_normalize stopped
-# touching these lines the moment the drop moved to sd_apply_ownership_rule
-# (see "sd_normalize no longer drops..." above). That passthrough claim is
-# already covered there; the actual rule (target/-R/identity/unrelated-chown
-# all producing real drift) is covered end-to-end, against the real tool, by
-# the four "ownership idiom ... is drift, not dropped" tests and "an
-# unrelated chown line is compared normally" below. Deleted as a redundant,
-# uncatchable duplicate rather than kept as a test that cannot fail.
-
 @test "sd_extract unions windows in file order, deduped, and normalizes" {
   printf 'echo ANCHOR one\n\necho middle\n\nas_user echo ANCHOR two\n' >"$FIX/f.sh"
   make_scan "$FIX/f.sh"
@@ -1538,13 +1459,11 @@ SEEDEOF
   t7_doc "neovim install" NVIM_DIST
   t7_own_tpl
   # The chown half is byte-identical to the template on both sides here, so
-  # it cancels in the diff and never reaches AHEAD_FILE. Only the find-half
-  # (`! -uid`) changed. A guard that only looks for `chown` in AHEAD_FILE is
-  # blind to this: AHEAD_FILE holds nothing but the modified find-half line,
-  # which has no `chown` token, so the guard fires anyway, the idiom is
-  # dropped from BEHIND_FILE, and the block reports AHEAD with "promotion
-  # candidate" advice — silently wrong, since the seed's ownership check no
-  # longer verifies the group it claims to.
+  # it cancels in the diff; only the find-half (`! -uid`) differs. There is
+  # no ownership-specific rule left to fool, but this still stresses that a
+  # single changed line inside a two-line idiom instance is reported as
+  # ordinary drift — DIVERGED, never AHEAD/"promotion candidate" — the same
+  # way any other single-line change inside a multi-line block would be.
   cat >"$SEED" <<'SEEDEOF'
 #!/usr/bin/env bash
 
@@ -1581,13 +1500,39 @@ SEEDEOF
   # This line has nothing to do with the ownership idiom (a different target
   # entirely, no matching template counterpart), so per Decision 5 (design
   # doc :521-522, "extra seed lines -> AHEAD") it is a promotion candidate,
-  # not a divergence — the ownership rule (group-2 fix) only changes the
-  # verdict for lines that DO match the idiom's shape on one side. The
-  # positive assertion below is the test's actual subject: the line must be
-  # compared (shown as extra), not silently absorbed by the ownership drop.
+  # not a divergence. There is no ownership-specific rule anymore to risk
+  # over-matching it; this pins the ordinary case — an unrelated added line
+  # is compared and reported like any other, not swallowed by anything.
   [[ "$output" == *AHEAD* ]]
   [[ "$output" == *'chown -R "$SEED_UID:$SEED_GID" "«HOME»/.cache"'* ]]
   [[ "$output" != *"overwrite the seed with"* ]]
+}
+
+# Fix round 2 (Task 7 review): the ownership rule was removed entirely (per
+# the human's ruling after measurement showed it changed no verdict on the
+# real corpus, and it had failed three separate ways — per-file asymmetry,
+# blindness to a rewritten idiom half, and diff hunk adjacency). A root-
+# flavored seed that verifies nothing about ownership now correctly reports
+# the template's two idiom lines as BEHIND, same as any other omitted
+# template content. This is the documented, intended behavior — pin it so it
+# is not mistaken for a regression and "fixed" back into a drop later.
+@test "a root-flavored seed with no ownership check reports the idiom lines as BEHIND" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+  [[ "$output" == *'2 template lines absent from seed'* ]]
+  [[ "$output" == *'chown -R "$SEED_UID:$SEED_GID"'* ]]
 }
 
 @test "false-positive guard: as_user prefix vs direct invocation" {
@@ -1691,45 +1636,6 @@ SEEDEOF
   t7_run "$SEED"
   [ "$status" -eq 0 ]
   [[ "$output" == *ok* ]]
-}
-
-@test "false-positive guard: both exact ownership idiom forms are dropped" {
-  t7_setup
-  t7_doc "neovim install" NVIM_DIST "tree-sitter CLI" TS_BIN
-  cat >"$TPL" <<'TPLEOF'
-#!/usr/bin/env bash
-
-NVIM_DIST="$SEED_HOME/.local/nvim"
-if [ -d "$NVIM_DIST.new" ]; then
-  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
-    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
-    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
-fi
-
-TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
-if [ -f "$TS_BIN.new" ]; then
-  { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||
-    [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
-    as_user mv "$TS_BIN.new" "$TS_BIN"
-fi
-TPLEOF
-  cat >"$SEED" <<'SEEDEOF'
-#!/usr/bin/env bash
-
-NVIM_DIST="$SEED_HOME/.local/nvim"
-if [ -d "$NVIM_DIST.new" ]; then
-  as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
-fi
-
-TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
-if [ -f "$TS_BIN.new" ]; then
-  as_user mv "$TS_BIN.new" "$TS_BIN"
-fi
-SEEDEOF
-  t7_run "$SEED"
-  [ "$status" -eq 0 ]
-  [[ "$output" != *BEHIND* ]]
-  [[ "$output" != *DIVERGED* ]]
 }
 
 @test "sed substitution with # delimiters survives comment stripping" {

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -421,3 +421,25 @@ Z="«WS»/p"' ]
   [ "$status" -eq 0 ]
   [ "$output" = "echo keep" ]
 }
+
+@test "sd_normalize passes Hq heredoc payload through verbatim" {
+  scan_line 1 1 Hq '# Personal docker-compose overrides.'
+  scan_line 1 2 Hq ''
+  scan_line 1 3 Hq '  keep   spacing'
+  scan_line 1 4 Hq 'trailing \'
+  scan_line 1 5 Hq '$HOME/literal'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '# Personal docker-compose overrides.
+
+  keep   spacing
+trailing \
+$HOME/literal' ]
+}
+
+@test "sd_normalize neutralizes paths in an Hu body but nothing else" {
+  scan_line 1 1 Hu '  $HOME/x   # not a comment'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '  «HOME»/x   # not a comment' ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -227,3 +227,17 @@ FIX
   [ "${lines[14]}" = "$(printf '1\t15\tHu\t\tu2')" ]
   [ "${lines[15]}" = "$(printf '1\t16\tC\t\tE')" ]
 }
+
+@test "sd_scan queues two heredocs opened on the same line" {
+  local f="$TEST_ROOT/two.sh"
+  printf '%s\n' 'cat <<A; cat <<-"B"' 'x' 'A' $'\ty' $'\tB' 'echo tail' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[1]}" = "$(printf '1\t2\tHu\tx')" ]
+  [ "${lines[2]}" = "$(printf '1\t3\tC\tA')" ]
+  [ "${lines[3]}" = "$(printf '1\t4\tHq\t\ty')" ]
+  [ "${lines[4]}" = "$(printf '1\t5\tC\t\tB')" ]
+  [ "${lines[5]}" = "$(printf '1\t6\tC\techo tail')" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -2071,3 +2071,66 @@ PYEOF
   [[ "$output" == *"seed block could not be extracted"* ]]
   [[ "$output" != *MISSING* ]]
 }
+
+# ── Minor-round guards (M-4, M-1) ────────────────────────────────────────────
+
+@test "discovery leaves the caller's nullglob setting exactly as it found it" {
+  # The script is designed to be sourced (SEED_DRIFT_SOURCE_ONLY=1), so
+  # `shopt -s nullglob` inside discovery is a write into somebody else's
+  # shell. All three paths are pinned: the loop that finds a project, the
+  # same loop with nullglob already on (which must stay on), and the
+  # early-return path where discovery finds nothing and returns 2.
+  setup_drift_fixtures
+  seed_from_template clean
+  mkdir -p "$BATS_TEST_TMPDIR/empty-root"
+
+  run env SEED_DRIFT_SOURCE_ONLY=1 SEED_DRIFT_ROOT="$SEED_DRIFT_ROOT" bash -c '
+    source "$1"
+    shopt -u nullglob
+    sd_main --template "$2" --doc "$3" >/dev/null
+    if shopt -q nullglob; then echo "off-case: LEAKED"; else echo "off-case: restored"; fi
+    shopt -s nullglob
+    sd_main --template "$2" --doc "$3" >/dev/null
+    if shopt -q nullglob; then echo "on-case: preserved"; else echo "on-case: CLOBBERED"; fi
+    shopt -u nullglob
+    SEED_DRIFT_ROOT="$4"
+    sd_main --template "$2" --doc "$3" >/dev/null 2>&1 || true
+    if shopt -q nullglob; then echo "empty-root: LEAKED"; else echo "empty-root: restored"; fi
+  ' _ "$SEED_DRIFT" "$FIXTURE_TEMPLATE" "$FIXTURE_DOC" "$BATS_TEST_TMPDIR/empty-root"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"off-case: restored"* ]]
+  [[ "$output" == *"on-case: preserved"* ]]
+  [[ "$output" == *"empty-root: restored"* ]]
+  [[ "$output" != *LEAKED* ]]
+  [[ "$output" != *CLOBBERED* ]]
+}
+
+@test "a template block that extracts to nothing is an ERROR at exit 2, never ok" {
+  # sd_verdict_from_counts 0 0 is `ok`, so an empty template side would report
+  # a clean block having compared nothing. sd_main's anchor validation makes
+  # that unreachable through the CLI, which is exactly why this calls
+  # sd_check_seed directly with an sd_extract that reports success and writes
+  # nothing — the shape the guard exists to catch if that validation is ever
+  # weakened.
+  setup_drift_fixtures
+  seed_from_template clean
+
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    SD_TEMPLATE="$2"
+    SD_DOC="$3"
+    sd_tmp SD_TEMPLATE_SCAN
+    sd_scan "$SD_TEMPLATE" >"$SD_TEMPLATE_SCAN"
+    sd_extract() {
+      SD_LAST_WINDOW_SIZE=42
+      return 0
+    }
+    sd_check_seed "$4"
+  ' _ "$SEED_DRIFT" "$FIXTURE_TEMPLATE" "$FIXTURE_DOC" "$(seed_path clean)"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"template block extracted to nothing"* ]]
+  [[ "$output" != *"ok  "* ]]
+  [[ "$output" != *"window is only"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  SEED_DRIFT="$REPO_ROOT/bin/seed-drift"
+  SKILL_DIR="$REPO_ROOT/ai/marketplace/plugins/my/skills/project-claude-setup"
+  REAL_TEMPLATE="$SKILL_DIR/templates/local-seed.sh"
+  REAL_DOC="$SKILL_DIR/catch-up-local-seed.md"
+  FIX="$BATS_TEST_TMPDIR/fix"
+  mkdir -p "$FIX"
+}
+
+sd_source() {
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    shift
+    "$@"
+  ' _ "$SEED_DRIFT" "$@"
+}
+
+@test "seed-drift --help prints usage and exits 0" {
+  run "$SEED_DRIFT" --help
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: bin/seed-drift"* ]]
+}
+
+@test "seed-drift rejects an unknown flag with usage on exit 2" {
+  run "$SEED_DRIFT" --nope
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown option --nope"* ]]
+  [[ "$output" == *"Usage: bin/seed-drift"* ]]
+}
+
+@test "seed-drift rejects --template with no value" {
+  run "$SEED_DRIFT" --template
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--template needs a PATH"* ]]
+}
+
+@test "seed-drift exits 2 when the template is unreadable" {
+  run "$SEED_DRIFT" --template "$TEST_ROOT/missing.sh" --doc "$REAL_DOC"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"cannot read template"* ]]
+}
+
+@test "seed-drift exits 2 when the doc is unreadable" {
+  run "$SEED_DRIFT" --template "$REAL_TEMPLATE" --doc "$TEST_ROOT/missing.md"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"cannot read doc"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -116,3 +116,19 @@ DOC
   [ "${lines[2]}" = "$(printf '2\t5\tC\tthird=3')" ]
   [ "${#lines[@]}" -eq 3 ]
 }
+
+@test "sd_scan strips comments quote-aware so a sed s#...#g program survives" {
+  local f="$TEST_ROOT/comments.sh"
+  cat >"$f" <<'FIX'
+# whole line comment
+links="$(find . | sed 's#^\./##')" # trailing note
+echo "kept # inside quotes"
+FIX
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\t')" ]
+  [ "${lines[1]}" = "$(printf '1\t2\tC\tlinks="$(find . | sed '"'"'s#^\\./##'"'"')" ')" ]
+  [ "${lines[2]}" = "$(printf '1\t3\tC\techo "kept # inside quotes"')" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -443,3 +443,27 @@ $HOME/literal' ]
   [ "$status" -eq 0 ]
   [ "$output" = '  «HOME»/x   # not a comment' ]
 }
+
+@test "sd_normalize drops the four exact ownership-verification lines" {
+  scan_line 1 1 C '      { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
+  scan_line 1 2 C '        [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+  scan_line 1 3 C '      { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||'
+  scan_line 1 4 C '        [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
+  scan_line 1 5 C 'echo after'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "echo after" ]
+}
+
+@test "the ownership rule is exact: target, -R, identity, and unrelated chown all survive" {
+  scan_line 1 1 C '{ chown -R "$SEED_UID:$SEED_GID" "$OTHER.new" 2>/dev/null ||'
+  scan_line 1 2 C '{ chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
+  scan_line 1 3 C '{ chown -R "$SEED_UID:0" "$NVIM_DIST.new" 2>/dev/null ||'
+  scan_line 1 4 C 'chown -R node:node /app'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '{ chown -R "$SEED_UID:$SEED_GID" "$OTHER.new" 2>/dev/null ||
+{ chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+{ chown -R "$SEED_UID:0" "$NVIM_DIST.new" 2>/dev/null ||
+chown -R node:node /app' ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -748,3 +748,42 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   [ "$status" -eq 0 ]
   [[ "$output" == *"1 checked, 0 skipped"* ]]
 }
+
+@test "a malformed seed exits 2 without suppressing drift in the others" {
+  setup_drift_fixtures
+  seed_from_template aaa-broken
+  printf 'if true; then\nTREE_SITTER_VERSION=1\n' >"$(seed_path aaa-broken)"
+  seed_from_template zzz-behind
+  sed -i '/tree-sitter ready/d' "$(seed_path zzz-behind)"
+
+  sd_drift
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"does not parse (bash -n)"* ]]
+  [[ "$output" == *"BEHIND   tree-sitter CLI"* ]]
+  [[ "$output" == *"2 checked, 0 skipped, 1 blocks drifted (1 behind)"* ]]
+}
+
+@test "an unparseable template is exit 2 before any verdict" {
+  setup_drift_fixtures
+  seed_from_template clean
+  printf 'if true; then\n' >"$FIXTURE_TEMPLATE"
+
+  sd_drift
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"template does not parse"* ]]
+  [[ "$output" != *"ok       tree-sitter CLI"* ]]
+}
+
+@test "the detector never writes to a seed" {
+  setup_drift_fixtures
+  seed_from_template clean
+  local before after
+  before=$(cksum <"$(seed_path clean)")
+
+  sd_drift
+
+  after=$(cksum <"$(seed_path clean)")
+  [ "$before" = "$after" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -251,3 +251,37 @@ FIX
   [ "$status" -eq 3 ]
   [[ "$output" == *"unterminated heredoc E"* ]]
 }
+
+# --- Task 3 helpers ---------------------------------------------------------
+# Sourcing goes through Task 1's `sd_source`, which sets SEED_DRIFT_SOURCE_ONLY=1.
+# make_scan needs its own form because it captures stdout to a file rather than
+# going through bats' `run`, but it sets the same guard.
+make_scan() {
+  env SEED_DRIFT_SOURCE_ONLY=1 bash -c \
+    'source "$1"; sd_scan "$2"' _ "$SEED_DRIFT" "$1" >"$1.scan"
+}
+
+@test "sd_paras_with_anchor matches C-tag text as a fixed string, every occurrence" {
+  printf 'A="lname '"'"'*dotfiles/projects/*'"'"'"\n\necho other\n\nB="lname '"'"'*dotfiles/projects/*'"'"'"\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_paras_with_anchor "$FIX/f.sh.scan" "lname '*dotfiles/projects/*'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1
+3" ]
+}
+
+@test "sd_paras_with_anchor ignores an anchor that appears only in a comment" {
+  printf 'echo hi # TREE_SITTER_VERSION is pinned\n\nTS=1\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_paras_with_anchor "$FIX/f.sh.scan" TREE_SITTER_VERSION
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "sd_para_range reports the first and last source line of a paragraph" {
+  printf 'a\nb\n\nc\nd\ne\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_para_range "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "4 6" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -520,3 +520,43 @@ write_lines() {
   [ "$status" -eq 0 ]
   [ "$output" = "run_new" ]
 }
+
+@test "sd_verdict reports ok for identical line sequences" {
+  write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_thing' 'export B=2'
+  write_lines "$TEST_ROOT/seed" 'export A=1' 'run_thing' 'export B=2'
+
+  sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+}
+
+@test "sd_verdict reports ok for two empty extractions" {
+  : >"$TEST_ROOT/tpl"
+  : >"$TEST_ROOT/seed"
+
+  sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+}
+
+@test "sd_verdict reports BEHIND when only the template has extra lines" {
+  write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_thing' 'export B=2'
+  write_lines "$TEST_ROOT/seed" 'export A=1' 'export B=2'
+
+  sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "BEHIND" ]
+}
+
+@test "sd_verdict reports AHEAD when only the seed has extra lines" {
+  write_lines "$TEST_ROOT/tpl" 'export A=1' 'export B=2'
+  write_lines "$TEST_ROOT/seed" 'export A=1' 'run_thing' 'export B=2'
+
+  sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "AHEAD" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -329,6 +329,71 @@ make_scan() {
   [ "$output" = "1 4" ]
 }
 
+@test "sd_window stops at the enclosing statement when growing backward, not at EOF" {
+  # The test above cannot detect the bug this one is for: its anchor sits in
+  # the file's LAST paragraph, so the window end is already EOF and a correct
+  # implementation and one that never rolls the end back agree. Here there is
+  # a trailing paragraph after the enclosing `fi`, so the two disagree — the
+  # old forward-to-EOF-then-backward walk returned "1 6", swallowing
+  # UNRELATED=2 into a block that has nothing to do with it.
+  printf 'if [ -n "$x" ]; then\n\n  echo ANCHOR\nfi\n\nUNRELATED=2\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 4" ]
+}
+
+@test "sd_window grows in both directions at once for an anchor inside a function body" {
+  # The common real shape: the anchor's paragraph needs the window grown BACK
+  # to `setup() {` and FORWARD to its closing `}` simultaneously. No
+  # one-dimensional walk can reach this pair; only the (lo, hi) search can.
+  printf 'setup() {\n  local a=1\n\n  if [ -n "$x" ]; then\n    echo ANCHOR\n\n    echo more\n  fi\n}\n\nUNRELATED=2\n' \
+    >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 9" ]
+}
+
+# sd_cap_fixture BEFORE AFTER — a file whose anchor paragraph is extractable
+# only at the very last (lo, hi) pair the search tries.
+#
+# The anchor's paragraph carries the closing `fi` of an `if` opened in
+# paragraph 1, so no pair starting below paragraph 1 can ever parse: the
+# stray `fi` is unmatched in every one of them. The search therefore walks
+# every `hi` for every `lo` down to 1 before it succeeds, which is
+# (BEFORE + 1) * (AFTER + 1) + 1 parse attempts — the knob these two tests
+# turn to sit either side of SD_MAX_PARSE_ATTEMPTS.
+sd_cap_fixture() {
+  local n
+  {
+    printf 'if true; then\n\n'
+    for n in $(seq "$1"); do printf '  echo p%s\n\n' "$n"; done
+    printf '  ANCHOR=1\nfi\n\n'
+    for n in $(seq "$2"); do printf '  echo q%s\n\n' "$n"; done
+  } >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+}
+
+@test "sd_window finds a far window while the search stays under the parse-attempt cap" {
+  # 9 * 9 + 1 = 82 attempts, well under the cap: the window is found.
+  sd_cap_fixture 8 8
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 10
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 20" ]
+}
+
+@test "sd_window gives up with status 3 once the parse-attempt cap is reached" {
+  # Identical shape, only bigger: 21 * 21 + 1 = 442 attempts, so the winning
+  # pair sits past SD_MAX_PARSE_ATTEMPTS=400 and is never reached. The cap —
+  # not exhaustion — is what ends this search, and it reports the same
+  # status 3 the exhaustion path already uses, so it needs no new handling in
+  # sd_extract or sd_check_seed.
+  sd_cap_fixture 20 20
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 22
+  [ "$status" -eq 3 ]
+}
+
 @test "sd_window returns a single paragraph unchanged when it already parses" {
   printf 'echo one\n\necho ANCHOR\n\necho three\n' >"$FIX/f.sh"
   make_scan "$FIX/f.sh"
@@ -1934,4 +1999,75 @@ PYEOF
   [[ "$output" != *"window is only"* ]]
 
   t7_assert_repo_tool_untouched
+}
+
+# ── Window-growth regressions, end to end (final review I-1) ─────────────────
+
+@test "a block needing backward growth is not merged with the paragraphs after it" {
+  # The final review's reproduction. Template and seed are identical inside the
+  # anchor's own `if` block and differ only in a trailing paragraph that has
+  # nothing to do with it. The old forward-to-EOF-then-backward walk left the
+  # window end pinned at EOF, so UNRELATED was extracted as part of the block
+  # and reported as a DIVERGED verdict under the wrong block's name. The
+  # correct window stops at `fi`, so this is `ok` at exit 0.
+  t7_setup
+  t7_doc "anchor block" ANCHOR_VAR
+  printf '#!/usr/bin/env bash\n\nif [ -n "$x" ]; then\n\n  # pad\n  # pad\n  ANCHOR_VAR=1\nfi\n\nUNRELATED=2\n' \
+    >"$TPL"
+  printf '#!/usr/bin/env bash\n\nif [ -n "$x" ]; then\n\n  # pad\n  # pad\n  ANCHOR_VAR=1\nfi\n\nUNRELATED=999\n' \
+    >"$SEED"
+
+  t7_run
+  [ "$status" -eq 0 ]
+  [[ "$output" != *DIVERGED* ]]
+  [[ "$output" != *UNRELATED* ]]
+  [[ "$output" != *"window is only"* ]]
+}
+
+@test "a block needing growth in both directions gets the verdict of that block alone" {
+  # The anchor sits mid-function with blank lines on both sides, so the window
+  # must reach back to `setup() {` and forward to its closing `}`. The seed is
+  # missing one line from inside the function and also differs in a trailing
+  # paragraph outside it. The correct verdict is BEHIND by exactly that one
+  # line; a window that ran to EOF would pull UNRELATED in on both sides and
+  # report DIVERGED instead.
+  t7_setup
+  t7_doc "anchor block" ANCHOR_VAR
+  printf '#!/usr/bin/env bash\n\nsetup() {\n  local a=1\n\n  if [ -n "$x" ]; then\n    ANCHOR_VAR=1\n\n    echo more\n  fi\n}\n\nUNRELATED=2\n' \
+    >"$TPL"
+  printf '#!/usr/bin/env bash\n\nsetup() {\n  local a=1\n\n  if [ -n "$x" ]; then\n    ANCHOR_VAR=1\n\n  fi\n}\n\nUNRELATED=999\n' \
+    >"$SEED"
+
+  t7_run
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"BEHIND"* ]]
+  [[ "$output" == *"1 template lines absent from seed"* ]]
+  [[ "$output" != *DIVERGED* ]]
+  [[ "$output" != *UNRELATED* ]]
+  [[ "$output" != *"window is only"* ]]
+}
+
+@test "a seed block whose search exceeds the parse-attempt cap is an ERROR at exit 2, never 3" {
+  # sd_window's new cap returns 3, the same status its exhaustion path already
+  # returned. 3 is internal: the public contract is 0/1/2 only. This pins that
+  # sd_extract -> sd_check_seed still converts it, on the error path I-1
+  # changed rather than on the one that existed before.
+  t7_setup
+  t7_doc "anchor block" ANCHOR
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'ANCHOR=1\n'
+  } >"$TPL"
+  {
+    printf 'if true; then\n\n'
+    for n in $(seq 20); do printf '  echo p%s\n\n' "$n"; done
+    printf '  ANCHOR=1\nfi\n\n'
+    for n in $(seq 20); do printf '  echo q%s\n\n' "$n"; done
+  } >"$SEED"
+
+  t7_run
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"seed block could not be extracted"* ]]
+  [[ "$output" != *MISSING* ]]
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -195,3 +195,35 @@ FIX
   [ "$status" -eq 0 ]
   [ "$output" = "204 236" ]
 }
+
+@test "sd_scan excludes herestrings and recognizes every delimiter form" {
+  local f="$TEST_ROOT/forms.sh"
+  printf '%s\n' \
+    'grep q <<<"$v"' \
+    'cat <<A' \
+    'u1' \
+    'A' \
+    "cat <<'B'" \
+    'q1' \
+    'B' \
+    'cat <<"C"' \
+    'q2' \
+    'C' \
+    'cat <<\D' \
+    'q3' \
+    'D' \
+    'cat <<-E' \
+    $'\tu2' \
+    $'\tE' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\tgrep q <<<"$v"')" ]
+  [ "${lines[2]}" = "$(printf '1\t3\tHu\tu1')" ]
+  [ "${lines[5]}" = "$(printf '1\t6\tHq\tq1')" ]
+  [ "${lines[8]}" = "$(printf '1\t9\tHq\tq2')" ]
+  [ "${lines[11]}" = "$(printf '1\t12\tHq\tq3')" ]
+  [ "${lines[14]}" = "$(printf '1\t15\tHu\t\tu2')" ]
+  [ "${lines[15]}" = "$(printf '1\t16\tC\t\tE')" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -294,3 +294,42 @@ make_scan() {
   run bash -n "$FIX/split.sh"
   [ "$status" -eq 0 ]
 }
+
+@test "sd_window grows forward past a blank line between an if condition and its body" {
+  printf 'if [ -n "$ANCHOR" ]; then\n\n  echo hi\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 4" ]
+}
+
+@test "sd_window grows backward when the anchor is in the body and the header is above" {
+  printf 'if [ -n "$x" ]; then\n\n  echo ANCHOR\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 4" ]
+}
+
+@test "sd_window returns a single paragraph unchanged when it already parses" {
+  printf 'echo one\n\necho ANCHOR\n\necho three\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 0 ]
+  [ "$output" = "3 3" ]
+}
+
+@test "sd_window exits 3 when neither direction ever parses" {
+  printf 'echo ok\n\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 2
+  [ "$status" -eq 3 ]
+}
+
+@test "sd_window reads the raw fragment from the file, not the comment-stripped scan" {
+  printf 'if [ -n "$x" ]; then # start\n\n  echo hi\nfi\n' >"$FIX/f.sh"
+  make_scan "$FIX/f.sh"
+  sd_source sd_window "$FIX/f.sh" "$FIX/f.sh.scan" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "1 4" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -2137,3 +2137,28 @@ PYEOF
   [[ "$output" != *"ok  "* ]]
   [[ "$output" != *"window is only"* ]]
 }
+
+@test "a seed whose doc table yields no blocks is an ERROR at exit 2, never clean" {
+  # The block loop reads through a process substitution, whose failure is
+  # invisible to both `set -e` and pipefail: with no rows the body never runs,
+  # rc stays 0, and the seed reports clean having compared nothing. sd_main's
+  # own parse check makes that unreachable through the CLI, so this calls
+  # sd_check_seed directly with an sd_parse_doc that succeeds and emits
+  # nothing — the shape the guard exists to catch.
+  setup_drift_fixtures
+  seed_from_template clean
+
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    SD_TEMPLATE="$2"
+    SD_DOC="$3"
+    sd_tmp SD_TEMPLATE_SCAN
+    sd_scan "$SD_TEMPLATE" >"$SD_TEMPLATE_SCAN"
+    sd_parse_doc() { return 0; }
+    sd_check_seed "$4"
+  ' _ "$SEED_DRIFT" "$FIXTURE_TEMPLATE" "$FIXTURE_DOC" "$(seed_path clean)"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no blocks read from the doc table"* ]]
+  [[ "$output" != *"ok  "* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -85,3 +85,21 @@ DOC
   [[ "$output" == *"TREE_SITTER_VERSION"* ]]
   [[ "$output" == *"lname '*dotfiles/projects/*'"* ]]
 }
+
+@test "every anchor in the real doc table is present in the real template" {
+  run "$SEED_DRIFT" --template "$REAL_TEMPLATE" --doc "$REAL_DOC"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "a doc anchor the template lacks is a hard error" {
+  local doc="$TEST_ROOT/doc.md" template="$TEST_ROOT/tpl.sh"
+  write_fixture_doc "$doc"
+  printf '#!/usr/bin/env bash\ntrue\n' >"$template"
+
+  run "$SEED_DRIFT" --template "$template" --doc "$doc"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"is absent from"* ]]
+  [[ "$output" == *"core.excludesFile"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -787,3 +787,27 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   after=$(cksum <"$(seed_path clean)")
   [ "$before" = "$after" ]
 }
+
+@test "sd_check_seed can be called directly without sd_main having run" {
+  setup_drift_fixtures
+  seed_from_template clean
+
+  # Mirrors the review's exact repro: source the script (never call sd_main,
+  # so SD_TEMPLATE_SCAN is never built by anything), then set only SD_TEMPLATE
+  # and SD_DOC before calling sd_check_seed directly. A bare `source` must
+  # leave every global sd_check_seed touches in a defined, empty state under
+  # `set -u` — if SD_TEMPLATE_SCAN is left undeclared, this dies with
+  # "unbound variable" (exit 1) before it ever reaches the anchor check,
+  # which misreports a shell crash as "drift" under the public 0/1/2
+  # contract. With SD_TEMPLATE_SCAN declared empty, an unscanned template
+  # correctly reports an extraction ERROR (exit 2) instead of crashing.
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    SD_TEMPLATE="$2"
+    SD_DOC="$3"
+    sd_check_seed "$4"
+  ' _ "$SEED_DRIFT" "$FIXTURE_TEMPLATE" "$FIXTURE_DOC" "$(seed_path clean)"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" != *"unbound variable"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -625,7 +625,10 @@ setup_drift_fixtures() {
 
 make_project() { mkdir -p "$SEED_DRIFT_ROOT/$1/.devcontainer"; }
 seed_path() { printf '%s\n' "$SEED_DRIFT_ROOT/$1/.devcontainer/local-seed.sh"; }
-seed_from_template() { make_project "$1"; write_drift_template "$(seed_path "$1")"; }
+seed_from_template() {
+  make_project "$1"
+  write_drift_template "$(seed_path "$1")"
+}
 sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DOC" "$@"; }
 
 @test "a clean seed exits 0 and is counted as checked" {

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -1697,3 +1697,117 @@ SEEDEOF
   after="$(find "$WS" -type f -exec sha256sum {} + | sort)"
   [ "$before" = "$after" ]
 }
+
+# ── Task 8 fixture helpers ───────────────────────────────────────────────────
+#
+# A comment-only line strips to empty text in sd_scan and contributes nothing
+# to sd_normalize's output, but it is still a non-blank physical line and so
+# still counts toward sd_window's raw (pre-normalization) line count. That
+# lets these fixtures pad one side's window past the thin-window threshold
+# without changing what actually gets compared: `# pad 1` through `# pad 4`
+# below add four lines to the raw window and zero lines to the normalized
+# diff, while `ANCHOR_VAR=1` (and `FOO=2`, where present) are the only lines
+# that ever reach the diff.
+
+t8_pad() {
+  printf '# pad 1\n# pad 2\n# pad 3\n# pad 4\n'
+}
+
+@test "a thin SEED window emits the note, names the seed side, and stays exit 0 when ok" {
+  t7_setup
+  t7_doc "anchor block" ANCHOR_VAR
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'ANCHOR_VAR=1\n'
+  } >"$TPL"
+  printf '#!/usr/bin/env bash\n\nANCHOR_VAR=1\n' >"$SEED"
+
+  t7_run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"seed window is only 1 lines"* ]]
+  [[ "$output" != *"template window is only"* ]]
+  [[ "$output" == *"  ok"*"anchor block"* ]]
+}
+
+@test "a thin TEMPLATE window emits the note and names the template side" {
+  t7_setup
+  t7_doc "anchor block" ANCHOR_VAR
+  printf '#!/usr/bin/env bash\n\nANCHOR_VAR=1\n' >"$TPL"
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'ANCHOR_VAR=1\n'
+  } >"$SEED"
+
+  t7_run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"template window is only 1 lines"* ]]
+  [[ "$output" != *"seed window is only"* ]]
+}
+
+@test "a normal-sized window on both sides emits no thin-window note" {
+  t7_setup
+  t7_doc "anchor block" ANCHOR_VAR
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'ANCHOR_VAR=1\n'
+  } >"$TPL"
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'ANCHOR_VAR=1\n'
+  } >"$SEED"
+
+  t7_run
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"window is only"* ]]
+  [[ "$output" == *"  ok"*"anchor block"* ]]
+}
+
+@test "a thin AND drifted block reports both the real verdict and the note" {
+  t7_setup
+  t7_doc "anchor block" ANCHOR_VAR
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'ANCHOR_VAR=1\nFOO=2\n'
+  } >"$TPL"
+  printf '#!/usr/bin/env bash\n\nANCHOR_VAR=1\n' >"$SEED"
+
+  t7_run
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+  [[ "$output" == *"seed window is only 1 lines"* ]]
+}
+
+@test "sabotage: raising SD_THIN_WINDOW past the seed's window size hides the note" {
+  # Pins the load-bearing test above to the actual threshold constant, not to
+  # a hardcoded string it happens to match. Backed up to /tmp first per the
+  # brief: `git checkout --` restores to HEAD, not to a moment ago, and would
+  # silently destroy any uncommitted work in this file.
+  local backup="/tmp/seed-drift.t8-sabotage.bak.$$"
+  cp "$REPO_ROOT/bin/seed-drift" "$backup"
+
+  t7_setup
+  t7_doc "anchor block" ANCHOR_VAR
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'ANCHOR_VAR=1\n'
+  } >"$TPL"
+  printf '#!/usr/bin/env bash\n\nANCHOR_VAR=1\n' >"$SEED"
+
+  sed -i.orig 's/^SD_THIN_WINDOW=5$/SD_THIN_WINDOW=1/' "$REPO_ROOT/bin/seed-drift"
+  t7_run
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"window is only"* ]]
+
+  cp "$backup" "$REPO_ROOT/bin/seed-drift"
+  rm -f "$backup" "$REPO_ROOT/bin/seed-drift.orig"
+
+  t7_run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"seed window is only 1 lines"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -87,7 +87,7 @@ DOC
 }
 
 @test "every anchor in the real doc table is present in the real template" {
-  # Discovery finding zero projects is now a hard error (fix round 2, I-2);
+  # Discovery finding zero projects is now a hard error (fix round 2, I-3);
   # give it one skip-only candidate so this test still exercises only what
   # it is meant to check: real-doc/real-template anchor agreement, exit 0.
   export SEED_DRIFT_ROOT="$TEST_ROOT/workspace"
@@ -108,6 +108,18 @@ DOC
   [ "$status" -eq 2 ]
   [[ "$output" == *"is absent from"* ]]
   [[ "$output" == *"core.excludesFile"* ]]
+  [[ "$output" == *"lname '*dotfiles/projects/*'"* ]]
+}
+
+@test "a doc with no parseable block table is a hard error" {
+  local doc="$TEST_ROOT/doc.md" template="$TEST_ROOT/tpl.sh"
+  printf 'Just some prose, no table here.\n' >"$doc"
+  printf '#!/usr/bin/env bash\ntrue\n' >"$template"
+
+  run "$SEED_DRIFT" --template "$template" --doc "$doc"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no block table found in $doc"* ]]
 }
 
 @test "sd_scan numbers every line and starts a new paragraph after a blank line" {
@@ -450,7 +462,14 @@ $HOME/literal' ]
   [ "$output" = '  «HOME»/x   # not a comment' ]
 }
 
-@test "sd_normalize drops the four exact ownership-verification lines" {
+# Fix round 3 (Task 7, group 2): the ownership drop moved out of per-file
+# normalization into sd_apply_ownership_rule at the comparison stage, because
+# the rule is inherently cross-file ("does the OTHER side still show a chown
+# difference?") and per-file dropping hid a changed target/flag/identity as
+# AHEAD instead of DIVERGED. sd_normalize on its own must now pass these
+# lines through unchanged; see the sd_apply_ownership_rule unit test below
+# for the actual dropping behavior.
+@test "sd_normalize no longer drops the ownership-verification lines itself" {
   scan_line 1 1 C '      { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
   scan_line 1 2 C '        [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&'
   scan_line 1 3 C '      { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||'
@@ -458,7 +477,40 @@ $HOME/literal' ]
   scan_line 1 5 C 'echo after'
   norm
   [ "$status" -eq 0 ]
-  [ "$output" = "echo after" ]
+  [ "$output" = '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+[ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+{ chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||
+[ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+echo after' ]
+}
+
+# sd_apply_ownership_rule BEHIND_FILE AHEAD_FILE: drops the exact idiom lines
+# from BEHIND_FILE only when AHEAD_FILE has no chown/chgrp line of its own —
+# the root-flavored-seed-omits-it-entirely case the rule exists for.
+@test "sd_apply_ownership_rule drops the idiom from behind when ahead is silent about ownership" {
+  local behind="$FIX/behind" ahead="$FIX/ahead"
+  printf '%s\n%s\n' \
+    '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||' \
+    '[ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&' \
+    >"$behind"
+  : >"$ahead"
+  sd_source sd_apply_ownership_rule "$behind" "$ahead"
+  [ "$status" -eq 0 ]
+  [ ! -s "$behind" ]
+}
+
+# The counterpart: any chown/chgrp line on the ahead side blocks the drop, so
+# a changed target/flag/identity keeps the idiom's original lines in behind
+# and the block reports DIVERGED rather than AHEAD.
+@test "sd_apply_ownership_rule keeps behind untouched when ahead mentions chown" {
+  local behind="$FIX/behind" ahead="$FIX/ahead"
+  printf '%s\n' \
+    '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||' \
+    >"$behind"
+  printf '%s\n' 'chown -R "0:0" "$NVIM_DIST.new"' >"$ahead"
+  sd_source sd_apply_ownership_rule "$behind" "$ahead"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$behind")" = '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||' ]
 }
 
 @test "the ownership rule is exact: target, -R, identity, and unrelated chown all survive" {
@@ -783,15 +835,40 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
 }
 
 @test "the detector never writes to a seed" {
+  # A hypothetical auto-fixer has nothing to write against a zero-drift seed,
+  # so that fixture cannot tell a read-only tool from a broken one. Checksum a
+  # DRIFTED seed instead, across a run that exits 1 — plus the template and
+  # doc, since either could tempt a "helpfully" self-updating implementation —
+  # and require both content and mtime to be untouched. Seeds are gitignored
+  # and hand-owned with no revert path, so this is the guarantee that matters.
   setup_drift_fixtures
-  seed_from_template clean
-  local before after
-  before=$(cksum <"$(seed_path clean)")
+  seed_from_template behindp
+  sed -i '/tree-sitter ready/d' "$(seed_path behindp)"
+  local seed_before seed_after doc_before doc_after tpl_before tpl_after
+  local seed_mtime_before seed_mtime_after doc_mtime_before doc_mtime_after
+  local tpl_mtime_before tpl_mtime_after
+  seed_before=$(sha256sum <"$(seed_path behindp)")
+  tpl_before=$(sha256sum <"$FIXTURE_TEMPLATE")
+  doc_before=$(sha256sum <"$FIXTURE_DOC")
+  seed_mtime_before=$(stat -c %Y "$(seed_path behindp)")
+  tpl_mtime_before=$(stat -c %Y "$FIXTURE_TEMPLATE")
+  doc_mtime_before=$(stat -c %Y "$FIXTURE_DOC")
 
   sd_drift
 
-  after=$(cksum <"$(seed_path clean)")
-  [ "$before" = "$after" ]
+  [ "$status" -eq 1 ]
+  seed_after=$(sha256sum <"$(seed_path behindp)")
+  tpl_after=$(sha256sum <"$FIXTURE_TEMPLATE")
+  doc_after=$(sha256sum <"$FIXTURE_DOC")
+  seed_mtime_after=$(stat -c %Y "$(seed_path behindp)")
+  tpl_mtime_after=$(stat -c %Y "$FIXTURE_TEMPLATE")
+  doc_mtime_after=$(stat -c %Y "$FIXTURE_DOC")
+  [ "$seed_before" = "$seed_after" ]
+  [ "$tpl_before" = "$tpl_after" ]
+  [ "$doc_before" = "$doc_after" ]
+  [ "$seed_mtime_before" = "$seed_mtime_after" ]
+  [ "$tpl_mtime_before" = "$tpl_mtime_after" ]
+  [ "$doc_mtime_before" = "$doc_mtime_after" ]
 }
 
 @test "sd_check_seed can be called directly without sd_main having run" {
@@ -839,10 +916,859 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   [[ "$output" == *"0 checked, 0 skipped, 0 blocks drifted"* ]]
 }
 
-@test "an explicit-candidate run with an equally empty result still exits 0" {
-  setup_drift_fixtures
+# ── Task 7 fixture helpers ───────────────────────────────────────────────────
 
-  sd_drift "$SEED_DRIFT_ROOT/absent-project"
+t7_setup() {
+  TPL="$BATS_TEST_TMPDIR/template.sh"
+  DOC="$BATS_TEST_TMPDIR/catch-up.md"
+  WS="$TEST_ROOT/ws"
+  PROJ="$WS/demo"
+  SEED="$PROJ/.devcontainer/local-seed.sh"
+  mkdir -p "$PROJ/.devcontainer"
+  export SEED_DRIFT_ROOT="$WS"
+}
 
+# t7_doc "Block name" anchor [ "Block name" anchor ... ]
+t7_doc() {
+  {
+    printf '| Block | Anchor in template | Why it matters |\n'
+    printf '|---|---|---|\n'
+    while [ "$#" -gt 0 ]; do
+      printf '| %s | `%s` | fixture row |\n' "$1" "$2"
+      shift 2
+    done
+  } >"$DOC"
+}
+
+t7_run() {
+  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC" "$@"
+}
+
+@test "a tab inside a heredoc payload survives extraction verbatim" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  # No blank line between the heredoc closer and the git-config line: that gap
+  # is load-bearing (team-lead ruling, fix round 3). With it present, the
+  # anchor's own paragraph (just the git-config line) already parses standalone
+  # via `bash -n`, so sd_window never grows to include the heredoc paragraph
+  # and the payload — the very thing this test is named for — is never
+  # extracted at all. This mirrors the real template, where the closing `fi`
+  # of the `if ! as_user test -f "$GITIGNORE"` guard and the trailing
+  # `as_user git config --global core.excludesFile "$GITIGNORE"` sit in one
+  # paragraph with no blank line, so don't "tidy" this back in.
+  printf '#!/usr/bin/env bash\n\ntee "$G" <<%s\n\tcol1\tcol2\nGITEOF\ngit config --global core.excludesFile "$G"\n' "'GITEOF'" >"$TPL"
+  # Seed differs ONLY by collapsing the payload tabs to spaces.
+  printf '#!/usr/bin/env bash\n\ntee "$G" <<%s\n  col1  col2\nGITEOF\ngit config --global core.excludesFile "$G"\n' "'GITEOF'" >"$SEED"
+
+  t7_run
+  # If the reader strips or truncates tabs, both sides normalize alike and this
+  # reports ok — the exact false-clean the tool exists to prevent.
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "sd_count_lines counts blank records" {
+  printf '\n\na\n' >"$BATS_TEST_TMPDIR/three"
+  sd_source sd_count_lines "$BATS_TEST_TMPDIR/three"
   [ "$status" -eq 0 ]
+  [ "$output" = 3 ]
+}
+
+@test "a temp file from sd_tmp is still writable after the call returns" {
+  # `raw="$(sd_tmp)"` ran the whole thing in a subshell: the directory and its
+  # EXIT trap were created there, so the trap fired the moment the substitution
+  # closed and deleted the directory before the caller could write to the path
+  # it had just been handed. Every diff in the tool wrote into thin air.
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    sd_tmp f || exit 9
+    printf hello >"$f" || exit 8
+    cat "$f"
+  ' _ "$SEED_DRIFT"
+  [ "$status" -eq 0 ]
+  [ "$output" = hello ]
+}
+
+@test "a seed block that cannot be extracted is ERROR and exit 2, not MISSING" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  printf '#!/usr/bin/env bash\n\ninstall_ts "$TREE_SITTER_VERSION"\n' >"$TPL"
+  # Anchor present, but no window around it ever parses: the `do` is never
+  # closed anywhere in the file, so sd_window exhausts both directions.
+  printf '#!/usr/bin/env bash\n\nfor x in a b; do\n  install_ts "$TREE_SITTER_VERSION"\n' >"$SEED"
+
+  t7_run
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  # The bug this pins: `if ! sd_extract` collapsed 3 and 4, reporting a seed
+  # that will not parse as merely behind the template.
+  [[ "$output" != *MISSING* ]]
+}
+
+@test "sd_extract returns 3, not 4, when no window around the anchor parses" {
+  # The integration test above stops at sd_check_seed's whole-file `bash -n`
+  # gate and never reaches sd_extract, so it cannot tell 3 from 4 at the
+  # helper level. This does, by calling sd_extract directly. Since sd_window
+  # grows to the whole file before giving up, only a file that itself fails to
+  # parse can produce status 3 — hence the same unclosed `do`.
+  printf '#!/usr/bin/env bash\n\nfor x in a b; do\n  install_ts "$TREE_SITTER_VERSION"\n' \
+    >"$FIX/bad.sh"
+  sd_source sd_scan "$FIX/bad.sh"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" >"$FIX/bad.scan"
+
+  sd_source sd_extract "$FIX/bad.sh" "$FIX/bad.scan" TREE_SITTER_VERSION
+  [ "$status" -eq 3 ]
+
+  # And 4 really is reserved for the absent anchor, on the same inputs.
+  sd_source sd_extract "$FIX/bad.sh" "$FIX/bad.scan" NVIM_VERSION
+  [ "$status" -eq 4 ]
+}
+
+@test "privilege normalization is portable and keyword-boundary correct" {
+  # `\b` is a GNU sed extension; BSD sed (macOS, which this script supports)
+  # silently fails to match it, so every `if as_user ...` line would keep its
+  # privilege word and report as drift on a Mac and clean on Linux.
+  run grep -n '\\b' "$SEED_DRIFT"
+  [ "$status" -ne 0 ]
+
+  scan_line 1 1 C 'if as_user test -x /x; then'
+  scan_line 1 2 C 'foo || $SUDO chmod 0755 /x'
+  scan_line 1 3 C 'do runuser -u me -- npm i'
+  # The boundary the `\b` used to provide: a word merely ENDING in a keyword
+  # must not license the drop.
+  scan_line 1 4 C 'notif as_user keepme'
+  norm
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = 'if test -x /x; then' ]
+  [ "${lines[1]}" = 'foo || chmod 0755 /x' ]
+  [ "${lines[2]}" = 'do npm i' ]
+  [ "${lines[3]}" = 'notif as_user keepme' ]
+}
+
+@test "an anchor present only in a template comment fails validation" {
+  t7_setup
+  t7_doc "codex guard" local/bin/codex
+  printf '#!/usr/bin/env bash\n\n# once guarded local/bin/codex, now removed\necho hi\n' >"$TPL"
+  printf '#!/usr/bin/env bash\n\necho hi\n' >"$SEED"
+
+  t7_run
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"is absent from"* ]]
+}
+
+@test "anchor present but surrounding block outdated reports BEHIND with exit 1" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+  if curl -fsSL -o "$TS_TMP/tree-sitter.gz" "$TS_URL" &&
+    gunzip -c "$TS_TMP/tree-sitter.gz" >"$TS_TMP/tree-sitter" &&
+    chmod 0755 "$TS_BIN.new" &&
+    as_user "$TS_BIN.new" --version >/dev/null 2>&1 &&
+    as_user mv "$TS_BIN.new" "$TS_BIN"; then
+    echo "seed: tree-sitter ready"
+  elif [ -f "$TS_BIN.new" ] && ! TS_ERR="$(as_user "$TS_BIN.new" --version 2>&1 >/dev/null)"; then
+    echo "seed: tree-sitter binary unusable: $TS_ERR" >&2
+  elif sh -c 'command -v tree-sitter >/dev/null 2>&1'; then
+    echo "seed: tree-sitter already present (image-provided)"
+  else
+    echo "seed: tree-sitter install failed" >&2
+  fi
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+  if curl -fsSL -o "$TS_TMP/tree-sitter.gz" "$TS_URL" &&
+    gunzip -c "$TS_TMP/tree-sitter.gz" >"$TS_TMP/tree-sitter" &&
+    chmod 0755 "$TS_BIN.new" &&
+    as_user "$TS_BIN.new" --version >/dev/null 2>&1 &&
+    as_user mv "$TS_BIN.new" "$TS_BIN"; then
+    echo "seed: tree-sitter ready"
+  else
+    echo "seed: tree-sitter install failed" >&2
+  fi
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+  [[ "$output" == *"tree-sitter CLI"* ]]
+  [[ "$output" != *MISSING* ]]
+}
+
+@test "change confined to non-anchor lines of the block is reported" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITIGNORE="$SEED_HOME/.gitignore"
+if ! as_user test -f "$GITIGNORE"; then
+  as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*~
+*.swp
+
+# Personal Claude Code overlay shims (symlinked in from ~/.dotfiles/projects/).
+CLAUDE.local.md
+AGENTS.local.md
+
+# Personal docker-compose overrides.
+docker-compose.override.yml
+GITEOF
+  echo "seed: wrote container-local ~/.gitignore"
+fi
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITIGNORE="$SEED_HOME/.gitignore"
+if ! as_user test -f "$GITIGNORE"; then
+  as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*~
+
+# Personal Claude Code overlay shims (symlinked in from ~/.dotfiles/projects/).
+CLAUDE.local.md
+AGENTS.local.md
+
+# Personal docker-compose overrides.
+docker-compose.override.yml
+GITEOF
+  echo "seed: wrote container-local ~/.gitignore"
+fi
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+  [[ "$output" == *core.excludesFile* ]]
+}
+
+@test "changed # line inside a quoted heredoc body is drift, not stripped as a comment" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+# Personal Claude Code overlay shims (symlinked in from ~/.dotfiles/projects/).
+CLAUDE.local.md
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+# Personal overlay shims.
+CLAUDE.local.md
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "changed leading whitespace inside a heredoc body is drift" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+    *.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "removed blank line inside a heredoc body is drift" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+
+*.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+.DS_Store
+*.swp
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *BEHIND* ]]
+}
+
+@test "trailing backslash inside a heredoc body is not a line continuation" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+literal-backslash \
+second-payload-line
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
+literal-backslash second-payload-line
+GITEOF
+as_user git config --global core.excludesFile "$GITIGNORE"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "unquoted heredoc delimiter gets path neutralization" {
+  t7_setup
+  t7_doc "unquoted body" HEREDOC_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=unquoted
+tee "$OUT" >/dev/null <<UNQ
+$SEED_HOME/.local/bin
+UNQ
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=unquoted
+tee "$OUT" >/dev/null <<UNQ
+$HOME/.local/bin
+UNQ
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "quoted heredoc delimiter does not get path neutralization" {
+  t7_setup
+  t7_doc "quoted body" HEREDOC_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=quoted
+tee "$OUT" >/dev/null <<'QUO'
+$SEED_HOME/.local/bin
+QUO
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+HEREDOC_ANCHOR=quoted
+tee "$OUT" >/dev/null <<'QUO'
+$HOME/.local/bin
+QUO
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "<< inside a double-quoted string is not a heredoc opener" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+GI_MARK_BEGIN="# >>> overlay symlinks (auto, do not edit) >>>"
+GI_MARK_END="# << overlay symlinks (auto) <<"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # The anchor is kept verbatim so this test exercises only the heredoc-opener
+  # question (does the literal `<<` inside GI_MARK_END's double-quoted string
+  # get mistaken for a heredoc start, corrupting the scan?). The drift lives
+  # in the unrelated echo line instead — a seed whose anchor genuinely drifted
+  # to the old-narrow glob is a different, documented case; see the dedicated
+  # "old-narrow overlay glob" test below.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+GI_MARK_BEGIN="# >>> overlay symlinks (auto, do not edit) >>>"
+GI_MARK_END="# << overlay symlinks (auto) <<"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links" >&2
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Overlay-link gitignore"* ]]
+  [[ "$output" != *MISSING* ]]
+}
+
+# The doc's own prose for this row (catch-up-local-seed.md:77) says: "If the
+# seed has the old narrow '*/.dotfiles/projects/*', it must be widened." The
+# anchor is deliberately the WIDENED (desired) glob, so a seed still on the
+# old-narrow form genuinely lacks that literal substring — MISSING is the
+# correct, honest, actionable verdict here (not a defect): exit 1, block
+# named, and the action points at the doc's own remedy step. Anchor text must
+# be chosen from the stable part of a block; if the anchor string itself is
+# what's drifting, the verdict is MISSING rather than DIVERGED.
+@test "a seed on the documented old-narrow overlay glob is reported MISSING, not ok" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*/.dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *MISSING* ]]
+  [[ "$output" == *"Overlay-link gitignore"* ]]
+  [[ "$output" == *"Step 2"* ]]
+}
+
+@test "<<< herestrings are not heredoc openers" {
+  t7_setup
+  t7_doc "herestring block" HERESTRING_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+HERESTRING_ANCHOR=1
+read -r first_word <<<"$SEED_HOME/.local/bin"
+echo "template says $first_word"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+HERESTRING_ANCHOR=1
+read -r first_word <<<"$SEED_HOME/.local/bin"
+echo "seed says $first_word"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+  [[ "$output" != *MISSING* ]]
+}
+
+@test "each heredoc delimiter form is recognized and tracks its body" {
+  t7_setup
+  t7_doc "form block" FORM_ANCHOR
+  local open
+  for open in "<<TAG" "<<'TAG'" '<<"TAG"' '<<\TAG' "<<-TAG"; do
+    {
+      printf '#!/usr/bin/env bash\n\n'
+      printf 'FORM_ANCHOR=1\n'
+      printf 'tee "$OUT" >/dev/null %s\n' "$open"
+      printf 'payload-one\n\npayload-two\nTAG\n'
+    } >"$TPL"
+    {
+      printf '#!/usr/bin/env bash\n\n'
+      printf 'FORM_ANCHOR=1\n'
+      printf 'tee "$OUT" >/dev/null %s\n' "$open"
+      printf 'payload-one\n\npayload-CHANGED\nTAG\n'
+    } >"$SEED"
+    t7_run "$SEED"
+    [ "$status" -eq 1 ] || {
+      echo "form $open: expected drift, got status $status: $output" >&2
+      return 1
+    }
+    [[ "$output" == *DIVERGED* ]] || {
+      echo "form $open: expected DIVERGED, got: $output" >&2
+      return 1
+    }
+  done
+}
+
+@test "unrecognized heredoc syntax is an error, not a silent fallback" {
+  t7_setup
+  t7_doc "form block" FORM_ANCHOR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+FORM_ANCHOR=1
+TAG=EOFWORD
+cat <<$TAG
+payload
+EOFWORD
+TPLEOF
+  cp "$TPL" "$SEED"
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" != *ok* ]]
+}
+
+t7_own_tpl() {
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+TPLEOF
+}
+
+@test "ownership idiom with a changed target is drift, not dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_CACHE.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_CACHE.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "ownership idiom with -R removed is drift, not dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "ownership idiom with a changed identity is drift, not dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "0:0" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "an unrelated chown line is compared normally" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+  chown -R "$SEED_UID:$SEED_GID" "$SEED_HOME/.cache"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  # This line has nothing to do with the ownership idiom (a different target
+  # entirely, no matching template counterpart), so per Decision 5 (design
+  # doc :521-522, "extra seed lines -> AHEAD") it is a promotion candidate,
+  # not a divergence — the ownership rule (group-2 fix) only changes the
+  # verdict for lines that DO match the idiom's shape on one side. The
+  # positive assertion below is the test's actual subject: the line must be
+  # compared (shown as extra), not silently absorbed by the ownership drop.
+  [[ "$output" == *AHEAD* ]]
+  [[ "$output" == *'chown -R "$SEED_UID:$SEED_GID" "«HOME»/.cache"'* ]]
+  [[ "$output" != *"overwrite the seed with"* ]]
+}
+
+@test "false-positive guard: as_user prefix vs direct invocation" {
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+as_user git config --global core.hooksPath "$DOTFILES_HOME/git/hooks"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$DOTFILES_HOME/git/hooks"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: SEED_HOME vs HOME" {
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$SEED_HOME/.dotfiles/git/hooks"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: DOTFILES_HOME vs HOME/.dotfiles" {
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$DOTFILES_HOME/git/hooks"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: restyled line continuations" {
+  t7_setup
+  t7_doc "codex guard" local/bin/codex
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then
+  as_user npm install -g \
+    --prefix "$SEED_HOME/.local" \
+    @openai/codex
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then
+  as_user npm install -g --prefix "$SEED_HOME/.local" @openai/codex
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: reworded comments" {
+  t7_setup
+  t7_doc "codex guard" local/bin/codex
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+# Guard the reinstall on the binary, not ~/.codex/config.toml: the installer
+# writes config even when it fails to produce a binary.
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then # binary, not config
+  as_user npm install -g @openai/codex
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+# Check for the codex binary itself; a config-based guard latches shut.
+if [ ! -x "$SEED_HOME/.local/bin/codex" ]; then # check the binary
+  as_user npm install -g @openai/codex
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: both exact ownership idiom forms are dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST "tree-sitter CLI" TS_BIN
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+
+TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+if [ -f "$TS_BIN.new" ]; then
+  { chown "$SEED_UID:$SEED_GID" "$TS_BIN.new" 2>/dev/null ||
+    [ -z "$(find "$TS_BIN.new" \( ! -uid "$SEED_UID" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+
+TS_BIN="$SEED_HOME/.local/bin/tree-sitter"
+if [ -f "$TS_BIN.new" ]; then
+  as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *BEHIND* ]]
+  [[ "$output" != *DIVERGED* ]]
+}
+
+@test "sed substitution with # delimiters survives comment stripping" {
+  t7_setup
+  t7_doc "plugin repair" PLUGIN_REPAIR
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+PLUGIN_REPAIR=1
+sed -i 's#/opt/dotfiles#/home/seed/.dotfiles#g' "$f" # rewrite the stable root
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+PLUGIN_REPAIR=1
+sed -i 's#/opt/dotfiles#/home/seed/.dotfiles#g' "$f" # fix up the link root
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+PLUGIN_REPAIR=1
+sed -i 's#/opt/dotfiles#/home/seed/OTHER#g' "$f" # rewrite the stable root
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+}
+
+@test "seeds are byte-identical after a run (read-only)" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+  as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+fi
+SEEDEOF
+  # a drifted seed, a clean seed, and a candidate with no seed at all
+  mkdir -p "$WS/clean/.devcontainer" "$WS/noseed/.devcontainer"
+  cp "$TPL" "$WS/clean/.devcontainer/local-seed.sh"
+
+  local before after
+  before="$(find "$WS" -type f -exec sha256sum {} + | sort)"
+  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC"
+  [ "$status" -eq 1 ]
+  after="$(find "$WS" -type f -exec sha256sum {} + | sort)"
+  [ "$before" = "$after" ]
+}
+
+@test "a malformed seed does not suppress drift reporting for the others" {
+  t7_setup
+  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+  as_user mv "$TS_BIN.new" "$TS_BIN"
+fi
+TPLEOF
+  mkdir -p "$WS/broken/.devcontainer"
+  cat >"$WS/broken/.devcontainer/local-seed.sh" <<'BROKENEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "unterminated"
+BROKENEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ -n "${TREE_SITTER_VERSION:-}" ]; then
+  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
+fi
+SEEDEOF
+  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *broken* ]]
+  [[ "$output" == *demo* ]]
+  [[ "$output" == *BEHIND* ]]
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -132,3 +132,66 @@ FIX
   [ "${lines[1]}" = "$(printf '1\t2\tC\tlinks="$(find . | sed '"'"'s#^\\./##'"'"')" ')" ]
   [ "${lines[2]}" = "$(printf '1\t3\tC\techo "kept # inside quotes"')" ]
 }
+
+@test "sd_scan keeps a quoted heredoc body in one paragraph and tags it Hq" {
+  local f="$TEST_ROOT/hd.sh"
+  cat >"$f" <<'FIX'
+GITIGNORE="$HOME/.gitignore"
+tee "$GITIGNORE" <<'GITEOF'
+.DS_Store
+
+# Personal overlay shims.
+CLAUDE.local.md
+GITEOF
+git config --global core.excludesFile "$GITIGNORE"
+FIX
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[2]}" = "$(printf '1\t3\tHq\t.DS_Store')" ]
+  [ "${lines[3]}" = "$(printf '1\t4\tHq\t')" ]
+  [ "${lines[4]}" = "$(printf '1\t5\tHq\t# Personal overlay shims.')" ]
+  [ "${lines[6]}" = "$(printf '1\t7\tC\tGITEOF')" ]
+  [ "${lines[7]}" = "$(printf '1\t8\tC\tgit config --global core.excludesFile "$GITIGNORE"')" ]
+}
+
+@test "sd_scan does not treat << inside a double-quoted string as a heredoc" {
+  local f="$TEST_ROOT/quoted.sh"
+  cat >"$f" <<'FIX'
+GI_MARK_END="# <<< overlay symlinks (auto) <<<"
+echo done
+
+echo after
+FIX
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\tGI_MARK_END="# <<< overlay symlinks (auto) <<<"')" ]
+  [ "${lines[1]}" = "$(printf '1\t2\tC\techo done')" ]
+  [ "${lines[2]}" = "$(printf '2\t4\tC\techo after')" ]
+}
+
+@test "sd_scan fails closed on unrecognized heredoc syntax" {
+  local f="$TEST_ROOT/bad.sh"
+  printf 'cat << ;\n' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"unrecognized heredoc delimiter"* ]]
+}
+
+@test "sd_scan puts the real template core.excludesFile block in one paragraph" {
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    scan=$(sd_scan "$2")
+    para=$(printf "%s\n" "$scan" | awk -F"\t" "\$3 == \"C\" && index(\$4, \"core.excludesFile\") { print \$1 }")
+    printf "%s\n" "$scan" | awk -F"\t" -v p="$para" "\$1 == p { print \$2 }" |
+      awk "NR == 1 { first = \$0 } { last = \$0 } END { print first, last }"
+  ' _ "$SEED_DRIFT" "$REAL_TEMPLATE"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "204 236" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -883,8 +883,53 @@ t7_doc() {
   } >"$DOC"
 }
 
+# t7_run_tool TOOL [CANDIDATE...] — run an explicit seed-drift executable
+# against the current fixture template and doc. t7_run is the ordinary form,
+# running the repository's own copy; the sabotage probes pass a private copy.
+t7_run_tool() {
+  local tool="$1"
+  shift
+  run "$tool" --template "$TPL" --doc "$DOC" "$@"
+}
+
 t7_run() {
-  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC" "$@"
+  t7_run_tool "$REPO_ROOT/bin/seed-drift" "$@"
+}
+
+# Takes a private copy of bin/seed-drift in the test's own temp dir and sets
+# T7_TOOL to it, along with T7_TOOL_PRISTINE, a byte snapshot of the repository
+# file as it stood before the test ran.
+#
+# Sabotage probes must edit the COPY, never $REPO_ROOT/bin/seed-drift. Editing
+# the repository file in place has three failure modes, all of which this
+# removes at once: bats aborts a test at the first failing assertion, so a
+# failure between sabotage and restore leaves the real tool broken; restoring
+# with `git checkout --` restores to HEAD and so destroys any uncommitted work
+# a developer has in the file under test (this already bit an earlier round of
+# this project); and restoring with `cp` is worse still, because `cp` in this
+# environment is interactive and silently declines. Working on a copy also
+# makes the suite parallel-safe.
+t7_copy_tool() {
+  T7_TOOL="$BATS_TEST_TMPDIR/seed-drift"
+  T7_TOOL_PRISTINE="$BATS_TEST_TMPDIR/seed-drift.pristine"
+  cp "$REPO_ROOT/bin/seed-drift" "$T7_TOOL"
+  cp "$REPO_ROOT/bin/seed-drift" "$T7_TOOL_PRISTINE"
+  # Verify rather than trust: see the `cp` note above. Both copies land on
+  # fresh paths, where cp does not prompt, but the whole point of this helper
+  # is that a silently-skipped copy must not become a green test.
+  cmp -s "$REPO_ROOT/bin/seed-drift" "$T7_TOOL"
+  cmp -s "$REPO_ROOT/bin/seed-drift" "$T7_TOOL_PRISTINE"
+  chmod +x "$T7_TOOL"
+}
+
+# The property the copy-based sabotage buys us, asserted directly: the suite
+# never writes the repository's own bin/seed-drift. Compared against the
+# snapshot taken by t7_copy_tool rather than against HEAD, so the assertion
+# still holds — and still means exactly this — while a developer has
+# uncommitted edits in the file.
+t7_assert_repo_tool_untouched() {
+  cmp -s "$T7_TOOL_PRISTINE" "$REPO_ROOT/bin/seed-drift"
+  [ ! -e "$REPO_ROOT/bin/seed-drift.orig" ]
 }
 
 @test "a tab inside a heredoc payload survives extraction verbatim" {
@@ -1826,15 +1871,10 @@ t8_pad() {
   # quotes, `$` sigils), so the swap goes through python3 doing an exact,
   # asserted-unique literal replacement instead.
   #
-  # bin/seed-drift is committed at 6091300 with no further edits since, so
-  # restoring via `git checkout --` is safe here (unlike the file-under-
-  # construction case the /tmp-backup convention above guards against). Still
-  # take the /tmp backup and diff-verify the restore, per the standing
-  # process note: `cp` in this environment is interactive and silently
-  # declines instead of failing loudly — confirmed again while building this
-  # very test.
-  local backup="/tmp/seed-drift.t8-union-sabotage.bak.$$"
-  cp "$REPO_ROOT/bin/seed-drift" "$backup"
+  # The sabotage lands on a private copy of the tool (t7_copy_tool), so there
+  # is no restore step to get wrong and no window in which the repository's
+  # own bin/seed-drift is broken.
+  t7_copy_tool
 
   t7_setup
   t7_doc "multi block" MULTI_ANCHOR
@@ -1845,7 +1885,14 @@ t8_pad() {
   } >"$TPL"
   printf '#!/usr/bin/env bash\n\n# s1\n# s2\nMULTI_ANCHOR=1\n\n# s3\n# s4\nMULTI_ANCHOR_TWO=2\n' >"$SEED"
 
-  python3 - "$REPO_ROOT/bin/seed-drift" <<'PYEOF'
+  # Unsabotaged first, so the probe shows the flip in both directions from a
+  # single run rather than relying on the sibling test above.
+  t7_run_tool "$T7_TOOL"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *AHEAD* ]]
+  [[ "$output" != *"window is only"* ]]
+
+  python3 - "$T7_TOOL" <<'PYEOF'
 import sys
 path = sys.argv[1]
 old = '''  SD_LAST_WINDOW_SIZE=$(printf '%s\\n' "$keep" | awk 'END { print NR }')'''
@@ -1855,27 +1902,18 @@ assert text.count(old) == 1, "sabotage target line not found or not unique"
 open(path, "w").write(text.replace(old, new))
 PYEOF
 
-  t7_run
+  t7_run_tool "$T7_TOOL"
   [ "$status" -eq 1 ]
   [[ "$output" == *"seed window is only 3 lines"* ]]
 
-  git -C "$REPO_ROOT" checkout -- bin/seed-drift
-  diff -q "$backup" "$REPO_ROOT/bin/seed-drift" >/dev/null
-  rm -f "$backup"
-
-  t7_run
-  [ "$status" -eq 1 ]
-  [[ "$output" == *AHEAD* ]]
-  [[ "$output" != *"window is only"* ]]
+  t7_assert_repo_tool_untouched
 }
 
 @test "sabotage: raising SD_THIN_WINDOW past the seed's window size hides the note" {
   # Pins the load-bearing test above to the actual threshold constant, not to
-  # a hardcoded string it happens to match. Backed up to /tmp first per the
-  # brief: `git checkout --` restores to HEAD, not to a moment ago, and would
-  # silently destroy any uncommitted work in this file.
-  local backup="/tmp/seed-drift.t8-sabotage.bak.$$"
-  cp "$REPO_ROOT/bin/seed-drift" "$backup"
+  # a hardcoded string it happens to match. The edit goes to a private copy of
+  # the tool, never to $REPO_ROOT/bin/seed-drift — see t7_copy_tool for why.
+  t7_copy_tool
 
   t7_setup
   t7_doc "anchor block" ANCHOR_VAR
@@ -1886,15 +1924,14 @@ PYEOF
   } >"$TPL"
   printf '#!/usr/bin/env bash\n\nANCHOR_VAR=1\n' >"$SEED"
 
-  sed -i.orig 's/^SD_THIN_WINDOW=5$/SD_THIN_WINDOW=1/' "$REPO_ROOT/bin/seed-drift"
-  t7_run
+  t7_run_tool "$T7_TOOL"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"seed window is only 1 lines"* ]]
+
+  sed -i 's/^SD_THIN_WINDOW=5$/SD_THIN_WINDOW=1/' "$T7_TOOL"
+  t7_run_tool "$T7_TOOL"
   [ "$status" -eq 0 ]
   [[ "$output" != *"window is only"* ]]
 
-  cp "$backup" "$REPO_ROOT/bin/seed-drift"
-  rm -f "$backup" "$REPO_ROOT/bin/seed-drift.orig"
-
-  t7_run
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"seed window is only 1 lines"* ]]
+  t7_assert_repo_tool_untouched
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -596,3 +596,78 @@ write_lines() {
   [ "$status" -eq 0 ]
   [ "$output" = "BEHIND" ]
 }
+
+write_drift_template() {
+  cat >"$1" <<'TPL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+TREE_SITTER_VERSION=0.25.10
+install_tree_sitter "$TREE_SITTER_VERSION"
+echo "seed: tree-sitter ready"
+
+GITIGNORE="$HOME/.gitignore_global"
+git config --global core.excludesFile "$GITIGNORE"
+TPL
+}
+
+write_drift_doc() {
+  cat >"$1" <<'DOC'
+| Block | Anchor in template | Why it matters |
+|---|---|---|
+| tree-sitter CLI | `TREE_SITTER_VERSION` | pinned install |
+| global gitignore | `core.excludesFile` | git config |
+DOC
+}
+
+setup_drift_fixtures() {
+  export SEED_DRIFT_ROOT="$TEST_ROOT/workspace"
+  mkdir -p "$SEED_DRIFT_ROOT"
+  FIXTURE_TEMPLATE="$TEST_ROOT/template.sh"
+  FIXTURE_DOC="$TEST_ROOT/catch-up.md"
+  write_drift_template "$FIXTURE_TEMPLATE"
+  write_drift_doc "$FIXTURE_DOC"
+}
+
+make_project() { mkdir -p "$SEED_DRIFT_ROOT/$1/.devcontainer"; }
+seed_path() { printf '%s\n' "$SEED_DRIFT_ROOT/$1/.devcontainer/local-seed.sh"; }
+seed_from_template() { make_project "$1"; write_drift_template "$(seed_path "$1")"; }
+sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DOC" "$@"; }
+
+@test "a clean seed exits 0 and is counted as checked" {
+  setup_drift_fixtures
+  seed_from_template clean
+
+  sd_drift
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok       tree-sitter CLI"* ]]
+  [[ "$output" == *"1 checked, 0 skipped, 0 blocks drifted"* ]]
+}
+
+@test "a candidate with .devcontainer but no seed is skipped and a plain directory is silent" {
+  setup_drift_fixtures
+  seed_from_template clean
+  make_project noseed
+  mkdir -p "$SEED_DRIFT_ROOT/unrelated"
+
+  sd_drift
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"noseed  .devcontainer/ present, no local-seed.sh - skipped"* ]]
+  [[ "$output" != *"unrelated"* ]]
+  [[ "$output" == *"1 checked, 1 skipped, 0 blocks drifted"* ]]
+}
+
+@test "checked plus skipped equals the number of candidates" {
+  setup_drift_fixtures
+  seed_from_template one
+  seed_from_template two
+  make_project three
+  mkdir -p "$SEED_DRIFT_ROOT/not-a-candidate"
+
+  sd_drift
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2 checked, 1 skipped"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -2139,12 +2139,10 @@ PYEOF
 }
 
 @test "a seed whose doc table yields no blocks is an ERROR at exit 2, never clean" {
-  # The block loop reads through a process substitution, whose failure is
-  # invisible to both `set -e` and pipefail: with no rows the body never runs,
-  # rc stays 0, and the seed reports clean having compared nothing. sd_main's
-  # own parse check makes that unreachable through the CLI, so this calls
-  # sd_check_seed directly with an sd_parse_doc that succeeds and emits
-  # nothing — the shape the guard exists to catch.
+  # A successful parse that emits nothing: sd_parse_doc's awk exits non-zero on
+  # zero rows, so this shape is unreachable through the CLI. The guard exists so
+  # that "compared nothing" can never be reported as "clean". Calling
+  # sd_check_seed directly is the only way to produce it.
   setup_drift_fixtures
   seed_from_template clean
 
@@ -2160,5 +2158,33 @@ PYEOF
 
   [ "$status" -eq 2 ]
   [[ "$output" == *"no blocks read from the doc table"* ]]
+  [[ "$output" != *"ok  "* ]]
+}
+
+@test "a doc parse that emits rows and then fails is an ERROR at exit 2, never clean" {
+  # The row-count guard above cannot catch a parse that dies partway through:
+  # rows were emitted, so the counter is non-zero, and the seed would be judged
+  # on a truncated block list. The stub emits both real fixture rows — which a
+  # clean seed matches — and then fails, so a run that ignores the exit status
+  # reports "ok" at exit 0 and this test fails.
+  setup_drift_fixtures
+  seed_from_template clean
+
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    SD_TEMPLATE="$2"
+    SD_DOC="$3"
+    sd_tmp SD_TEMPLATE_SCAN
+    sd_scan "$SD_TEMPLATE" >"$SD_TEMPLATE_SCAN"
+    sd_parse_doc() {
+      printf "tree-sitter CLI\tTREE_SITTER_VERSION\n"
+      printf "global gitignore\tcore.excludesFile\n"
+      return 3
+    }
+    sd_check_seed "$4"
+  ' _ "$SEED_DRIFT" "$FIXTURE_TEMPLATE" "$FIXTURE_DOC" "$(seed_path clean)"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"the doc table could not be parsed"* ]]
   [[ "$output" != *"ok  "* ]]
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -1782,6 +1782,90 @@ t8_pad() {
   [[ "$output" == *"seed window is only 1 lines"* ]]
 }
 
+@test "a multi-paragraph anchor is judged by the UNION of its windows, not the last one alone" {
+  # Pins SD_LAST_WINDOW_SIZE to the union computation in sd_extract rather than
+  # a naive `sd_window`-per-call formula (Task 8 review). An anchor can match
+  # more than one paragraph (the design doc's own example: TREE_SITTER_VERSION,
+  # core.hooksPath). Two disjoint 3-line paragraphs here each fall under the
+  # 5-line threshold on their own, but their union (6 raw lines) does not. A
+  # formula that only remembers the LAST paragraph's window (the loop
+  # overwrites a per-call global on every iteration) would see just that one
+  # 3-line window and wrongly call the seed side thin; the union formula sees
+  # 6 and correctly does not.
+  t7_setup
+  t7_doc "multi block" MULTI_ANCHOR
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'MULTI_ANCHOR=1\n'
+  } >"$TPL"
+  # Two separate 3-line paragraphs, both matched by the fixed-string anchor
+  # (MULTI_ANCHOR is a substring of MULTI_ANCHOR_TWO too) — mirrors the real
+  # template's own multi-occurrence anchors. Each already parses standalone,
+  # so sd_window never grows either one past its own 3 lines.
+  printf '#!/usr/bin/env bash\n\n# s1\n# s2\nMULTI_ANCHOR=1\n\n# s3\n# s4\nMULTI_ANCHOR_TWO=2\n' >"$SEED"
+
+  t7_run
+  [ "$status" -eq 1 ]
+  [[ "$output" == *AHEAD* ]]
+  [[ "$output" != *"window is only"* ]]
+}
+
+@test "sabotage: reverting to a per-call (non-union) window size wrongly flags the multi-paragraph seed as thin" {
+  # Same intent as the other sabotage-probe: confirm the test above actually
+  # exercises the union math rather than passing under both formulas. The
+  # naive replacement here is exactly the brief's original suggestion —
+  # END - START + 1 off the single `sd_window` result, i.e. the last one the
+  # loop ran (the loop overwrites `window` every iteration) — which is what a
+  # regression back to it would look like.
+  #
+  # A plain `sed`/string substitution on this line is fragile (nested single
+  # quotes, `$` sigils), so the swap goes through python3 doing an exact,
+  # asserted-unique literal replacement instead.
+  #
+  # bin/seed-drift is committed at 6091300 with no further edits since, so
+  # restoring via `git checkout --` is safe here (unlike the file-under-
+  # construction case the /tmp-backup convention above guards against). Still
+  # take the /tmp backup and diff-verify the restore, per the standing
+  # process note: `cp` in this environment is interactive and silently
+  # declines instead of failing loudly — confirmed again while building this
+  # very test.
+  local backup="/tmp/seed-drift.t8-union-sabotage.bak.$$"
+  cp "$REPO_ROOT/bin/seed-drift" "$backup"
+
+  t7_setup
+  t7_doc "multi block" MULTI_ANCHOR
+  {
+    printf '#!/usr/bin/env bash\n\n'
+    t8_pad
+    printf 'MULTI_ANCHOR=1\n'
+  } >"$TPL"
+  printf '#!/usr/bin/env bash\n\n# s1\n# s2\nMULTI_ANCHOR=1\n\n# s3\n# s4\nMULTI_ANCHOR_TWO=2\n' >"$SEED"
+
+  python3 - "$REPO_ROOT/bin/seed-drift" <<'PYEOF'
+import sys
+path = sys.argv[1]
+old = '''  SD_LAST_WINDOW_SIZE=$(printf '%s\\n' "$keep" | awk 'END { print NR }')'''
+new = '''  SD_LAST_WINDOW_SIZE=$(printf '%s\\n' "$window" | awk '{ print $2 - $1 + 1 }')'''
+text = open(path).read()
+assert text.count(old) == 1, "sabotage target line not found or not unique"
+open(path, "w").write(text.replace(old, new))
+PYEOF
+
+  t7_run
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"seed window is only 3 lines"* ]]
+
+  git -C "$REPO_ROOT" checkout -- bin/seed-drift
+  diff -q "$backup" "$REPO_ROOT/bin/seed-drift" >/dev/null
+  rm -f "$backup"
+
+  t7_run
+  [ "$status" -eq 1 ]
+  [[ "$output" == *AHEAD* ]]
+  [[ "$output" != *"window is only"* ]]
+}
+
 @test "sabotage: raising SD_THIN_WINDOW past the seed's window size hides the note" {
   # Pins the load-bearing test above to the actual threshold constant, not to
   # a hardcoded string it happens to match. Backed up to /tmp first per the

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -725,3 +725,26 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   [[ "$output" == *"MISSING  global gitignore     anchor absent from seed"* ]]
   [[ "$output" == *"1 blocks drifted (1 missing)"* ]]
 }
+
+@test "a nonexistent argument is skipped and named, exit 0" {
+  setup_drift_fixtures
+
+  sd_drift "$SEED_DRIFT_ROOT/absent-project"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"absent-project - not present on this machine - skipped"* ]]
+  [[ "$output" == *"0 checked, 1 skipped, 0 blocks drifted"* ]]
+}
+
+@test "an argument is accepted as a project directory or as a direct seed path" {
+  setup_drift_fixtures
+  seed_from_template clean
+
+  sd_drift "$SEED_DRIFT_ROOT/clean"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1 checked, 0 skipped"* ]]
+
+  sd_drift "$(seed_path clean)"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1 checked, 0 skipped"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -671,3 +671,57 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   [ "$status" -eq 0 ]
   [[ "$output" == *"2 checked, 1 skipped"* ]]
 }
+
+@test "a behind seed exits 1 and the finding names project, block and direction" {
+  setup_drift_fixtures
+  seed_from_template behindp
+  sed -i '/tree-sitter ready/d' "$(seed_path behindp)"
+
+  sd_drift
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"behindp  $(seed_path behindp)"* ]]
+  [[ "$output" == *"BEHIND   tree-sitter CLI      1 template lines absent from seed"* ]]
+  [[ "$output" == *'- echo "seed: tree-sitter ready"'* ]]
+  [[ "$output" == *"port from template; see catch-up-local-seed.md Step 2"* ]]
+  [[ "$output" == *"1 checked, 0 skipped, 1 blocks drifted (1 behind)"* ]]
+}
+
+@test "an ahead seed is a promotion candidate and never suggests overwriting" {
+  setup_drift_fixtures
+  seed_from_template aheadp
+  sed -i '/tree-sitter ready/a echo "seed: project extra"' "$(seed_path aheadp)"
+
+  sd_drift
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"AHEAD    tree-sitter CLI      1 seed lines absent from template"* ]]
+  [[ "$output" == *"promotion candidate; do NOT overwrite the seed"* ]]
+  [[ "$output" != *"overwrite the seed with"* ]]
+}
+
+@test "a reordered seed is DIVERGED and told to inspect by hand" {
+  setup_drift_fixtures
+  seed_from_template reorder
+  sed -i '5d' "$(seed_path reorder)"
+  sed -i '/tree-sitter ready/a install_tree_sitter "$TREE_SITTER_VERSION"' \
+    "$(seed_path reorder)"
+
+  sd_drift
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"DIVERGED tree-sitter CLI"* ]]
+  [[ "$output" == *"inspect by hand; do NOT overwrite the seed"* ]]
+}
+
+@test "an anchor absent from the seed is MISSING" {
+  setup_drift_fixtures
+  seed_from_template gone
+  sed -i '/core.excludesFile/d' "$(seed_path gone)"
+
+  sd_drift
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"MISSING  global gitignore     anchor absent from seed"* ]]
+  [[ "$output" == *"1 blocks drifted (1 missing)"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -103,3 +103,16 @@ DOC
   [[ "$output" == *"is absent from"* ]]
   [[ "$output" == *"core.excludesFile"* ]]
 }
+
+@test "sd_scan numbers every line and starts a new paragraph after a blank line" {
+  local f="$TEST_ROOT/paras.sh"
+  printf '%s\n' 'first=1' 'second=2' '' '   ' 'third=3' >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$(printf '1\t1\tC\tfirst=1')" ]
+  [ "${lines[1]}" = "$(printf '1\t2\tC\tsecond=2')" ]
+  [ "${lines[2]}" = "$(printf '2\t5\tC\tthird=3')" ]
+  [ "${#lines[@]}" -eq 3 ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -333,3 +333,91 @@ make_scan() {
   [ "$status" -eq 0 ]
   [ "$output" = "1 4" ]
 }
+
+# --- Task 4 helpers ---------------------------------------------------------
+scan_line() {
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >>"$FIX/in.scan"
+}
+
+norm() {
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c \
+    'source "$1"; sd_normalize <"$2"' _ "$SEED_DRIFT" "$FIX/in.scan"
+}
+
+@test "sd_normalize joins backslash continuations and collapses whitespace" {
+  scan_line 1 1 C '  curl -fsSL   \'
+  scan_line 1 2 C '      -o out   url'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "curl -fsSL -o out url" ]
+}
+
+@test "sd_normalize drops privilege prefixes" {
+  scan_line 1 1 C 'as_user mkdir -p a'
+  scan_line 1 2 C '$SUDO mkdir -p b'
+  scan_line 1 3 C 'sudo -n mkdir -p c'
+  scan_line 1 4 C 'sudo mkdir -p d'
+  scan_line 1 5 C 'runuser -u node -- mkdir -p e'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "mkdir -p a
+mkdir -p b
+mkdir -p c
+mkdir -p d
+mkdir -p e" ]
+}
+
+@test "sd_normalize drops privilege words in command position, not just at line start" {
+  # Template line 218 vs wanderer's root-flavor equivalent: these must
+  # normalize identically or the spec's required "as_user vs direct
+  # invocation" false-positive guard fails on the core.excludesFile block.
+  scan_line 1 1 C 'if ! as_user test -f "$GITIGNORE"; then'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if ! test -f "$GITIGNORE"; then' ]
+}
+
+@test "sd_normalize drops privilege words after && and ||" {
+  # Template lines 390, 431 and 514 all stack privilege words mid-line.
+  scan_line 1 1 C 'if as_user test -x "$A" || as_user bash -lc "c"; then'
+  scan_line 1 2 C 'if as_user test -f "$N" && as_user test -x "$N"; then'
+  scan_line 1 3 C 'if as_user test -L "$C" || ! as_user test -e "$C"; then'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if test -x "$A" || bash -lc "c"; then
+if test -f "$N" && test -x "$N"; then
+if test -L "$C" || ! test -e "$C"; then' ]
+}
+
+@test "sd_normalize does not strip privilege words outside command position" {
+  # Over-broad stripping is the silent direction, so this guard matters more
+  # than the ones above: a genuine difference in an argument must survive.
+  scan_line 1 1 C 'grep as_user "$f"'
+  scan_line 1 2 C 'run_as_user_thing x'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'grep as_user "$f"
+run_as_user_thing x' ]
+}
+
+@test "sd_normalize substitutes the path token only and preserves surrounding quotes" {
+  scan_line 1 1 C '      TS_BIN="$SEED_HOME/.local/bin/tree-sitter"'
+  scan_line 1 2 C 'X="$HOME/a"'
+  scan_line 1 3 C 'Y="$DOTFILES_HOME/config"'
+  scan_line 1 4 C 'Z="$WORKSPACE/p"'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'TS_BIN="«HOME»/.local/bin/tree-sitter"
+X="«HOME»/a"
+Y="«HOME»/.dotfiles/config"
+Z="«WS»/p"' ]
+}
+
+@test "sd_normalize drops lines that normalize to empty" {
+  scan_line 1 1 C ''
+  scan_line 1 2 C '   '
+  scan_line 1 3 C 'echo keep'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = "echo keep" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -501,3 +501,22 @@ fi' ]
   sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" NOPE
   [ "$status" -eq 4 ]
 }
+
+write_lines() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" >"$path"
+}
+
+@test "sd_diff_lines names the lines missing from each side" {
+  write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_old'
+  write_lines "$TEST_ROOT/seed" 'export A=1' 'run_new'
+
+  sd_source sd_diff_lines "$TEST_ROOT/tpl" "$TEST_ROOT/seed" '<'
+  [ "$status" -eq 0 ]
+  [ "$output" = "run_old" ]
+
+  sd_source sd_diff_lines "$TEST_ROOT/tpl" "$TEST_ROOT/seed" '>'
+  [ "$status" -eq 0 ]
+  [ "$output" = "run_new" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -285,3 +285,12 @@ make_scan() {
   [ "$status" -eq 0 ]
   [ "$output" = "4 6" ]
 }
+
+@test "bash -n rejects a lone if header and accepts it split by a blank line" {
+  printf 'if [ -n "$x" ]; then\n' >"$FIX/lone.sh"
+  printf 'if [ -n "$x" ]; then\n\n  echo hi\nfi\n' >"$FIX/split.sh"
+  run bash -n "$FIX/lone.sh"
+  [ "$status" -eq 2 ]
+  run bash -n "$FIX/split.sh"
+  [ "$status" -eq 0 ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -87,6 +87,12 @@ DOC
 }
 
 @test "every anchor in the real doc table is present in the real template" {
+  # Discovery finding zero projects is now a hard error (fix round 2, I-2);
+  # give it one skip-only candidate so this test still exercises only what
+  # it is meant to check: real-doc/real-template anchor agreement, exit 0.
+  export SEED_DRIFT_ROOT="$TEST_ROOT/workspace"
+  mkdir -p "$SEED_DRIFT_ROOT/placeholder/.devcontainer"
+
   run "$SEED_DRIFT" --template "$REAL_TEMPLATE" --doc "$REAL_DOC"
 
   [ "$status" -eq 0 ]

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -560,3 +560,31 @@ write_lines() {
   [ "$status" -eq 0 ]
   [ "$output" = "AHEAD" ]
 }
+
+@test "sd_verdict reports DIVERGED for a pure reordering, never ok" {
+  write_lines "$TEST_ROOT/tpl" \
+    'printf "source «HOME»/.dotfiles/load-custom.zsh" >>«HOME»/.zshrc' \
+    'printf "source «HOME»/ai/vekil/env.zsh" >>«HOME»/.zshrc'
+  write_lines "$TEST_ROOT/seed" \
+    'printf "source «HOME»/ai/vekil/env.zsh" >>«HOME»/.zshrc' \
+    'printf "source «HOME»/.dotfiles/load-custom.zsh" >>«HOME»/.zshrc'
+
+  # Same lines, different order: a sorted comparison would call this clean.
+  run diff <(sort "$TEST_ROOT/tpl") <(sort "$TEST_ROOT/seed")
+  [ "$status" -eq 0 ]
+
+  sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "DIVERGED" ]
+}
+
+@test "sd_verdict reports DIVERGED when lines differ in both directions" {
+  write_lines "$TEST_ROOT/tpl" 'export A=1' 'run_old'
+  write_lines "$TEST_ROOT/seed" 'export A=1' 'run_new'
+
+  sd_source sd_verdict "$TEST_ROOT/tpl" "$TEST_ROOT/seed"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "DIVERGED" ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -241,3 +241,13 @@ FIX
   [ "${lines[4]}" = "$(printf '1\t5\tC\t\tB')" ]
   [ "${lines[5]}" = "$(printf '1\t6\tC\techo tail')" ]
 }
+
+@test "sd_scan fails closed on an unterminated heredoc" {
+  local f="$TEST_ROOT/unterminated.sh"
+  printf "cat <<'E'\nbody\n" >"$f"
+
+  sd_source sd_scan "$f"
+
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"unterminated heredoc E"* ]]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -513,18 +513,33 @@ echo after' ]
   [ "$(cat "$behind")" = '{ chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||' ]
 }
 
-@test "the ownership rule is exact: target, -R, identity, and unrelated chown all survive" {
-  scan_line 1 1 C '{ chown -R "$SEED_UID:$SEED_GID" "$OTHER.new" 2>/dev/null ||'
-  scan_line 1 2 C '{ chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||'
-  scan_line 1 3 C '{ chown -R "$SEED_UID:0" "$NVIM_DIST.new" 2>/dev/null ||'
-  scan_line 1 4 C 'chown -R node:node /app'
-  norm
-  [ "$status" -eq 0 ]
-  [ "$output" = '{ chown -R "$SEED_UID:$SEED_GID" "$OTHER.new" 2>/dev/null ||
-{ chown "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
-{ chown -R "$SEED_UID:0" "$NVIM_DIST.new" 2>/dev/null ||
-chown -R node:node /app' ]
+# Fix round 1 (Task 7 review, I-1): pins SD_OWNERSHIP_GUARD_PATTERN to
+# SD_OWNERSHIP_DROP so the two cannot drift apart silently. The guard exists
+# to recognize when AHEAD_FILE still carries a trace of an idiom line; if a
+# future idiom entry is added to the array whose distinguishing tokens the
+# guard doesn't cover, this is exactly the class of bug the find-half
+# regression test (below, in the Task 7 end-to-end block) caught — and it
+# would recur silently, one entry at a time, without this test.
+@test "SD_OWNERSHIP_GUARD_PATTERN matches every SD_OWNERSHIP_DROP entry" {
+  run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
+    source "$1"
+    for line in "${SD_OWNERSHIP_DROP[@]}"; do
+      grep -qE "$SD_OWNERSHIP_GUARD_PATTERN" <<<"$line" || printf "MISS: %s\n" "$line"
+    done
+  ' _ "$SEED_DRIFT"
+  [ -z "$output" ]
 }
+
+# Fix round 1 (Task 7 review, M-2): this test used to claim to cover "the
+# ownership rule" but only ever exercised sd_normalize passthrough — it would
+# pass identically with no ownership rule at all, since sd_normalize stopped
+# touching these lines the moment the drop moved to sd_apply_ownership_rule
+# (see "sd_normalize no longer drops..." above). That passthrough claim is
+# already covered there; the actual rule (target/-R/identity/unrelated-chown
+# all producing real drift) is covered end-to-end, against the real tool, by
+# the four "ownership idiom ... is drift, not dropped" tests and "an
+# unrelated chown line is compared normally" below. Deleted as a redundant,
+# uncatchable duplicate rather than kept as a test that cannot fail.
 
 @test "sd_extract unions windows in file order, deduped, and normalizes" {
   printf 'echo ANCHOR one\n\necho middle\n\nas_user echo ANCHOR two\n' >"$FIX/f.sh"
@@ -807,6 +822,10 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   [[ "$output" == *"1 checked, 0 skipped"* ]]
 }
 
+# Fix round 1 (Task 7 review, M-3): a t7_-style duplicate of this test ("a
+# malformed seed does not suppress drift reporting for the others") was
+# folded in here rather than kept alongside it — same intent, weaker
+# assertions (no "does not parse" text, no exact summary count).
 @test "a malformed seed exits 2 without suppressing drift in the others" {
   setup_drift_fixtures
   seed_from_template aaa-broken
@@ -1028,8 +1047,12 @@ t7_run() {
 @test "privilege normalization is portable and keyword-boundary correct" {
   # `\b` is a GNU sed extension; BSD sed (macOS, which this script supports)
   # silently fails to match it, so every `if as_user ...` line would keep its
-  # privilege word and report as drift on a Mac and clean on Linux.
-  run grep -n '\\b' "$SEED_DRIFT"
+  # privilege word and report as drift on a Mac and clean on Linux. Fix
+  # round 1 (Task 7 review, M-4): scoped to sd_drop_priv_prefix's own body —
+  # the only function that runs `sed -E` — rather than the whole file, so
+  # unrelated prose elsewhere (this comment included) is free to name the
+  # token without tripping the check.
+  run bash -c "sed -n '/^sd_drop_priv_prefix()/,/^}/p' '$SEED_DRIFT' | grep -n '\\\\b'"
   [ "$status" -ne 0 ]
 
   scan_line 1 1 C 'if as_user test -x /x; then'
@@ -1510,6 +1533,34 @@ SEEDEOF
   [[ "$output" == *DIVERGED* ]]
 }
 
+@test "ownership idiom with only the find-half identity changed is drift, not dropped" {
+  t7_setup
+  t7_doc "neovim install" NVIM_DIST
+  t7_own_tpl
+  # The chown half is byte-identical to the template on both sides here, so
+  # it cancels in the diff and never reaches AHEAD_FILE. Only the find-half
+  # (`! -uid`) changed. A guard that only looks for `chown` in AHEAD_FILE is
+  # blind to this: AHEAD_FILE holds nothing but the modified find-half line,
+  # which has no `chown` token, so the guard fires anyway, the idiom is
+  # dropped from BEHIND_FILE, and the block reports AHEAD with "promotion
+  # candidate" advice — silently wrong, since the seed's ownership check no
+  # longer verifies the group it claims to.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+NVIM_DIST="$SEED_HOME/.local/nvim"
+if [ -d "$NVIM_DIST.new" ]; then
+  { chown -R "$SEED_UID:$SEED_GID" "$NVIM_DIST.new" 2>/dev/null ||
+    [ -z "$(find "$NVIM_DIST.new" \( ! -uid "0" -o ! -gid "$SEED_GID" \) -print -quit 2>/dev/null)" ]; } &&
+    as_user mv "$NVIM_DIST.new" "$NVIM_DIST"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *DIVERGED* ]]
+  [[ "$output" != *"promotion candidate"* ]]
+}
+
 @test "an unrelated chown line is compared normally" {
   t7_setup
   t7_doc "neovim install" NVIM_DIST
@@ -1739,36 +1790,4 @@ SEEDEOF
   [ "$status" -eq 1 ]
   after="$(find "$WS" -type f -exec sha256sum {} + | sort)"
   [ "$before" = "$after" ]
-}
-
-@test "a malformed seed does not suppress drift reporting for the others" {
-  t7_setup
-  t7_doc "tree-sitter CLI" TREE_SITTER_VERSION
-  cat >"$TPL" <<'TPLEOF'
-#!/usr/bin/env bash
-
-if [ -n "${TREE_SITTER_VERSION:-}" ]; then
-  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
-  as_user mv "$TS_BIN.new" "$TS_BIN"
-fi
-TPLEOF
-  mkdir -p "$WS/broken/.devcontainer"
-  cat >"$WS/broken/.devcontainer/local-seed.sh" <<'BROKENEOF'
-#!/usr/bin/env bash
-
-if [ -n "${TREE_SITTER_VERSION:-}" ]; then
-  echo "unterminated"
-BROKENEOF
-  cat >"$SEED" <<'SEEDEOF'
-#!/usr/bin/env bash
-
-if [ -n "${TREE_SITTER_VERSION:-}" ]; then
-  echo "seed: installing tree-sitter $TREE_SITTER_VERSION"
-fi
-SEEDEOF
-  run "$REPO_ROOT/bin/seed-drift" --template "$TPL" --doc "$DOC"
-  [ "$status" -eq 2 ]
-  [[ "$output" == *broken* ]]
-  [[ "$output" == *demo* ]]
-  [[ "$output" == *BEHIND* ]]
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -811,3 +811,32 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   [ "$status" -eq 2 ]
   [[ "$output" != *"unbound variable"* ]]
 }
+
+@test "an explicit candidate directory with no .devcontainer is named and skipped, exit 0" {
+  setup_drift_fixtures
+  mkdir -p "$SEED_DRIFT_ROOT/nodev"
+
+  sd_drift "$SEED_DRIFT_ROOT/nodev"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nodev"*"no .devcontainer/ - skipped"* ]]
+  [[ "$output" == *"0 checked, 1 skipped, 0 blocks drifted"* ]]
+}
+
+@test "discovery that finds nothing is an error, exit 2" {
+  setup_drift_fixtures
+
+  sd_drift
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no projects found under $SEED_DRIFT_ROOT"* ]]
+  [[ "$output" == *"0 checked, 0 skipped, 0 blocks drifted"* ]]
+}
+
+@test "an explicit-candidate run with an equally empty result still exits 0" {
+  setup_drift_fixtures
+
+  sd_drift "$SEED_DRIFT_ROOT/absent-project"
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What this adds

`bin/seed-drift` — a detector for drift between each project's gitignored
`.devcontainer/local-seed.sh` and the `project-claude-setup` template, at
**block** granularity. Plus `tests/seed_drift.bats` (113 cases) and a
`bin/list-check-files` change that puts `tests/*.bats` under the shfmt gate.

Today the only detection is the manual Step 1 audit in `catch-up-local-seed.md`,
and that audit has already failed once: all five seeds sat on the pre-#38
tree-sitter error routing for weeks while the doc's anchor grep reported them
clean, because it only checks that `TREE_SITTER_VERSION` *appears* — not that
the block around it matches.

## The representation decision

Three candidates, per the brief:

| | verdict |
|---|---|
| anchor presence | too coarse — this is the bug being fixed |
| whole-file diff | too noisy — seeds legitimately differ in `as_user` vs direct invocation, `$SEED_HOME` vs `$HOME`, `$SUDO`, `$WORKSPACE`, continuation style, and project-specific blocks |
| **normalized block comparison** | **picked** |
| per-block fingerprint in the template | rejected |

Fingerprinting was the close call. It is cheaper to check and unambiguous, but
it requires the template to carry a hash per block that someone must remember to
regenerate on every template edit — a second thing to keep in sync, which is the
same class of failure this tool exists to catch. It also answers only
"same/different," and the brief requires **direction**: behind, ahead, diverged.
A hash cannot tell you a seed is *ahead*.

So: locate the block by its documented anchor, grow a window outward until
`bash -n` parses the fragment, normalize (strip comments, join continuations,
collapse whitespace, neutralize `as_user`/`$SUDO`/`$SEED_HOME`/`$DOTFILES_HOME`/
`$WORKSPACE`), then diff the normalized line sequences in both directions.

`SEED_VERSION` is never consulted, per the brief — always-run blocks correctly
don't bump it.

## Drift runs both ways

`ok` / `MISSING` / `BEHIND` / `AHEAD` / `DIVERGED` / `ERROR`. `AHEAD` prints
`promotion candidate; do NOT overwrite the seed`, and `DIVERGED` prints
`inspect by hand; do NOT overwrite the seed`. The tool is **strictly read-only**
with respect to the seeds — asserted by test, because `local-seed.sh` is
gitignored and hand-owned with no revert path.

Exit codes: `0` clean, `1` drift, `2` error. Discovery finding zero projects is
a `2`, not a clean bill of health. An explicitly-named absent project is a
counted skip at exit 0, so one project list works on every machine.

## Current corpus

```
5 checked, 2 skipped, 28 blocks drifted (4 behind, 1 ahead, 23 diverged)
```

**The 23 `DIVERGED` are genuine drift, not a false-positive rate.** The seeds
really have diverged; the tool is reporting the backlog that motivated it. The
live outstanding behind-drift is `neovim install` (`NVIM_VERSION`, 5 template
lines absent) on three seeds.

The motivating tree-sitter regression was remediated between the brief and this
landing, so `tree-sitter CLI` is now `ok` on three seeds. Regression coverage for
it therefore lives in a fixture — *"anchor present but surrounding block outdated
reports BEHIND with exit 1"* — not in the live corpus. A test that depends on
production drift staying broken is not a test.

## A real bug this branch found in itself

Mid-review, `sd_window` was found to grow the window end forward to EOF and never
roll it back, so any block needing *upward* growth extracted `[start..EOF]`. This
was not hypothetical: `wanderer-notifier`/`DOTFILES_LOAD_HOOK` extracted lines
582–719 against a true statement end of 649, attributing 70 lines to the wrong
block. Fixed by a two-dimensional `(lo, hi)` paragraph search that returns the
first pair which parses.

Two knock-on corrections worth recording: the "138-line maximum window" cited in
an earlier draft was an artifact of that same bug (true max is 109), and the
"95 windows" figure double-counted the template's 9 windows once per seed. The
measured truth is **59 windows, 9–109 lines, median 29, 58 of 59 parsing at the
very first pair.** `SD_THIN_WINDOW=5` is calibrated against the *minimum* (9),
which the bug never affected.

## Known limitations

**1. The anchor must sit in the stable part of its block.** If a seed drifts in a
way that changes the anchor line itself, the verdict is `MISSING` rather than
`DIVERGED` — still non-zero and still named, but the message understates what
happened. Mitigation is editorial: pick anchors from the least-volatile part of a
block (a variable name or URL, not a flag or test expression).

**2. Root-flavor seeds report the ownership-verification lines as `BEHIND`.** The
template's non-root flavor `chown`s after unpacking; a root-flavor seed has no
reason to. A special case for this was tried and deliberately removed — it failed
three separate ways and measurement showed it changed no verdict and no summary
line. So this is a known false positive, and a loud one: it names the project,
the block, and the lines. The design prefers noise that announces itself over a
clean report that is quietly wrong. `slabledger` and `wanderer` are root flavor.

**3. A thin window proves little.** The tool prints an informational note when an
extracted window is under 5 lines. It never affects the verdict or the exit code.
On the current corpus it fires zero times.

## Note for reviewers

`bin/seed-drift` runs under `set -euo pipefail`, and the `[ cond ] && cmd` form
is only safe when a `return`/`exit` is the immediately-following statement. Three
separate instances of that shape were caught during review of this branch — two
by code review, one by a polish pass. It is a pattern in this file, not three
coincidences. Worth watching for in follow-ups.

## `.bats` under shfmt

`bin/list-check-files` did not cover `.bats` files for either linter, and two
suites had already drifted unformatted as a result. They are now in the **shfmt**
class only — `bash -n` and `shellcheck` cannot parse `@test` block syntax. Pinned
by a test in `tests/check_file_discovery.bats`.

## Verification

- 113/113 `tests/seed_drift.bats`
- `command make check` — PASSED, 0 errors, 0 warnings
- `shfmt -i 2 -ci` and `shellcheck -x -S warning` clean
- Real five-seed corpus run, with the five seed `md5sum`s identical before and
  after, confirming read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only `seed-drift` tool to compare project seed scripts with documented templates.
  * Reports clean, behind, ahead, diverged, missing, and error states with actionable guidance.
  * Supports automatic project discovery and checking specific paths.

* **Documentation**
  * Added usage guidance, exit-code details, detection rules, result interpretation, and executable-table requirements.

* **Chores**
  * Expanded shell-formatting checks to include Bats test files.

* **Tests**
  * Added comprehensive coverage for drift detection, malformed inputs, portability, read-only behavior, and Bats file discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->