### PR TITLE
doc(catch-up-local-seed): drive the audit off bin/seed-drift

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -11,10 +11,18 @@ aborts another under `set -euo pipefail`.
 
 ## Prompt
 
+Run from the project's directory, one project per session:
+
 > Catch this project's `.devcontainer/local-seed.sh` up to the current template
 > at `~/.dotfiles/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh`,
-> following `catch-up-local-seed.md` in that same directory. Audit first, show me
-> what's missing and what you plan to port, then apply it.
+> following `catch-up-local-seed.md` in that same directory — read it first.
+> Audit with `~/.dotfiles/bin/seed-drift "$PWD"`, then work block by block from
+> its verdicts, honouring the direction each one implies: port a `BEHIND` down
+> into the seed translated into this file's vocabulary, treat an `AHEAD` as a
+> promotion candidate and leave the seed alone, and inspect a `DIVERGED` by hand
+> rather than assuming the template wins. Show me what you plan to change and
+> which verdicts you intend to leave standing, before you apply anything. Then
+> stop after Step 3 so I can rebuild the container.
 
 ## Why not just regenerate from the template
 
@@ -34,19 +42,59 @@ as cruft.
 From the project directory:
 
 ```bash
-f=.devcontainer/local-seed.sh
-printf 'SEED_VERSION=%s\n' "$(sed -n 's/^SEED_VERSION=//p' "$f")"
-for k in 'STABLE_LINK_ROOT' 'ensure_stable_link_root' 'NVIM_VERSION' \
-         'TREE_SITTER_VERSION' 'load-custom.zsh' 'core.hooksPath' \
-         'core.excludesFile' 'local/bin/codex' 'config/nvim'; do
-  grep -q "$k" "$f" && printf '  %-24s present\n' "$k" || printf '  %-24s MISSING\n' "$k"
-done
-grep -o "lname '[^']*'" "$f" || echo "  overlay-gitignore matcher MISSING"
+~/.dotfiles/bin/seed-drift "$PWD"
 ```
+
+Or by name, from anywhere:
+
+```bash
+~/.dotfiles/bin/seed-drift ~/workspace/<project>
+```
+
+Exit `0` clean, `1` drift found, `2` usage / template / doc / extraction error or
+no projects discovered. With no arguments it checks every project under
+`~/workspace` (override with `SEED_DRIFT_ROOT`); a project that is not checked
+out on this machine is a counted skip, not a failure. It is strictly read-only
+with respect to the seeds.
 
 **`SEED_VERSION` does not tell you what's in the file.** Every block below is
 always-run, and by the two-clause gating rule an always-run change must not bump
-the version — so two seeds can both say `v8` and differ. Grep is the only check.
+the version — so two seeds can both say `v8` and differ.
+
+**Nor does anchor presence.** Grepping for `TREE_SITTER_VERSION` proves only
+that the string occurs somewhere; it says nothing about the block around it.
+That is not hypothetical — all five seeds sat on the pre-#38 tree-sitter error
+routing for weeks while a presence check reported them clean. `bin/seed-drift`
+extracts the whole enclosing top-level statement around each anchor, normalizes
+away the vocabulary differences below, and compares the result, which is why it
+catches what the grep could not.
+
+### Reading the verdicts
+
+The direction of the fix depends on the verdict. It is not always "make the seed
+match the template":
+
+| Verdict | Meaning | What to do |
+|---|---|---|
+| `ok` | normalized blocks match | nothing |
+| `BEHIND` | template has lines the seed lacks | port template → seed, translated into that seed's vocabulary — Step 2 |
+| `AHEAD` | seed has lines the template lacks | **promotion candidate, not an error.** Do not overwrite the seed. Propose lifting the block into the template — a tracked change in `~/.dotfiles`, so it needs its own worktree and PR |
+| `DIVERGED` | both sides have lines the other lacks | inspect by hand. On a seed whose vocabulary differs from the template's this is often spelling rather than stale logic — decide per block |
+| `MISSING` | the anchor is absent from the seed entirely | port the whole block — Step 2 |
+| `ERROR` | the block could not be extracted or parsed | the tool could not compare; investigate before treating the seed as clean |
+
+A `note: … window is only N lines` under a verdict means the extracted block was
+small enough that the comparison covers little — worth an eye even when it says
+`ok`.
+
+The table above is prose, unlike the one in Step 2: the parser only takes a row
+whose **second** cell is a backticked anchor, and these rows backtick the first.
+Do not add a backticked second cell here — the parser would read the row as a
+block and abort every project at exit 2 when the "anchor" turned up missing from
+the template. `tests/seed_drift.bats` pins the count at nine and would catch it.
+
+The blocks it compares are the rows of the Step 2 table below, so the two stay
+in step by construction.
 
 ## Step 2 — port the missing blocks
 
@@ -131,6 +179,18 @@ Two substitutions are templated and must be replaced when pasting: `{USER}` and
 bash -n .devcontainer/local-seed.sh
 shellcheck -x -S warning -e SC1091 .devcontainer/local-seed.sh
 shfmt -d -i 2 -ci .devcontainer/local-seed.sh
+
+# Re-run the Step 1 audit: the ported blocks must now read `ok`. Parsing clean
+# is not the same as drifting clean — a block pasted without translating its
+# vocabulary parses fine and still reports BEHIND or DIVERGED. Expect exit 0,
+# or exit 1 with only the verdicts you consciously decided to leave (an AHEAD
+# awaiting promotion, a DIVERGED ruled benign); anything else is unfinished.
+#
+# Invoked by absolute path, NOT as `(cd ~/.dotfiles && bin/seed-drift "$PWD")`
+# — `$PWD` re-evaluates after the `cd`, so that form audits the dotfiles repo
+# and reports a clean `0 checked, 1 skipped` at exit 0 without ever looking at
+# this seed.
+~/.dotfiles/bin/seed-drift "$PWD"
 
 # Nothing tracked may have moved. Diffed against the Step 2 baseline rather than
 # asserted empty: the seed and the override are gitignored, but any other


### PR DESCRIPTION
Step 1 of `catch-up-local-seed.md` still told the reader to run the coarse anchor grep — the check that reported all five seeds clean while they sat on the pre-#38 tree-sitter error routing for weeks. `bin/seed-drift` (#44) was built to replace it, but the doc never said so: the tool appeared only in the note about the Step 2 table being executable input.

## What changed

- **Step 1** runs the detector, and documents what each verdict means for the *direction* of the fix. That mapping previously existed only in the tool's output hints and the README. `BEHIND` ports down into the seed; `AHEAD` is a promotion candidate that must not overwrite the seed; `DIVERGED` needs a per-block ruling and is often vocabulary rather than stale logic.
- **Step 3** re-runs the audit. Parsing clean is not drifting clean — a block pasted without translating its vocabulary passes `bash -n`, shellcheck and shfmt and still reports `BEHIND`.
- **The paste-in prompt** at the top now drives off the detector and its verdicts.

## Two things worth a reviewer's eye

**The Step 3 invocation is by absolute path, deliberately.** I first wrote the natural-looking `(cd ~/.dotfiles && bin/seed-drift "$PWD")` and tested it: `$PWD` re-evaluates after the `cd`, so it audits the dotfiles repo and prints `0 checked, 1 skipped, 0 blocks drifted` at **exit 0** — a silent false pass in the step whose whole job is catching an unfinished port. Both forms were run before documenting either; the trap is called out inline so it does not get "simplified" back.

**Step 1 introduces a second Markdown table into a file the tool parses.** It is inert because the parser only takes rows whose *second* cell is a backticked anchor, and these rows backtick the first. A backticked second cell there would be read as a block and abort every project at exit 2. Noted inline, and the nine-block canary in `tests/seed_drift.bats` catches it.

## Verification

- 116/116 `tests/seed_drift.bats`, including `sd_parse_doc reads all nine blocks from the real catch-up doc`
- `make check` PASSED (0 errors, 0 warnings)
- Both documented invocation forms run verbatim and exit 1 against a drifted project
- Real corpus unchanged at `5 checked, 2 skipped, 28 blocks drifted (4 behind, 1 ahead, 23 diverged)`; five seed md5sums identical before and after

No markdownlint is wired into this repo, so the Markdown is unlinted locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)