### PR TITLE
feat(seed-drift): stop per-project templated assignments reading as drift

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -82,6 +82,7 @@ match the template":
 | `DIVERGED` | both sides have lines the other lacks | inspect by hand. On a seed whose vocabulary differs from the template's this is often spelling rather than stale logic — decide per block |
 | `MISSING` | the anchor is absent from the seed entirely | port the whole block — Step 2 |
 | `ERROR` | the block could not be extracted or parsed | the tool could not compare; investigate before treating the seed as clean |
+| `ERROR` on `(whole file)` | the seed reads `$WORKSPACE` or `$SEED_USER` but never assigns it | fix before rebuilding. Under `set -euo pipefail` the first expansion aborts the whole seed, which surfaces as an unrelated-looking container start error rather than as a seed failure |
 
 A `note: … window is only N lines` under a verdict means the extracted block was
 small enough that the comparison covers little — worth an eye even when it says

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -83,6 +83,7 @@ match the template":
 | `MISSING` | the anchor is absent from the seed entirely | port the whole block — Step 2 |
 | `ERROR` | the block could not be extracted or parsed | the tool could not compare; investigate before treating the seed as clean |
 | `ERROR` on `(whole file)` | the seed reads `$WORKSPACE` or `$SEED_USER` but never assigns it | fix before rebuilding. Under `set -euo pipefail` the first expansion aborts the whole seed, which surfaces as an unrelated-looking container start error rather than as a seed failure |
+| `ERROR` on `(whole file)` | the seed *derives* `WORKSPACE`/`SEED_USER` instead of assigning a literal | fix before rebuilding. The seed is mounted at an arbitrary container path that need not sit inside the checkout, so `git rev-parse` and friends resolve against the wrong tree |
 
 A `note: … window is only N lines` under a verdict means the extracted block was
 small enough that the comparison covers little — worth an eye even when it says

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -362,8 +362,48 @@ sd_drop_priv_prefix() {
 #   0 - a declaration with a plain literal RHS   => dropped from comparison
 #   2 - a declaration with any other RHS         => kept, and reported
 #   1 - not one of these declarations at all
+# Splits a declaration into its individual words, one per line, honouring one
+# level of quoting so `export WORKSPACE="/my path" OTHER=1` yields two words and
+# not three. Deliberately not `eval` or `set --`: the input is seed content, and
+# word-splitting it through the shell would execute the substitutions inside it.
+sd_split_words() {
+  local s="$1" out="" q="" c i n=${#1}
+  for ((i = 0; i < n; i++)); do
+    c="${s:i:1}"
+    if [ -n "$q" ]; then
+      out="$out$c"
+      [ "$c" = "$q" ] && q=""
+      continue
+    fi
+    case "$c" in
+      \" | \')
+        q="$c"
+        out="$out$c"
+        ;;
+      ' ' | $'\t') out="$out"$'\n' ;;
+      *) out="$out$c" ;;
+    esac
+  done
+  printf '%s\n' "$out"
+}
+
+# The single grammar for a per-project templated declaration, shared by the drop
+# rule in sd_normalize_code_line and the whole-file check in
+# sd_templated_var_problems. Exactly one place decides what one of these
+# declarations IS and whether its RHS is a plain literal: two copies of that
+# question drifting apart is precisely how a line gets dropped from the diff by
+# one rule and then missed by the other.
+#
+# With no $2 the question is "is this line, as a whole, a lone literal
+# declaration?" - the drop rule's question. With $2 it is "does this line
+# declare THAT variable, and how?" - the whole-file check's question.
+#
+#   0 - a declaration with a plain literal RHS   => dropped from comparison
+#   2 - a declaration with any other RHS         => kept, and reported
+#   1 - not one of these declarations at all
 sd_classify_templated_assignment() {
-  local line="$1" rhs inner
+  local line="$1" want="${2:-}" rhs inner word name kw=0 found=1
+  local words=() w
   line="${line#"${line%%[![:space:]]*}"}"
   # Declaration prefixes, kept identical on both sides of the shared grammar.
   # `export` matters: a seed that exports WORKSPACE has declared it just as much
@@ -371,41 +411,82 @@ sd_classify_templated_assignment() {
   # the definedness check is the inconsistency this function exists to prevent.
   case "$line" in
     export\ * | declare\ * | readonly\ * | typeset\ * | local\ *)
+      kw=1
       line="${line#* }"
       line="${line#"${line%%[![:space:]]*}"}"
+      # EVERY option word, not just the first: `declare -x -r WORKSPACE=...` and
+      # `local -r WORKSPACE=...` are declarations too, and stopping after one
+      # leaves the option looking like the variable name - which reports a
+      # perfectly well-defined WORKSPACE as never assigned.
+      while :; do
+        case "$line" in
+          -*)
+            case "$line" in
+              *' '*)
+                line="${line#* }"
+                line="${line#"${line%%[![:space:]]*}"}"
+                ;;
+              # Options and nothing else.
+              *) return 1 ;;
+            esac
+            ;;
+          *) break ;;
+        esac
+      done
       ;;
   esac
-  case "$line" in
-    SEED_USER=* | WORKSPACE=*) ;;
-    *) return 1 ;;
-  esac
-  rhs="${line#*=}"
-  case "$rhs" in
-    # Single quotes suppress every expansion, so the content is literal whatever
-    # it holds - but the closing quote must be the LAST character, or what looks
-    # like a quoted value is really a quoted value followed by more command.
-    \'*\')
-      inner="${rhs%\'}" inner="${inner#\'}"
-      case "$inner" in *\'*) return 2 ;; esac
-      return 0
-      ;;
-    \"*\")
-      inner="${rhs%\"}" inner="${inner#\"}"
-      case "$inner" in *'$'* | *'`'* | *'"'*) return 2 ;; esac
-      return 0
-      ;;
-    # Unquoted: an allowlist of characters a literal path can contain, so every
-    # form carrying shell syntax - `WORKSPACE=/w;true`, `WORKSPACE=<(pwd)`,
-    # `WORKSPACE=~`, a glob, a prefix assignment with a trailing command - is
-    # rejected rather than silently dropped from the comparison. Rejecting is
-    # the safe direction: a rejected line is kept and shows up as drift.
-    *)
-      case "$rhs" in
-        *[!A-Za-z0-9_/.:@%+,-]*) return 2 ;;
-      esac
-      return 0
-      ;;
-  esac
+  while IFS= read -r w; do
+    [ -n "$w" ] || continue
+    words+=("$w")
+  done <<<"$(sd_split_words "$line")"
+  [ "${#words[@]}" -gt 0 ] || return 1
+  # Without a declaration keyword, only a LONE `NAME=VALUE` line declares
+  # anything: `WORKSPACE=/w cmd` is a prefix assignment scoped to that one
+  # command, so it must not count as defining WORKSPACE for the rest of the
+  # seed. With a keyword, every word is a declaration.
+  if [ "$kw" -eq 0 ] && [ "${#words[@]}" -ne 1 ]; then
+    return 1
+  fi
+  # The drop rule never removes a line that does more than one thing: whatever
+  # else it assigns is information the diff still needs.
+  if [ -z "$want" ] && [ "${#words[@]}" -ne 1 ]; then
+    return 1
+  fi
+  for word in "${words[@]}"; do
+    case "$word" in *=*) ;; *) continue ;; esac
+    name="${word%%=*}"
+    case "$name" in
+      SEED_USER | WORKSPACE) ;;
+      *) continue ;;
+    esac
+    [ -z "$want" ] || [ "$name" = "$want" ] || continue
+    rhs="${word#*=}"
+    case "$rhs" in
+      # Single quotes suppress every expansion, so the content is literal
+      # whatever it holds - but the closing quote must be the LAST character, or
+      # what looks like a quoted value is a quoted value followed by more.
+      \'*\')
+        inner="${rhs%\'}" inner="${inner#\'}"
+        case "$inner" in *\'*) return 2 ;; esac
+        ;;
+      \"*\")
+        inner="${rhs%\"}" inner="${inner#\"}"
+        case "$inner" in *'$'* | *'`'* | *'"'*) return 2 ;; esac
+        ;;
+      # Unquoted: an allowlist of characters a literal path can contain, so
+      # every form carrying shell syntax - `WORKSPACE=/w;true`,
+      # `WORKSPACE=<(pwd)`, `WORKSPACE=~`, a glob - is rejected rather than
+      # silently dropped. Rejecting is the safe direction: a rejected line is
+      # kept and shows up as drift.
+      *)
+        case "$rhs" in
+          *[!A-Za-z0-9_/.:@%+,-]*) return 2 ;;
+        esac
+        ;;
+    esac
+    found=0
+  done
+  return "$found"
 }
 
 sd_normalize_code_line() {
@@ -680,10 +761,10 @@ sd_templated_var_problems() {
     while IFS=$'\t' read -r _ _ tag text; do
       [ "$tag" = C ] || continue
       cls=0
-      sd_classify_templated_assignment "$text" || cls=$?
+      sd_classify_templated_assignment "$text" "$var" || cls=$?
       case "$cls" in
-        0) case "$text" in *"$var"=*) assigned=1 ;; esac ;;
-        2) case "$text" in *"$var"=*) assigned=1 derived=1 ;; esac ;;
+        0) assigned=1 ;;
+        2) assigned=1 derived=1 ;;
       esac
     done <"$scan"
     if [ "$derived" = 1 ]; then
@@ -696,13 +777,23 @@ sd_templated_var_problems() {
       # `${v#...}`, `${v/...}`, `${v:?...}`, `${v:0:3}`, `${#v}`) aborts, so it
       # is a read. The trailing word-character exclusions keep `${WORKSPACE_X}`
       # and `$WORKSPACE_X` from counting as uses of WORKSPACE.
+      #
+      # The text is reconstructed from $0 rather than read out of $4: a scan
+      # record is para/lineno/tag/text, and a seed line containing its own tab
+      # (an indented one, most of them) splits that text across $4, $5, ... so
+      # matching $4 alone silently misses the reference and lets an undefined
+      # variable through.
       awk -F'\t' -v v="$var" '
         $3 != "C" { next }
-        $4 ~ ("\\$" v "([^A-Za-z0-9_]|$)") { used = 1 }
-        $4 ~ ("\\$\\{" v "\\}") { used = 1 }
-        $4 ~ ("\\$\\{" v ":[^-=+]") { used = 1 }
-        $4 ~ ("\\$\\{" v "[^:=+}A-Za-z0-9_-]") { used = 1 }
-        $4 ~ ("\\$\\{#" v "[^A-Za-z0-9_]") { used = 1 }
+        {
+          t = $0
+          if (sub(/^[^\t]*\t[^\t]*\t[^\t]*\t/, "", t) == 0) next
+        }
+        t ~ ("\\$" v "([^A-Za-z0-9_]|$)") { used = 1 }
+        t ~ ("\\$\\{" v "\\}") { used = 1 }
+        t ~ ("\\$\\{" v ":[^-=+]") { used = 1 }
+        t ~ ("\\$\\{" v "[^:=+}A-Za-z0-9_-]") { used = 1 }
+        t ~ ("\\$\\{#" v "[^A-Za-z0-9_]") { used = 1 }
         END { exit used ? 0 : 1 }
       ' "$scan"; then
       printf '%s\tundefined\n' "$var"

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -352,34 +352,74 @@ sd_drop_priv_prefix() {
 #
 # The definedness check in sd_check_seed is the compensating guard: block
 # comparison no longer notices a seed that never assigns these at all.
-sd_is_templated_assignment() {
-  case "$1" in
+# The single grammar for a per-project templated declaration, shared by the drop
+# rule in sd_normalize_code_line and the whole-file check in
+# sd_templated_var_problems. Exactly one place decides what one of these
+# declarations IS and whether its RHS is a plain literal: two copies of that
+# question drifting apart is precisely how a line gets dropped from the diff by
+# one rule and then missed by the other.
+#
+#   0 - a declaration with a plain literal RHS   => dropped from comparison
+#   2 - a declaration with any other RHS         => kept, and reported
+#   1 - not one of these declarations at all
+sd_classify_templated_assignment() {
+  local line="$1" rhs inner
+  line="${line#"${line%%[![:space:]]*}"}"
+  # Declaration prefixes, kept identical on both sides of the shared grammar.
+  # `export` matters: a seed that exports WORKSPACE has declared it just as much
+  # as a bare assignment does, and rejecting the form here while accepting it in
+  # the definedness check is the inconsistency this function exists to prevent.
+  case "$line" in
+    export\ * | declare\ * | readonly\ * | typeset\ * | local\ *)
+      line="${line#* }"
+      line="${line#"${line%%[![:space:]]*}"}"
+      ;;
+  esac
+  case "$line" in
     SEED_USER=* | WORKSPACE=*) ;;
     *) return 1 ;;
   esac
-  local rhs="${1#*=}"
-  # Strip one layer of matching quotes; a literal path needs no more than that.
+  rhs="${line#*=}"
   case "$rhs" in
-    \"*\") rhs="${rhs%\"}" rhs="${rhs#\"}" ;;
-    \'*\') rhs="${rhs%\'}" rhs="${rhs#\'}" ;;
+    # Single quotes suppress every expansion, so the content is literal whatever
+    # it holds - but the closing quote must be the LAST character, or what looks
+    # like a quoted value is really a quoted value followed by more command.
+    \'*\')
+      inner="${rhs%\'}" inner="${inner#\'}"
+      case "$inner" in *\'*) return 2 ;; esac
+      return 0
+      ;;
+    \"*\")
+      inner="${rhs%\"}" inner="${inner#\"}"
+      case "$inner" in *'$'* | *'`'* | *'"'*) return 2 ;; esac
+      return 0
+      ;;
+    # Unquoted: an allowlist of characters a literal path can contain, so every
+    # form carrying shell syntax - `WORKSPACE=/w;true`, `WORKSPACE=<(pwd)`,
+    # `WORKSPACE=~`, a glob, a prefix assignment with a trailing command - is
+    # rejected rather than silently dropped from the comparison. Rejecting is
+    # the safe direction: a rejected line is kept and shows up as drift.
+    *)
+      case "$rhs" in
+        *[!A-Za-z0-9_/.:@%+,-]*) return 2 ;;
+      esac
+      return 0
+      ;;
   esac
-  case "$rhs" in
-    *'$'* | *'`'*) return 1 ;;
-    # An unquoted RHS with whitespace is `WORKSPACE=/x cmd ...` - a prefix
-    # assignment to some other command, not the declaration we mean to drop.
-    *[[:space:]]*) [ "$rhs" != "${1#*=}" ] || return 1 ;;
-  esac
-  return 0
 }
 
 sd_normalize_code_line() {
-  local line="$1"
+  local line="$1" cls=0
   line="${line//$'\t'/ }"
   while [ "$line" != "${line//  / }" ]; do line="${line//  / }"; done
   line="${line#"${line%%[![:space:]]*}"}"
   line="${line%"${line##*[![:space:]]}"}"
   [ -n "$line" ] || return 0
-  sd_is_templated_assignment "$line" && return 0
+  # Only a LITERAL declaration is dropped. A derived one stays in the diff and
+  # is reported by the whole-file check as well, so that it is caught wherever
+  # the seed happens to put it.
+  sd_classify_templated_assignment "$line" || cls=$?
+  [ "$cls" -ne 0 ] || return 0
   line=$(sd_drop_priv_prefix "$line")
   [ -n "$line" ] || return 0
   printf '%s\n' "$line" | sd_neutralize_paths
@@ -607,30 +647,65 @@ sd_report_thin() {
     "$1" "$2" "$SD_THIN_WINDOW"
 }
 
-# Names every per-project variable the seed READS but never ASSIGNS. This is
-# the compensating guard for the drop rule in sd_normalize_code_line: once those
-# assignments are excluded from block comparison, "the seed hoisted it into its
-# variable block" and "the seed never defines it at all" look identical to the
-# diff. The second is the failure mode catch-up-local-seed.md calls the main way
-# the task goes wrong - under `set -euo pipefail` the first expansion aborts the
-# whole seed and surfaces as an unrelated-looking container start error - so it
-# is checked directly instead of being left to a block verdict that no longer
-# covers it. Reported on the host, before a rebuild, rather than in a log.
+# Names every per-project templated variable this seed gets WRONG, as
+# `VAR<TAB>KIND` with KIND one of `undefined` or `derived`. Both are whole-file
+# questions on purpose: block comparison cannot answer either one, and must not
+# be relied on to.
+#
+#   undefined - the seed reads the variable but never declares it. This is the
+#               compensating guard for the drop rule: once those declarations
+#               are excluded from comparison, "hoisted into the variable block"
+#               and "never defined at all" look identical to the diff. The
+#               second is the failure mode catch-up-local-seed.md calls the main
+#               way the task goes wrong - under `set -euo pipefail` the first
+#               expansion aborts the whole seed and surfaces as an
+#               unrelated-looking container start error.
+#   derived   - the declaration exists but is computed. The doc forbids this for
+#               WORKSPACE: the seed is mounted at an arbitrary container path
+#               that need not sit inside the checkout, so `git rev-parse` from
+#               there resolves to the wrong tree. Checked here rather than left
+#               to a block verdict because a derived declaration hoisted into
+#               the variable block never lands in a compared window at all - the
+#               same placement blindness the drop rule was written to remove.
 #
 # Reads the scan, not the file: `C` records have already had trailing comments
 # stripped, so a `$WORKSPACE` mentioned only in a comment is not a reference.
-# `${VAR:-...}` is deliberately not a reference either - a defaulted expansion
-# is exactly the shape that survives an undefined variable.
-sd_undefined_templated_vars() {
-  local scan="$1" var
+sd_templated_var_problems() {
+  local scan="$1" var tag text cls assigned derived
   for var in WORKSPACE SEED_USER; do
-    if awk -F'\t' -v v="$var" '
-      $3 != "C" { next }
-      $4 ~ ("^[[:space:]]*((export|declare|readonly|local)[[:space:]]+)?" v "=") { set = 1 }
-      $4 ~ ("\\$" v "([^A-Za-z0-9_]|$)") || $4 ~ ("\\$\\{" v "\\}") { used = 1 }
-      END { exit (used && !set) ? 0 : 1 }
-    ' "$scan"; then
-      printf '%s\n' "$var"
+    assigned=0
+    derived=0
+    # The declaration side goes through the shared grammar, in bash, so the
+    # answer here cannot disagree with what sd_normalize_code_line dropped.
+    while IFS=$'\t' read -r _ _ tag text; do
+      [ "$tag" = C ] || continue
+      cls=0
+      sd_classify_templated_assignment "$text" || cls=$?
+      case "$cls" in
+        0) case "$text" in *"$var"=*) assigned=1 ;; esac ;;
+        2) case "$text" in *"$var"=*) assigned=1 derived=1 ;; esac ;;
+      esac
+    done <"$scan"
+    if [ "$derived" = 1 ]; then
+      printf '%s\tderived\n' "$var"
+    elif [ "$assigned" = 0 ] &&
+      # The read side stays in awk, which is where the regex work belongs.
+      # A braced expansion counts as a read unless its operator TOLERATES an
+      # unset parameter - `:-` `:=` `:+` and their colonless forms substitute a
+      # default and survive `set -u`. Everything else (`${v}`, `${v%...}`,
+      # `${v#...}`, `${v/...}`, `${v:?...}`, `${v:0:3}`, `${#v}`) aborts, so it
+      # is a read. The trailing word-character exclusions keep `${WORKSPACE_X}`
+      # and `$WORKSPACE_X` from counting as uses of WORKSPACE.
+      awk -F'\t' -v v="$var" '
+        $3 != "C" { next }
+        $4 ~ ("\\$" v "([^A-Za-z0-9_]|$)") { used = 1 }
+        $4 ~ ("\\$\\{" v "\\}") { used = 1 }
+        $4 ~ ("\\$\\{" v ":[^-=+]") { used = 1 }
+        $4 ~ ("\\$\\{" v "[^:=+}A-Za-z0-9_-]") { used = 1 }
+        $4 ~ ("\\$\\{#" v "[^A-Za-z0-9_]") { used = 1 }
+        END { exit used ? 0 : 1 }
+      ' "$scan"; then
+      printf '%s\tundefined\n' "$var"
     fi
   done
   return 0
@@ -638,7 +713,7 @@ sd_undefined_templated_vars() {
 
 sd_check_seed() {
   local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
-  local behind ahead nb na est tst tsize esize docrows undef var
+  local behind ahead nb na est tst tsize esize docrows problems pvar pkind
   name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
   printf '%s  %s\n' "$name" "$seed"
   if ! bash -n "$seed" 2>/dev/null; then
@@ -658,12 +733,21 @@ sd_check_seed() {
   fi
   # rc, not `return 2`: the block verdicts are still worth printing, and this
   # is a whole-file finding that none of them depends on.
-  undef=$(sd_undefined_templated_vars "$sscan")
-  if [ -n "$undef" ]; then
-    for var in $undef; do
-      sd_report_block ERROR '(whole file)' "seed reads \$$var but never assigns it"
-    done
-    sd_report_action 'define it in the seed variable block; see catch-up-local-seed.md'
+  problems=$(sd_templated_var_problems "$sscan")
+  if [ -n "$problems" ]; then
+    while IFS=$'\t' read -r pvar pkind; do
+      [ -n "$pvar" ] || continue
+      case "$pkind" in
+        undefined)
+          sd_report_block ERROR '(whole file)' "seed reads \$$pvar but never assigns it"
+          sd_report_action 'define it in the seed variable block; see catch-up-local-seed.md'
+          ;;
+        derived)
+          sd_report_block ERROR '(whole file)' "seed derives $pvar instead of assigning a literal"
+          sd_report_action 'the container path need not sit inside the checkout; use a literal'
+          ;;
+      esac
+    done <<<"$problems"
     rc=2
   fi
   sd_tmp tnorm || return 2

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -327,6 +327,51 @@ sd_drop_priv_prefix() {
   printf '%s' "$line"
 }
 
+# Per-project assignments the template carries as `{USER}` / `{WORKSPACE}`
+# placeholders, for which every rendered seed necessarily holds a different
+# literal. Dropping them from BOTH sides is what makes the two shapes the fleet
+# actually uses compare equal:
+#
+#   inline  - the seed keeps `WORKSPACE="/workspaces/x"` where the template has
+#             `WORKSPACE="{WORKSPACE}"`, inside a compared window. A value
+#             mismatch: 1 line behind AND 1 ahead, reported as DIVERGED.
+#   hoisted - the seed lifts the assignment into its variable block, far above
+#             every anchor. A placement mismatch: the template's line has no
+#             counterpart in the window at all, reported as BEHIND.
+#
+# Neutralizing the placeholder to its value would only fix the first shape.
+# Dropping the line fixes both, because a window that no longer contains it on
+# either side compares equal whether the seed hoisted it or not.
+#
+# LITERAL RHS ONLY. catch-up-local-seed.md is explicit that WORKSPACE must not
+# be derived - the seed is mounted at an arbitrary container path that need not
+# sit inside the checkout, so `git rev-parse` from there resolves to the wrong
+# tree. A seed that regressed to `WORKSPACE="$(git rev-parse --show-toplevel)"`
+# must still be flagged, so anything containing `$`, a backtick or `$(` is kept
+# and drifts against the template's dropped literal.
+#
+# The definedness check in sd_check_seed is the compensating guard: block
+# comparison no longer notices a seed that never assigns these at all.
+sd_is_templated_assignment() {
+  case "$1" in
+    SEED_USER=* | WORKSPACE=*) ;;
+    *) return 1 ;;
+  esac
+  local rhs="${1#*=}"
+  # Strip one layer of matching quotes; a literal path needs no more than that.
+  case "$rhs" in
+    \"*\") rhs="${rhs%\"}" rhs="${rhs#\"}" ;;
+    \'*\') rhs="${rhs%\'}" rhs="${rhs#\'}" ;;
+  esac
+  case "$rhs" in
+    *'$'* | *'`'*) return 1 ;;
+    # An unquoted RHS with whitespace is `WORKSPACE=/x cmd ...` - a prefix
+    # assignment to some other command, not the declaration we mean to drop.
+    *[[:space:]]*) [ "$rhs" != "${1#*=}" ] || return 1 ;;
+  esac
+  return 0
+}
+
 sd_normalize_code_line() {
   local line="$1"
   line="${line//$'\t'/ }"
@@ -334,6 +379,7 @@ sd_normalize_code_line() {
   line="${line#"${line%%[![:space:]]*}"}"
   line="${line%"${line##*[![:space:]]}"}"
   [ -n "$line" ] || return 0
+  sd_is_templated_assignment "$line" && return 0
   line=$(sd_drop_priv_prefix "$line")
   [ -n "$line" ] || return 0
   printf '%s\n' "$line" | sd_neutralize_paths
@@ -561,9 +607,38 @@ sd_report_thin() {
     "$1" "$2" "$SD_THIN_WINDOW"
 }
 
+# Names every per-project variable the seed READS but never ASSIGNS. This is
+# the compensating guard for the drop rule in sd_normalize_code_line: once those
+# assignments are excluded from block comparison, "the seed hoisted it into its
+# variable block" and "the seed never defines it at all" look identical to the
+# diff. The second is the failure mode catch-up-local-seed.md calls the main way
+# the task goes wrong - under `set -euo pipefail` the first expansion aborts the
+# whole seed and surfaces as an unrelated-looking container start error - so it
+# is checked directly instead of being left to a block verdict that no longer
+# covers it. Reported on the host, before a rebuild, rather than in a log.
+#
+# Reads the scan, not the file: `C` records have already had trailing comments
+# stripped, so a `$WORKSPACE` mentioned only in a comment is not a reference.
+# `${VAR:-...}` is deliberately not a reference either - a defaulted expansion
+# is exactly the shape that survives an undefined variable.
+sd_undefined_templated_vars() {
+  local scan="$1" var
+  for var in WORKSPACE SEED_USER; do
+    if awk -F'\t' -v v="$var" '
+      $3 != "C" { next }
+      $4 ~ ("^[[:space:]]*((export|declare|readonly|local)[[:space:]]+)?" v "=") { set = 1 }
+      $4 ~ ("\\$" v "([^A-Za-z0-9_]|$)") || $4 ~ ("\\$\\{" v "\\}") { used = 1 }
+      END { exit (used && !set) ? 0 : 1 }
+    ' "$scan"; then
+      printf '%s\n' "$var"
+    fi
+  done
+  return 0
+}
+
 sd_check_seed() {
   local seed="$1" name rc=0 block anchor verdict tnorm snorm sscan
-  local behind ahead nb na est tst tsize esize docrows
+  local behind ahead nb na est tst tsize esize docrows undef var
   name=$(basename -- "$(dirname -- "$(dirname -- "$seed")")")
   printf '%s  %s\n' "$name" "$seed"
   if ! bash -n "$seed" 2>/dev/null; then
@@ -580,6 +655,16 @@ sd_check_seed() {
     sd_report_block ERROR '(whole file)' 'seed could not be scanned'
     sd_report_action 'check the seed parses; see catch-up-local-seed.md Step 3'
     return 2
+  fi
+  # rc, not `return 2`: the block verdicts are still worth printing, and this
+  # is a whole-file finding that none of them depends on.
+  undef=$(sd_undefined_templated_vars "$sscan")
+  if [ -n "$undef" ]; then
+    for var in $undef; do
+      sd_report_block ERROR '(whole file)' "seed reads \$$var but never assigns it"
+    done
+    sd_report_action 'define it in the seed variable block; see catch-up-local-seed.md'
+    rc=2
   fi
   sd_tmp tnorm || return 2
   sd_tmp snorm || return 2

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -412,6 +412,15 @@ sd_classify_templated_assignment() {
   case "$line" in
     export\ * | declare\ * | readonly\ * | typeset\ * | local\ *)
       kw=1
+      # `local` does NOT declare a whole-file variable: bash refuses it outside
+      # a function outright, and inside one the binding dies with the call, so a
+      # top-level read afterwards still aborts under `set -u`. Treating it as an
+      # assignment would silence exactly the failure this check exists to catch.
+      # It stays a declaration for the DROP rule, where the question is only
+      # whether the line is a per-project value the diff should ignore.
+      case "$line" in
+        local\ *) [ -z "$want" ] || return 1 ;;
+      esac
       line="${line#* }"
       line="${line#"${line%%[![:space:]]*}"}"
       # EVERY option word, not just the first: `declare -x -r WORKSPACE=...` and

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -1515,7 +1515,7 @@ SEEDEOF
   [[ "$output" != *BEHIND* ]]
 }
 
-@test "a DERIVED WORKSPACE is still flagged, not dropped" {
+@test "an INLINE derived WORKSPACE is an ERROR, not merely drift" {
   t7_setup
   t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
   cat >"$TPL" <<'TPLEOF'
@@ -1528,7 +1528,9 @@ TPLEOF
   # catch-up-local-seed.md is explicit that WORKSPACE must not be derived: the
   # seed is mounted at an arbitrary container path that need not sit inside the
   # checkout, so `git rev-parse` from there resolves to the wrong tree. The drop
-  # rule is literal-RHS-only precisely so this regression still surfaces.
+  # rule is literal-RHS-only precisely so this regression still surfaces - and
+  # since it breaks the seed rather than merely dating it, it is an ERROR at
+  # exit 2 rather than a drift verdict at exit 1.
   cat >"$SEED" <<'SEEDEOF'
 #!/usr/bin/env bash
 
@@ -1537,9 +1539,9 @@ overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*'
 echo "$overlay_links"
 SEEDEOF
   t7_run "$SEED"
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"Overlay-link gitignore"* ]]
-  [[ "$output" == *AHEAD* || "$output" == *DIVERGED* ]]
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  [[ "$output" == *"derives WORKSPACE"* ]]
 }
 
 @test "a seed that READS \$WORKSPACE but never assigns it is an ERROR at exit 2" {
@@ -1601,7 +1603,15 @@ SEEDEOF
   # is the whole argument for the check being mandatory rather than a nicety:
   # without it the drop rule trades a false positive for a false NEGATIVE on the
   # documented fatal case.
-  sed -i '/^  undef=\$(sd_undefined_templated_vars/,/^  fi$/d' "$T7_TOOL"
+  # Not `sed -i`: BSD sed takes a MANDATORY backup-suffix argument to -i, so on
+  # macOS the range expression is consumed as the suffix and the tool path is
+  # then read as the script. Write to a temp and mv it back instead.
+  sed '/^  problems=\$(sd_templated_var_problems/,/^  fi$/d' \
+    "$T7_TOOL" >"$BATS_TEST_TMPDIR/sabotaged"
+  mv "$BATS_TEST_TMPDIR/sabotaged" "$T7_TOOL"
+  chmod +x "$T7_TOOL"
+  # The excision must actually have happened, or this test passes vacuously.
+  ! grep -q 'sd_templated_var_problems "\$sscan"' "$T7_TOOL"
   cat >"$TPL" <<'TPLEOF'
 #!/usr/bin/env bash
 
@@ -1618,6 +1628,116 @@ SEEDEOF
   t7_run_tool "$T7_TOOL" "$SEED"
   [ "$status" -eq 0 ]
   [[ "$output" != *ERROR* ]]
+}
+
+@test "a HOISTED derived declaration is an ERROR, not invisible" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # The inline case above is caught by the block diff, but only because the
+  # declaration happens to sit in the compared window. Hoisted into the variable
+  # block it lands in no window at all - so placement, not correctness, would
+  # decide whether the seed's most dangerous regression is reported. Checked
+  # whole-file for exactly that reason.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="$(git rev-parse --show-toplevel)"
+
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  [[ "$output" == *"derives WORKSPACE"* ]]
+}
+
+@test "an unsafe braced read of an unassigned WORKSPACE is an ERROR" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd /w && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # `${v%/}` aborts under `set -u` exactly as `$v` does, so it is a read. Only
+  # the operators that substitute a default survive an unset parameter.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd "${WORKSPACE%/}" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  [[ "$output" == *"never assigns it"* ]]
+}
+
+@test "a defaulted \${WORKSPACE:-...} read is not a reference" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd "${WORKSPACE:-/w}" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # The control case for the test above: a defaulted expansion is precisely the
+  # shape that SURVIVES an unset parameter, so it must not raise the ERROR.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd "${WORKSPACE:-/w}" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *ERROR* ]]
+}
+
+@test "the templated-assignment grammar accepts declarations and rejects shell syntax" {
+  # Exercised through the tool's own function via sd_source, because the point
+  # of the shared grammar is that ONE definition answers this for both the drop
+  # rule and the whole-file check. 0 = literal declaration (dropped from the
+  # comparison), 2 = declaration with a non-literal RHS (kept and reported),
+  # 1 = not one of these declarations at all.
+  local good bad other
+  for good in 'WORKSPACE="/app"' "WORKSPACE='/app'" 'WORKSPACE=/app' \
+    'SEED_USER="vscode"' 'export WORKSPACE="/app"' 'readonly SEED_USER="node"' \
+    'WORKSPACE="{WORKSPACE}"'; do
+    sd_source sd_classify_templated_assignment "$good"
+    [ "$status" -eq 0 ] || {
+      echo "expected literal (0), got $status for: $good"
+      false
+    }
+  done
+  # Every one of these passed the old `$`/backtick/whitespace heuristic and so
+  # was silently dropped from the comparison.
+  for bad in 'WORKSPACE=/w;true' 'WORKSPACE=~' 'WORKSPACE=<(pwd)' \
+    'WORKSPACE="$(git rev-parse --show-toplevel)"' 'WORKSPACE=`pwd`' \
+    'WORKSPACE=/w cmd' 'WORKSPACE="/w" "x"' 'WORKSPACE=/w*'; do
+    sd_source sd_classify_templated_assignment "$bad"
+    [ "$status" -eq 2 ] || {
+      echo "expected non-literal (2), got $status for: $bad"
+      false
+    }
+  done
+  for other in 'PATH=/usr/bin' 'echo "$WORKSPACE"' 'WORKSPACES="/x"'; do
+    sd_source sd_classify_templated_assignment "$other"
+    [ "$status" -eq 1 ] || {
+      echo "expected not-a-declaration (1), got $status for: $other"
+      false
+    }
+  done
 }
 
 @test "<<< herestrings are not heredoc openers" {

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -1408,6 +1408,8 @@ TPLEOF
   cat >"$SEED" <<'SEEDEOF'
 #!/usr/bin/env bash
 
+WORKSPACE="/w"
+
 GI_MARK_BEGIN="# >>> overlay symlinks (auto, do not edit) >>>"
 GI_MARK_END="# << overlay symlinks (auto) <<"
 overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
@@ -1439,6 +1441,8 @@ TPLEOF
   cat >"$SEED" <<'SEEDEOF'
 #!/usr/bin/env bash
 
+WORKSPACE="/w"
+
 overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*/.dotfiles/projects/*' -print)"
 echo "$overlay_links"
 SEEDEOF
@@ -1447,6 +1451,173 @@ SEEDEOF
   [[ "$output" == *MISSING* ]]
   [[ "$output" == *"Overlay-link gitignore"* ]]
   [[ "$output" == *"Step 2"* ]]
+}
+
+# --- per-project templated assignments (SEED_USER / WORKSPACE) ---------------
+#
+# The template carries these as `{USER}` / `{WORKSPACE}` placeholders, so every
+# rendered seed necessarily holds a different literal and no seed can ever match
+# the template on that line. The fleet writes them in two shapes and BOTH must
+# read ok; the compensating definedness check is what keeps that from hiding a
+# seed that never assigns them at all.
+
+@test "an INLINE templated assignment reads ok despite the placeholder" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # Same paragraph as the anchor, so the assignment lands INSIDE the compared
+  # window: without the drop rule this is a value mismatch — 1 behind AND
+  # 1 ahead — and reports DIVERGED.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="/workspaces/demo"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *DIVERGED* ]]
+  [[ "$output" != *BEHIND* ]]
+}
+
+@test "a HOISTED templated assignment reads ok despite sitting in the variable block" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # Lifted into its own paragraph far from the anchor — the shape wanderer-kills,
+  # wanderer and slabledger all use. The template's line then has no counterpart
+  # in the window at all: a PLACEMENT mismatch reporting BEHIND, which is why
+  # neutralizing the placeholder to its value would not have been enough.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="/app"
+
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *DIVERGED* ]]
+  [[ "$output" != *BEHIND* ]]
+}
+
+@test "a DERIVED WORKSPACE is still flagged, not dropped" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # catch-up-local-seed.md is explicit that WORKSPACE must not be derived: the
+  # seed is mounted at an arbitrary container path that need not sit inside the
+  # checkout, so `git rev-parse` from there resolves to the wrong tree. The drop
+  # rule is literal-RHS-only precisely so this regression still surfaces.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="$(git rev-parse --show-toplevel)"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Overlay-link gitignore"* ]]
+  [[ "$output" == *AHEAD* || "$output" == *DIVERGED* ]]
+}
+
+@test "a seed that READS \$WORKSPACE but never assigns it is an ERROR at exit 2" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # The failure catch-up-local-seed.md calls the main way the task goes wrong:
+  # under `set -euo pipefail` the first expansion aborts the WHOLE seed and
+  # surfaces as an unrelated-looking container start error. Once the drop rule
+  # excludes these assignments from block comparison, "hoisted" and "never
+  # defined" look identical to the diff — so it is checked directly instead.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  [[ "$output" == *'$WORKSPACE'* ]]
+  [[ "$output" == *"never assigns it"* ]]
+}
+
+@test "a \$WORKSPACE mentioned only in a comment is not a reference" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd /w && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # The check reads `C` scan records, which have had trailing comments stripped,
+  # so this must not trip the definedness ERROR.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+# $WORKSPACE is deliberately not used by this seed
+overlay_links="$(cd /w && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *ERROR* ]]
+}
+
+@test "sabotage: dropping templated assignments without the definedness check hides an undefined WORKSPACE" {
+  t7_setup
+  t7_copy_tool
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  # Excise the guard from the copy and confirm the seed above goes quiet. This
+  # is the whole argument for the check being mandatory rather than a nicety:
+  # without it the drop rule trades a false positive for a false NEGATIVE on the
+  # documented fatal case.
+  sed -i '/^  undef=\$(sd_undefined_templated_vars/,/^  fi$/d' "$T7_TOOL"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run_tool "$T7_TOOL" "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *ERROR* ]]
 }
 
 @test "<<< herestrings are not heredoc openers" {

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -1642,11 +1642,12 @@ TPLEOF
   # after the FIRST word past the keyword leaves `-x` looking like the variable
   # name, and the seed is then reported as never assigning a variable it plainly
   # assigns — a false ERROR that sends the reader to fix a non-problem.
+  # `local` is deliberately NOT here; see the function-scope test below.
   local decl
   for decl in \
     'declare -x WORKSPACE="/w"' \
     'declare -x -r WORKSPACE="/w"' \
-    'local -r WORKSPACE="/w"' \
+    'typeset -r WORKSPACE="/w"' \
     'export FOO=1 WORKSPACE="/w"'; do
     cat >"$SEED" <<SEEDEOF
 #!/usr/bin/env bash
@@ -1667,6 +1668,39 @@ SEEDEOF
       return 1
     }
   done
+}
+
+@test "a function-local WORKSPACE does not define it for the rest of the seed" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # `local` binds for the duration of the CALL, so the read below still hits an
+  # unset variable and aborts the whole seed under `set -u` — the documented
+  # fatal case. Counting it as a declaration alongside export/declare/readonly
+  # would silence exactly the failure this check exists to catch. (Bash also
+  # rejects `local` outside a function outright, so there is no top-level form
+  # of it that declares anything either.)
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+seed_paths() {
+  local -r WORKSPACE="/w"
+  echo "inside $WORKSPACE"
+}
+seed_paths
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  [[ "$output" == *"never assigns it"* ]]
 }
 
 @test "a prefix assignment does not count as defining WORKSPACE" {
@@ -1862,6 +1896,15 @@ SEEDEOF
       false
     }
   done
+  # The one form whose answer depends on which question is being asked: `local`
+  # is a per-project value the drop rule may ignore, but it is NOT a whole-file
+  # declaration, because the binding dies with the function call.
+  sd_source sd_classify_templated_assignment 'local -r WORKSPACE="/w"'
+  [ "$status" -eq 0 ]
+  sd_source sd_classify_templated_assignment 'local -r WORKSPACE="/w"' WORKSPACE
+  [ "$status" -eq 1 ]
+  sd_source sd_classify_templated_assignment 'declare -r WORKSPACE="/w"' WORKSPACE
+  [ "$status" -eq 0 ]
 }
 
 @test "<<< herestrings are not heredoc openers" {

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -1572,6 +1572,103 @@ SEEDEOF
   [[ "$output" == *"never assigns it"* ]]
 }
 
+@test "a \$WORKSPACE read on a TAB-INDENTED line is still a reference" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+if true; then
+	overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+	echo "$overlay_links"
+fi
+TPLEOF
+  # A scan record is para/lineno/tag/text, tab-delimited. A seed line carrying
+  # its own tab — an indented one, which is most of them — splits that text
+  # across $4, $5, ... so a check that matches $4 alone sees `overlay_links="$(cd`
+  # and misses the reference entirely. That is a false NEGATIVE on the
+  # documented fatal case, which is the one direction this must never fail in.
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    '' \
+    'if true; then' \
+    $'\toverlay_links="$(cd "$WORKSPACE" && find . -type l -lname '"'"'*dotfiles/projects/*'"'"' -print)"' \
+    $'\techo "$overlay_links"' \
+    'fi' >"$SEED"
+  grep -q $'\toverlay_links' "$SEED"
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *ERROR* ]]
+  [[ "$output" == *"never assigns it"* ]]
+}
+
+@test "declare/local/export forms count as assigning WORKSPACE" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # Every one of these declares WORKSPACE for the rest of the seed. Stopping
+  # after the FIRST word past the keyword leaves `-x` looking like the variable
+  # name, and the seed is then reported as never assigning a variable it plainly
+  # assigns — a false ERROR that sends the reader to fix a non-problem.
+  local decl
+  for decl in \
+    'declare -x WORKSPACE="/w"' \
+    'declare -x -r WORKSPACE="/w"' \
+    'local -r WORKSPACE="/w"' \
+    'export FOO=1 WORKSPACE="/w"'; do
+    cat >"$SEED" <<SEEDEOF
+#!/usr/bin/env bash
+
+$decl
+overlay_links="\$(cd "\$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "\$overlay_links"
+SEEDEOF
+    t7_run "$SEED"
+    [[ "$output" != *"never assigns it"* ]] || {
+      echo "false undefined ERROR for: $decl"
+      echo "$output"
+      return 1
+    }
+    [[ "$output" != *"derives WORKSPACE"* ]] || {
+      echo "false derived ERROR for: $decl"
+      echo "$output"
+      return 1
+    }
+  done
+}
+
+@test "a prefix assignment does not count as defining WORKSPACE" {
+  t7_setup
+  t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+WORKSPACE="{WORKSPACE}"
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+TPLEOF
+  # `WORKSPACE=/w env` is scoped to that one command and does NOT define
+  # WORKSPACE for the line below it, so the seed still aborts under `set -u`.
+  # Splitting a declaration into words must not turn this into an assignment.
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+WORKSPACE=/w env >/dev/null
+overlay_links="$(cd "$WORKSPACE" && find . -type l -lname '*dotfiles/projects/*' -print)"
+echo "$overlay_links"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"never assigns it"* ]]
+}
+
 @test "a \$WORKSPACE mentioned only in a comment is not a reference" {
   t7_setup
   t7_doc "Overlay-link gitignore" "lname '*dotfiles/projects/*'"
@@ -1713,7 +1810,8 @@ SEEDEOF
   local good bad other
   for good in 'WORKSPACE="/app"' "WORKSPACE='/app'" 'WORKSPACE=/app' \
     'SEED_USER="vscode"' 'export WORKSPACE="/app"' 'readonly SEED_USER="node"' \
-    'WORKSPACE="{WORKSPACE}"'; do
+    'WORKSPACE="{WORKSPACE}"' 'declare -x WORKSPACE="/app"' \
+    'declare -x -r WORKSPACE="/app"' 'local -r SEED_USER="node"'; do
     sd_source sd_classify_templated_assignment "$good"
     [ "$status" -eq 0 ] || {
       echo "expected literal (0), got $status for: $good"
@@ -1724,14 +1822,21 @@ SEEDEOF
   # was silently dropped from the comparison.
   for bad in 'WORKSPACE=/w;true' 'WORKSPACE=~' 'WORKSPACE=<(pwd)' \
     'WORKSPACE="$(git rev-parse --show-toplevel)"' 'WORKSPACE=`pwd`' \
-    'WORKSPACE=/w cmd' 'WORKSPACE="/w" "x"' 'WORKSPACE=/w*'; do
+    'WORKSPACE=/w*'; do
     sd_source sd_classify_templated_assignment "$bad"
     [ "$status" -eq 2 ] || {
       echo "expected non-literal (2), got $status for: $bad"
       false
     }
   done
-  for other in 'PATH=/usr/bin' 'echo "$WORKSPACE"' 'WORKSPACES="/x"'; do
+  # Not declarations at all. The prefix forms are scoped to the one command they
+  # precede, so calling them declarations would let a seed that still aborts
+  # under `set -u` read as having defined the variable; `export FOO=1 WS=...`
+  # does declare it, but does more than one thing and so is not a line the drop
+  # rule may remove. Either way the line is KEPT, which is the safe direction.
+  for other in 'PATH=/usr/bin' 'echo "$WORKSPACE"' 'WORKSPACES="/x"' \
+    'WORKSPACE=/w cmd' 'WORKSPACE="/w" "x"' 'export FOO=1 WORKSPACE="/app"' \
+    'declare -x -r'; do
     sd_source sd_classify_templated_assignment "$other"
     [ "$status" -eq 1 ] || {
       echo "expected not-a-declaration (1), got $status for: $other"

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -20,6 +20,30 @@ sd_source() {
   ' _ "$SEED_DRIFT" "$@"
 }
 
+# BSD sed takes a MANDATORY backup-suffix argument to -i, so `sed -i EXPR f` on
+# macOS consumes EXPR as the suffix and then reads the file path as the script -
+# the edit silently does not happen and the test asserts against an unmodified
+# fixture. Edit through a temp instead, which behaves the same on both seds.
+# Written back with `cat >`, not `mv`, so the file keeps its mode: some of these
+# fixtures are executable copies of the tool itself.
+sed_inplace() {
+  local expr="$1" f="$2" tmp
+  tmp="$BATS_TEST_TMPDIR/sed_inplace.$$"
+  sed "$expr" "$f" >"$tmp"
+  cat "$tmp" >"$f"
+  rm -f "$tmp"
+}
+
+# `sed '/pat/a text'` is a GNU extension; BSD sed requires `a\` followed by the
+# text on its own line. The two-expression form is the one both accept.
+sed_append_after() {
+  local pat="$1" text="$2" f="$3" tmp
+  tmp="$BATS_TEST_TMPDIR/sed_append.$$"
+  sed -e "/$pat/a\\" -e "$text" "$f" >"$tmp"
+  cat "$tmp" >"$f"
+  rm -f "$tmp"
+}
+
 write_fixture_doc() {
   cat >"$1" <<'DOC'
 | Block | Anchor in template | Why it matters |
@@ -740,7 +764,7 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
 @test "a behind seed exits 1 and the finding names project, block and direction" {
   setup_drift_fixtures
   seed_from_template behindp
-  sed -i '/tree-sitter ready/d' "$(seed_path behindp)"
+  sed_inplace '/tree-sitter ready/d' "$(seed_path behindp)"
 
   sd_drift
 
@@ -755,7 +779,8 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
 @test "an ahead seed is a promotion candidate and never suggests overwriting" {
   setup_drift_fixtures
   seed_from_template aheadp
-  sed -i '/tree-sitter ready/a echo "seed: project extra"' "$(seed_path aheadp)"
+  sed_append_after 'tree-sitter ready' 'echo "seed: project extra"' \
+    "$(seed_path aheadp)"
 
   sd_drift
 
@@ -768,8 +793,8 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
 @test "a reordered seed is DIVERGED and told to inspect by hand" {
   setup_drift_fixtures
   seed_from_template reorder
-  sed -i '5d' "$(seed_path reorder)"
-  sed -i '/tree-sitter ready/a install_tree_sitter "$TREE_SITTER_VERSION"' \
+  sed_inplace '5d' "$(seed_path reorder)"
+  sed_append_after 'tree-sitter ready' 'install_tree_sitter "$TREE_SITTER_VERSION"' \
     "$(seed_path reorder)"
 
   sd_drift
@@ -782,7 +807,7 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
 @test "an anchor absent from the seed is MISSING" {
   setup_drift_fixtures
   seed_from_template gone
-  sed -i '/core.excludesFile/d' "$(seed_path gone)"
+  sed_inplace '/core.excludesFile/d' "$(seed_path gone)"
 
   sd_drift
 
@@ -823,7 +848,7 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   seed_from_template aaa-broken
   printf 'if true; then\nTREE_SITTER_VERSION=1\n' >"$(seed_path aaa-broken)"
   seed_from_template zzz-behind
-  sed -i '/tree-sitter ready/d' "$(seed_path zzz-behind)"
+  sed_inplace '/tree-sitter ready/d' "$(seed_path zzz-behind)"
 
   sd_drift
 
@@ -854,7 +879,7 @@ sd_drift() { run "$SEED_DRIFT" --template "$FIXTURE_TEMPLATE" --doc "$FIXTURE_DO
   # and hand-owned with no revert path, so this is the guarantee that matters.
   setup_drift_fixtures
   seed_from_template behindp
-  sed -i '/tree-sitter ready/d' "$(seed_path behindp)"
+  sed_inplace '/tree-sitter ready/d' "$(seed_path behindp)"
   local seed_before seed_after doc_before doc_after tpl_before tpl_after
   local seed_mtime_before seed_mtime_after doc_mtime_before doc_mtime_after
   local tpl_mtime_before tpl_mtime_after
@@ -1700,13 +1725,7 @@ SEEDEOF
   # is the whole argument for the check being mandatory rather than a nicety:
   # without it the drop rule trades a false positive for a false NEGATIVE on the
   # documented fatal case.
-  # Not `sed -i`: BSD sed takes a MANDATORY backup-suffix argument to -i, so on
-  # macOS the range expression is consumed as the suffix and the tool path is
-  # then read as the script. Write to a temp and mv it back instead.
-  sed '/^  problems=\$(sd_templated_var_problems/,/^  fi$/d' \
-    "$T7_TOOL" >"$BATS_TEST_TMPDIR/sabotaged"
-  mv "$BATS_TEST_TMPDIR/sabotaged" "$T7_TOOL"
-  chmod +x "$T7_TOOL"
+  sed_inplace '/^  problems=\$(sd_templated_var_problems/,/^  fi$/d' "$T7_TOOL"
   # The excision must actually have happened, or this test passes vacuously.
   ! grep -q 'sd_templated_var_problems "\$sscan"' "$T7_TOOL"
   cat >"$TPL" <<'TPLEOF'
@@ -2411,7 +2430,7 @@ PYEOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"seed window is only 1 lines"* ]]
 
-  sed -i 's/^SD_THIN_WINDOW=5$/SD_THIN_WINDOW=1/' "$T7_TOOL"
+  sed_inplace 's/^SD_THIN_WINDOW=5$/SD_THIN_WINDOW=1/' "$T7_TOOL"
   t7_run_tool "$T7_TOOL"
   [ "$status" -eq 0 ]
   [[ "$output" != *"window is only"* ]]


### PR DESCRIPTION
## Problem

The template carries `SEED_USER` and `WORKSPACE` as `{USER}` / `{WORKSPACE}` placeholders, so every rendered seed necessarily holds a different literal and **no seed can ever match the template on those lines**. The fleet writes them in two shapes, and both were reported as drift:

| shape | where the assignment sits | what the diff sees | verdict | seeds |
|---|---|---|---|---|
| **inline** | inside the compared window | values differ: 1 behind **and** 1 ahead | `DIVERGED` | double-holo-ui, wanderer-notifier |
| **hoisted** | lifted into the variable block, above every anchor | template's line has no counterpart in the window | `BEHIND` | wanderer-kills, wanderer, slabledger |

Neutralizing the placeholder to its value — the obvious fix — only addresses the first shape. **Dropping** the line from both sides addresses both, because a window that no longer contains it compares equal whether the seed hoisted it or not.

## Literal RHS only

`catch-up-local-seed.md` is explicit that `WORKSPACE` must not be derived: the seed is mounted at an arbitrary container path that need not sit inside the checkout, so `git rev-parse` from there resolves to the wrong tree. A seed that regressed to `WORKSPACE="$(git rev-parse --show-toplevel)"` must still be flagged, so anything containing `$`, a backtick or `$(` is kept and drifts against the template's dropped literal.

## The compensating guard is not optional

Dropping otherwise trades a false positive for a **false negative on the documented fatal case**. Once these assignments leave block comparison, *"the seed hoisted it"* and *"the seed never defines it at all"* look identical to the diff — and the second aborts the entire seed on first expansion under `set -euo pipefail`, surfacing as an unrelated-looking container start error rather than a seed failure.

So it is now checked directly: a seed that reads `$WORKSPACE`/`$SEED_USER` but never assigns it is an `ERROR` at exit 2, reported on the host **before** a rebuild. This is strictly stronger than the accidental paragraph coverage it replaces. A sabotage test pins the argument by excising the guard and asserting the seed goes quiet.

The check reads `C` scan records, whose trailing comments are already stripped, so a `$WORKSPACE` mentioned only in a comment is not a reference; `${VAR:-…}` is deliberately not one either, since a defaulted expansion is exactly the shape that survives being undefined.

## Fleet effect

Exactly one verdict changes, and it is the intended one:

| project / block | before | after |
|---|---|---|
| **wanderer-kills** Overlay-link gitignore | `BEHIND 1` | **`ok`** — clean on all nine blocks |
| double-holo-ui Overlay-link | `DIVERGED 5/2` | `DIVERGED 4/1` |
| wanderer-notifier Overlay-link | `DIVERGED 5/12` | `DIVERGED 4/11` |
| all others | — | unchanged |
| **totals** | 26 drifted (4 behind, 1 ahead, 21 diverged) | 25 drifted (3 behind, 1 ahead, 21 diverged) |

Inline-shape seeds lose exactly one line from each side of their counts and correctly stay `DIVERGED` on their remaining real drift. **No seed in the fleet raises the new ERROR**, so the guard has no false positives on real input.

## Tests

122 pass, 0 fail (116 before + 6 new): inline → ok, hoisted → ok, derived RHS → still flagged, comment-only mention → not a reference, referenced-but-unassigned → ERROR/exit 2, plus the sabotage probe.

Two **existing** fixtures referenced `$WORKSPACE` without ever assigning it — a shape that would abort a real seed — and correctly tripped the new guard. They are made well-formed rather than weakening the guard; the added line is dropped by the new rule, so it cannot perturb what those two tests actually assert.

`make check` passes: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seed validation for literal `WORKSPACE` and `SEED_USER` assignments.
  * Reduced false drift reports from inline or hoisted assignments.
  * Added detection for undefined or derived template variables that may cause misleading container startup errors.
  * Validation now continues other comparisons while reporting these issues and returns an appropriate error status.

* **Documentation**
  * Documented whole-file `ERROR` verdicts and their likely causes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->