### PR TITLE
fix(work): install Krew so the ctx and ns plugins land on Linux

### DIFF
--- a/bin/versions
+++ b/bin/versions
@@ -46,6 +46,7 @@ list_pins() {
   printf 'git zsh-defer %s\n' "$ZSH_DEFER_REF"
   printf 'channel kubernetes %s\n' "$KUBERNETES_CHANNEL"
   printf 'artifact mise %s\n' "$MISE_VERSION"
+  printf 'artifact krew %s\n' "$KREW_VERSION"
   printf 'artifact yq %s\n' "$YQ_VERSION"
   printf 'artifact win32yank %s\n' "$WIN32YANK_VERSION"
   printf 'artifact vekil %s\n' "$VEKIL_VERSION"
@@ -136,6 +137,7 @@ check_pins() {
     printf 'outdated channel kubernetes %s -> %s\n' "$KUBERNETES_CHANNEL" "$latest_channel"
   fi
   check_artifact_release mise jdx/mise "$MISE_VERSION"
+  check_artifact_release krew kubernetes-sigs/krew "$KREW_VERSION"
   check_artifact_release yq mikefarah/yq "$YQ_VERSION"
   check_artifact_release win32yank equalsraf/win32yank "$WIN32YANK_VERSION"
   check_artifact_release vekil sozercan/vekil "$VEKIL_VERSION"

--- a/config/versions.env
+++ b/config/versions.env
@@ -6,6 +6,15 @@ ZSH_DEFER_REF=53a26e287fbbe2dcebb3aa1801546c6de32416fa
 # the minor your cluster actually runs. `bin/versions update` reports upstream
 # drift but never picks a new minor, because moving it is a cluster decision.
 KUBERNETES_CHANNEL=v1.28
+# Krew, the kubectl plugin manager the work profile installs ctx and ns through.
+# macOS gets it from platforms/macos/brewfile; Linux and WSL have no package for
+# it, so the work profile installs this pinned release tarball instead. Upstream
+# publishes a .sha256 beside each asset; these were recomputed from the actual
+# downloads rather than copied from it.
+KREW_VERSION=v0.5.0
+KREW_RELEASE_BASE=https://github.com/kubernetes-sigs/krew/releases/download/v0.5.0
+KREW_LINUX_AMD64_SHA256=5d5a221fffdf331d1c5c68d9917530ecd102e0def5b5a6d62eeed1c404efb28a
+KREW_LINUX_ARM64_SHA256=ab7a98b992424e76b6c162f8b67fb76c4b1e243598aa2807bdf226752f964548
 MISE_VERSION=v2026.7.18
 MISE_RELEASE_BASE=https://github.com/jdx/mise/releases/download/v2026.7.18
 MISE_LINUX_X64_SHA256=e1fc2899f2bc7dfe9a3553f4c2d5944cf69d11b5f561545504a20f1e11cd6cc5

--- a/tests/dependency_pins.bats
+++ b/tests/dependency_pins.bats
@@ -23,6 +23,7 @@ setup() {
   [[ "$output" == *"git zsh-defer $ZSH_DEFER_REF"* ]]
   [[ "$output" == *"channel kubernetes v1.28"* ]]
   [[ "$output" == *"artifact mise v2026.7.18"* ]]
+  [[ "$output" == *"artifact krew v0.5.0"* ]]
   [[ "$output" == *"artifact yq v4.45.1"* ]]
   [[ "$output" == *"artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"artifact vekil v0.14.0"* ]]
@@ -90,6 +91,7 @@ url="${@: -1}"
 case "$url" in
   *dl.k8s.io*) printf 'v1.28.0\n' ;;
   *jdx/mise*) printf '{"tag_name":"v2026.7.18"}\n' ;;
+  *kubernetes-sigs/krew*) printf '{"tag_name":"v0.5.0"}\n' ;;
   *mikefarah/yq*) printf '{"tag_name":"v4.45.1"}\n' ;;
   *equalsraf/win32yank*) printf '{"tag_name":"v0.1.1"}\n' ;;
   *sozercan/vekil*) printf '{"tag_name":"v0.14.0"}\n' ;;
@@ -102,6 +104,7 @@ SCRIPT
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"current artifact mise v2026.7.18"* ]]
+  [[ "$output" == *"current artifact krew v0.5.0"* ]]
   [[ "$output" == *"current artifact yq v4.45.1"* ]]
   [[ "$output" == *"current artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"current artifact vekil v0.14.0"* ]]

--- a/tests/dependency_pins.bats
+++ b/tests/dependency_pins.bats
@@ -19,7 +19,7 @@ setup() {
   run bash "$REPO_ROOT/bin/versions" list
   [ "$status" -eq 0 ]
   [[ "$output" == *"mise go 1.25.12"* ]]
-  [[ "$output" == *"git prezto 9739c8bdc9c288ffc134c209225543180e32ff69"* ]]
+  [[ "$output" == *"git prezto $PREZTO_REF"* ]]
   [[ "$output" == *"git zsh-defer $ZSH_DEFER_REF"* ]]
   [[ "$output" == *"channel kubernetes v1.28"* ]]
   [[ "$output" == *"artifact mise v2026.7.18"* ]]

--- a/tests/install_orchestration.bats
+++ b/tests/install_orchestration.bats
@@ -268,7 +268,66 @@ CASES
   [ "${#lines[@]}" -eq 2 ]
 }
 
-# --- project overlay attach -------------------------------------------------
+# --- work profile Krew bootstrap --------------------------------------------
+#
+# The ctx/ns plugins are installed through Krew, and Linux/WSL has no package
+# for Krew itself, so the work profile installs the pinned tarball first. These
+# cover the artifact selection and the "already present" and "no artifact"
+# paths without touching the network.
+
+@test "work profile installs the reviewed Krew artifact for each Linux architecture" {
+  local arch expected_asset expected_digest
+  while read -r arch expected_asset expected_digest; do
+    run env WORK_INSTALL_SOURCE_ONLY=1 ARTIFACT_ARCH="$arch" OS=WSL bash -c '
+      source "$1/work/install.sh"
+      kubectl() { return 1; }
+      download_verified_artifact() { printf "%s|%s\n" "$1" "$2"; }
+      # Stand in for the real extraction: place a fake krew where the installer
+      # expects the unpacked binary, so the self-install step can run.
+      tar() {
+        local extracted="$4/${5#./}"
+        printf "%s\n" "#!/usr/bin/env bash" "echo krew-self-install \$*" >"$extracted"
+        chmod +x "$extracted"
+      }
+      install_krew
+    ' _ "$REPO_ROOT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/$expected_asset.tar.gz|$expected_digest"* ]]
+    [[ "$output" == *"krew-self-install install krew"* ]]
+  done <<CASES
+x86_64 krew-linux_amd64 $KREW_LINUX_AMD64_SHA256
+aarch64 krew-linux_arm64 $KREW_LINUX_ARM64_SHA256
+CASES
+}
+
+@test "work profile leaves an existing Krew install alone" {
+  run env WORK_INSTALL_SOURCE_ONLY=1 OS=WSL bash -c '
+    source "$1/work/install.sh"
+    kubectl() { return 0; }
+    download_verified_artifact() { printf "downloaded\n"; }
+    install_krew
+  ' _ "$REPO_ROOT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"downloaded"* ]]
+}
+
+@test "work profile warns instead of downloading a Krew artifact it has not reviewed" {
+  run env WORK_INSTALL_SOURCE_ONLY=1 ARTIFACT_ARCH=ppc64le OS=WSL bash -c '
+    source "$1/work/install.sh"
+    kubectl() { return 1; }
+    download_verified_artifact() { printf "downloaded\n"; }
+    install_krew
+  ' _ "$REPO_ROOT"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"downloaded"* ]]
+  [[ "$output" == *"No reviewed Krew artifact for ppc64le"* ]]
+}
+
+@test "work profile puts the Krew bin directory on PATH for interactive shells" {
+  run rg -n 'KREW_ROOT:-\$HOME/\.krew' "$REPO_ROOT/work/path.zsh"
+  [ "$status" -eq 0 ]
+}
+
 #
 # setup_projects_overlay clones the private overlay repo to ~/.dotfiles/projects.
 # It must never be fatal: a machine without overlays is a working machine, so

--- a/work/install.sh
+++ b/work/install.sh
@@ -54,6 +54,69 @@ setup_work_apt_repositories() {
   setup_microsoft_repositories
 }
 
+krew_bin_directory() {
+  printf '%s/bin\n' "${KREW_ROOT:-$HOME/.krew}"
+}
+
+# Krew installs itself as a kubectl plugin under $KREW_ROOT, which only becomes
+# reachable once its bin directory is on PATH. The install below and every later
+# `kubectl krew` call in this process need that, and work/path.zsh repeats it for
+# interactive shells.
+use_krew_bin_directory() {
+  local directory
+  directory="$(krew_bin_directory)"
+  [[ ":$PATH:" == *":$directory:"* ]] || export PATH="$directory:$PATH"
+}
+
+# macOS gets Krew from platforms/macos/brewfile. Linux and WSL have no package
+# for it, so without this a work host warned "install Krew first" on every run
+# and never got the ctx/ns plugins. Pinned tarball rather than upstream's
+# install script: same policy as every other artifact in config/versions.env.
+install_krew() {
+  local arch="${ARTIFACT_ARCH:-$(uname -m)}"
+  local asset digest workspace status=0
+
+  if kubectl krew version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  case "$OS" in
+    Ubuntu | WSL) ;;
+    *)
+      log_warning "No automated Krew install for $OS; install Krew before installing ctx and ns."
+      return 1
+      ;;
+  esac
+
+  case "$arch" in
+    x86_64 | amd64)
+      asset=krew-linux_amd64
+      digest="$KREW_LINUX_AMD64_SHA256"
+      ;;
+    aarch64 | arm64)
+      asset=krew-linux_arm64
+      digest="$KREW_LINUX_ARM64_SHA256"
+      ;;
+    *)
+      log_warning "No reviewed Krew artifact for $arch; install Krew before installing ctx and ns."
+      return 1
+      ;;
+  esac
+
+  workspace="$(mktemp -d)" || return 1
+  log_info "Installing Krew $KREW_VERSION"
+  if download_verified_artifact "$KREW_RELEASE_BASE/$asset.tar.gz" "$digest" "$workspace/krew.tar.gz" &&
+    tar -xzf "$workspace/krew.tar.gz" -C "$workspace" "./$asset" &&
+    "$workspace/$asset" install krew; then
+    log_success "Krew installed"
+  else
+    log_warning "Krew install failed; kubectl ctx and ns were skipped."
+    status=1
+  fi
+  rm -rf -- "$workspace"
+  return "$status"
+}
+
 install_krew_plugins() {
   if ! kubectl krew version >/dev/null 2>&1; then
     log_warning "kubectl krew is not available; install Krew before installing ctx and ns."
@@ -61,8 +124,21 @@ install_krew_plugins() {
   fi
 
   log_info "Installing kubectl ctx and ns plugins via Krew"
+  # Krew skips plugins that are already present, so re-running the work profile
+  # is a no-op rather than a failure.
   kubectl krew install ctx ns
   log_success "kubectl ctx and ns plugins installed"
+}
+
+setup_kubectl_plugins() {
+  if ! command_exists kubectl; then
+    log_warning "kubectl is not installed; skipping Krew and the ctx and ns plugins."
+    return 1
+  fi
+
+  use_krew_bin_directory
+  install_krew || return 1
+  install_krew_plugins
 }
 
 work_main() {
@@ -77,7 +153,7 @@ work_main() {
     *) ;;
   esac
 
-  install_krew_plugins
+  setup_kubectl_plugins
 }
 
 if [[ "${WORK_INSTALL_SOURCE_ONLY:-0}" != 1 ]]; then

--- a/work/path.zsh
+++ b/work/path.zsh
@@ -4,3 +4,5 @@
 export PATH=$PATH:$GOPATH/src/goms.io/aks/rp/bin
 export PATH=$PATH:$HOME/bin
 export PATH=$PATH:$HOME/.local/bin
+# kubectl plugins installed by work/install.sh live here, not on the system path.
+export PATH=${KREW_ROOT:-$HOME/.krew}/bin:$PATH


### PR DESCRIPTION
## Problem

`./bin/install` on a Linux/WSL work host ends the work phase with:

```
[ WARNING ] kubectl krew is not available; install Krew before installing ctx and ns.
[ WARNING ] Optional phase failed: work
```

`work/install.sh` installed the `ctx` and `ns` kubectl plugins *through* Krew, but nothing installed Krew itself. macOS gets it from `platforms/macos/brewfile`; Linux and WSL have no package for it, so the profile warned and gave up on every run and the shortcuts never existed.

## Change

- `config/versions.env`: pin Krew v0.5.0 with SHA256s for linux amd64/arm64. The digests were recomputed from the actual release downloads rather than copied from upstream's `.sha256` files, matching the policy comment on the Neovim and tree-sitter pins.
- `work/install.sh`: `install_krew()` fetches the pinned tarball through the existing `download_verified_artifact`, unpacks it, and self-installs. `setup_kubectl_plugins()` requires kubectl, puts `$KREW_ROOT/bin` on PATH, installs Krew, then the plugins. A missing kubectl, a non-Linux OS, and an unreviewed architecture each warn and return non-zero — the phase stays optional, so `./bin/install` does not abort.
- `work/path.zsh`: `${KREW_ROOT:-$HOME/.krew}/bin` on PATH for interactive work shells, so `kubectl ctx` and the `ktx`/`kns` aliases resolve.
- `bin/versions`: krew reported by `list` and `check`, like every other pinned artifact.
- Tests: artifact selection per architecture, the already-installed short-circuit, the unreviewed-architecture refusal, and the PATH entry.

A pinned, checksummed tarball rather than upstream's `install.sh` keeps this consistent with every other artifact in `config/versions.env` and avoids `ALLOW_REMOTE_INSTALLERS`.

## Verification

- Ran the real path on a WSL host: Krew v0.5.0 installed, `ctx` and `ns` installed. A second run exits 0 — Krew skips already-installed plugins, so re-running `./bin/install` is a no-op.
- `make syntax lint` clean. `make check` has 10 failures, all in `tests/claude_compose_override.bats`; the same 10 fail on a clean tree at `main`, so they are pre-existing and untouched here.

## Separate commit

`test(pins): assert the pinned Prezto ref rather than a stale literal` — 936f659 repinned Prezto but left the old commit hard-coded in `tests/dependency_pins.bats`, failing `make check` on `main` for a pin that is deliberately current. It now compares against `$PREZTO_REF`, matching the `zsh-defer` assertion beside it. Unrelated to Krew; drop the commit if you would rather handle it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Krew installation for Ubuntu and WSL environments.
  * Added architecture-specific, checksum-verified Krew downloads for supported Linux systems.
  * Automatically configures Krew’s plugin directory in `PATH`.
  * Kubernetes context and namespace plugins are now installed through Krew when needed.
* **Bug Fixes**
  * Existing Krew installations are preserved.
  * Unsupported systems, architectures, and failed installations now provide warnings or stop safely.
* **Chores**
  * Pinned Krew to release `v0.5.0` for consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->