### PR TITLE
fix(seed): give the seed's own claude calls ~/.local/bin on PATH

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -901,10 +901,18 @@ if [ "$SEED_ALREADY_CURRENT" -eq 0 ]; then
   # A failed install must NOT be stamped: the sentinel is the only thing standing
   # between a half-populated ~/.claude/plugins and a permanent skip on every later
   # launch. Record the failure and leave the sentinel alone so the next run retries.
+  # Every claude invocation below goes through as_user, which is non-interactive
+  # and so never sources ~/.zshrc — the only place ~/.local/bin joins PATH. Without
+  # this the seed cannot see the claude binary the always-run block just installed:
+  # the probe below answers "no", marketplaces go unregistered, and MARKETPLACE_OK=0
+  # leaves the sentinel unstamped, so EVERY launch re-runs this block and exits 1.
+  # Export it to the child rather than the seed's own PATH, so only the calls that
+  # need the CLI are affected.
+  SEED_PATH="$SEED_HOME/.local/bin:$PATH"
   MARKETPLACE_OK=1
   if [ -x "$DOTFILES_HOME/ai/marketplace/install.sh" ]; then
     echo "🌱 seed: installing my@guarzo marketplace + plugin"
-    as_user bash "$DOTFILES_HOME/ai/marketplace/install.sh" || {
+    as_user env PATH="$SEED_PATH" bash "$DOTFILES_HOME/ai/marketplace/install.sh" || {
       MARKETPLACE_OK=0
       echo "⚠️  seed: marketplace install failed — NOT stamping sentinel; next launch retries"
     }
@@ -926,7 +934,7 @@ if [ "$SEED_ALREADY_CURRENT" -eq 0 ]; then
   # `command -v claude` gets "no" while the user's shell finds it fine. And an
   # unavailable CLI clears MARKETPLACE_OK rather than silently skipping — skipping
   # stamps the sentinel, and the gated block then never retries the registration.
-  if as_user sh -c 'command -v claude >/dev/null 2>&1'; then
+  if as_user env PATH="$SEED_PATH" sh -c 'command -v claude >/dev/null 2>&1'; then
     mp_registry="$CLAUDE_HOME/plugins/known_marketplaces.json"
     while read -r mp_name mp_repo; do
       [ -n "$mp_name" ] || continue
@@ -941,7 +949,7 @@ if [ "$SEED_ALREADY_CURRENT" -eq 0 ]; then
         continue
       fi
       echo "🌱 seed: registering marketplace $mp_name ($mp_repo)"
-      as_user claude plugin marketplace add "$mp_repo" >/dev/null 2>&1 || {
+      as_user env PATH="$SEED_PATH" claude plugin marketplace add "$mp_repo" >/dev/null 2>&1 || {
         MARKETPLACE_OK=0
         echo "⚠️  seed: could not register $mp_repo (needs network) — NOT stamping sentinel"
       }


### PR DESCRIPTION
## Problem

The seed's own `claude` invocations could never find the `claude` binary the seed had just installed.

`~/.local/bin` joins `PATH` only through a hook in `~/.zshrc`, and only an *interactive* zsh sources that file. Every claude call the seed makes goes through `as_user` (`runuser -u node --`), which is non-interactive. So the marketplace block's probe answered "no" even with the binary sitting at `$SEED_HOME/.local/bin/claude`.

Consequence: `MARKETPLACE_OK=0`, which by design leaves the sentinel unstamped so the next launch retries. But the retry hits the same PATH gap, so the block re-ran and the seed exited 1 on *every* container start, and marketplaces were never registered.

## Root cause, reproduced in a live container

| probe | result |
|---|---|
| `test -x /home/node/.local/bin/claude` | PASS (binary present, v2.1.221) |
| `runuser -u node -- sh -c 'command -v claude'` | **FAIL** (the probe that gated the block) |
| `runuser -u node -- claude --version` | **FAIL** (`runuser: failed to execute claude`) |
| `runuser -u node -- bash -lc 'command -v claude'` | PASS |
| with `~/.local/bin` on PATH: `claude plugin marketplace list` | PASS |

## Fix

Define `SEED_PATH="$SEED_HOME/.local/bin:$PATH"` and pass it explicitly to the three `as_user` calls in the marketplace block (`install.sh`, the `command -v claude` probe, and `claude plugin marketplace add`). Exported to the child rather than set on the seed's own `PATH`, so only the calls that need the CLI are affected.

This mirrors the pattern already used correctly elsewhere in the same template, which reaches the binary via `as_user test -x` / `bash -lc` instead of relying on inherited `PATH`.

## Verification

Applied to a real project seed and re-run against a live container:

- seed completed with `seed: done (v8)`, no non-zero exit
- both marketplaces registered (`guarzo`, `claude-plugins-official`)
- sentinel `/home/node/.claude/.seeded` stamped with `8`
- a second, fresh re-run returned `exit=0`
- `bash -n`, `shellcheck -x -S warning -e SC1091`, `shfmt -d -i 2 -ci` all clean

No `SEED_VERSION` bump: the change lives inside the gated block, which satisfies both clauses of the gating rule (target persists in the named volume, source is the template).

## Note

`seed-drift` cannot catch this class of regression. It audits only the nine anchored blocks from the block table in `catch-up-local-seed.md`, and the marketplace block is not one of them, so this defect passed a clean drift audit in both the template and the rendered seed. Adding a tenth row would close that gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace installation and registration reliability by ensuring required command-line tools are available during automated setup.
  * Preserved existing failure handling and completion tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->