### PR TITLE
feat(seed-drift): audit the marketplace PATH block as a tenth anchor

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/catch-up-local-seed.md
@@ -91,7 +91,7 @@ The table above is prose, unlike the one in Step 2: the parser only takes a row
 whose **second** cell is a backticked anchor, and these rows backtick the first.
 Do not add a backticked second cell here — the parser would read the row as a
 block and abort every project at exit 2 when the "anchor" turned up missing from
-the template. `tests/seed_drift.bats` pins the count at nine and would catch it.
+the template. `tests/seed_drift.bats` pins the count at ten and would catch it.
 
 The blocks it compares are the rows of the Step 2 table below, so the two stay
 in step by construction.
@@ -115,9 +115,18 @@ SEED_BASELINE="$(git rev-parse --git-dir)/seed-baseline.status"
 git status --porcelain >"$SEED_BASELINE"
 ```
 
-Each entry gives the grep anchor to find it in the template. All of these live
-in the **always-run block, above the sentinel gate** — keep them there. Moving
-one below the gate means a container that is already stamped will never run it.
+Each entry gives the grep anchor to find it in the template. All of them except
+the last live in the **always-run block, above the sentinel gate** — keep them
+there. Moving one below the gate means a container that is already stamped will
+never run it.
+
+The `SEED_PATH` row is the deliberate exception: it belongs to the marketplace
+block, which is *correctly* gated (its target persists in the `claude-local-home`
+volume and its source is the template, so it satisfies both clauses of the
+gating rule in SKILL.md item 15). Porting it **above** the gate would be the
+error there. The gate position is not something the detector checks — it
+compares block contents wherever it finds the anchor — so this stays a rule you
+apply by hand.
 
 > **This table is executable input, not just prose.** `bin/seed-drift` parses it
 > to decide which blocks to compare, so editing it changes what the detector
@@ -140,6 +149,7 @@ one below the gate means a container that is already stamped will never run it.
 | tree-sitter CLI | `TREE_SITTER_VERSION` | `config/nvim` pins nvim-treesitter to `main`, whose installer shells out to `tree-sitter build` per parser with no fallback to a bare `cc`. A container with gcc but no CLI still fails every parser at first launch (`ENOENT ... (cmd): 'tree-sitter'`). On a host it comes from mise, which the seed never runs. Pinned and sha256-verified from `config/versions.env`; non-fatal. |
 | `load-custom.zsh` loader | `DOTFILES_LOAD_HOOK` | The supported entry point for the shell tree. Append it **before** the Vekil hook — `ai/vekil/env.zsh` exports `ANTHROPIC_MODEL`, which outranks `settings.json`, so it has to get the last word. |
 | codex guard | `local/bin/codex` | Guard the reinstall on the **binary**, not `~/.codex/config.toml`. The installer writes config even when it fails to produce a binary, so a config-based guard latches shut and codex never reinstalls. |
+| marketplace PATH | `SEED_PATH` | The seed's own `claude` calls run through `as_user` (`runuser -u node --`), which is non-interactive and so never sources `~/.zshrc` — the only place `~/.local/bin` joins `PATH`. Without `SEED_PATH` the seed cannot see the `claude` binary it just installed: the probe answers "no", marketplaces go unregistered, and `MARKETPLACE_OK=0` leaves the sentinel unstamped, so **every** launch re-runs the block and exits 1. The one row that lives below the gate. |
 
 ## Vocabulary differs per seed — do not paste blindly
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -584,8 +584,8 @@ sd_check_seed() {
   sd_tmp tnorm || return 2
   sd_tmp snorm || return 2
   # Allocated once per seed, not once per block: the diff output is consumed
-  # before the next iteration overwrites it, so nine blocks do not need
-  # eighteen files. Same reuse as tnorm/snorm/sscan above.
+  # before the next iteration overwrites it, so N blocks do not need 2N
+  # files. Same reuse as tnorm/snorm/sscan above.
   sd_tmp behind || return 2
   sd_tmp ahead || return 2
   # Parsed to a file, not piped into the loop through `< <(sd_parse_doc …)`: a

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -77,12 +77,13 @@ DOC
   [ "${#lines[@]}" -eq 2 ]
 }
 
-@test "sd_parse_doc reads all nine blocks from the real catch-up doc" {
+@test "sd_parse_doc reads all ten blocks from the real catch-up doc" {
   sd_source sd_parse_doc "$REAL_DOC"
 
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 9 ]
+  [ "${#lines[@]}" -eq 10 ]
   [[ "$output" == *"TREE_SITTER_VERSION"* ]]
+  [[ "$output" == *"SEED_PATH"* ]]
   [[ "$output" == *"lname '*dotfiles/projects/*'"* ]]
 }
 


### PR DESCRIPTION
Follow-up to #48.

## Why

The PATH defect fixed in #48 passed a **clean** `seed-drift` audit in both the template and the rendered seed. The detector compares only the nine anchored blocks in the Step 2 table of `catch-up-local-seed.md`, and the marketplace block is not one of them, so an entire class of regression was invisible to it.

## What

- Adds a tenth row to the Step 2 table, anchored on `SEED_PATH`.
- Updates the two places that pin the count: the assertion in `tests/seed_drift.bats` (9 → 10, plus a `SEED_PATH` presence check alongside the existing `TREE_SITTER_VERSION` one), and a comment in `bin/seed-drift` reworded to be count-agnostic so it stops needing an edit every time a row is added.

## The one row below the gate

Every other row in that table lives in the always-run block above the sentinel gate, and the doc says so. This one does not, and shouldn't: the marketplace block is *correctly* gated, because it satisfies both clauses of the gating rule in SKILL.md item 15 (target persists in the `claude-local-home` volume, source is the template). Porting it above the gate would be the error.

The detector compares block contents wherever it finds the anchor and never checks gate position, so this stays a by-hand rule. It is now called out explicitly in the doc right above the table rather than left as a contradiction between the prose and the new row.

## Verification

`bats tests/seed_drift.bats` — 116/116 pass.
`bash -n`, `shellcheck -x -S warning`, `shfmt -d -i 2 -ci` — clean on `bin/seed-drift`.

Real-corpus run, read-only, no seed modified:

| project | marketplace PATH |
|---|---|
| double-holo-ui | `ok` (carries the #48 fix) |
| slabledger | `MISSING` anchor absent from seed |
| wanderer-kills | `MISSING` anchor absent from seed |
| wanderer-notifier | `MISSING` anchor absent from seed |
| wanderer | `MISSING` anchor absent from seed |

Which is the intended result: `ok` on the seed that has the fix, `MISSING` on the four that don't. Those four are now flagged rather than silently passing. Note this raises the corpus drift count, so the aggregate line moves from 25 to 29 blocks drifted; that is the detector reporting work that was already outstanding, not new breakage.
