### PR TITLE
feat(seed): report versions in the claude/codex/nvim guards

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -420,7 +420,12 @@ fi
 # remote installer is then never invoked. Note `ai/claude/install.sh` itself has
 # no version/checksum support — the pinned artifact must come from the project.
 if as_user test -x "$SEED_HOME/.local/bin/claude" || as_user bash -lc 'command -v claude >/dev/null 2>&1'; then
-  echo "🌱 seed: claude already installed for $SEED_USER — skipping CLI install"
+  # Report the version, not just presence. "already installed" alone cannot
+  # distinguish a current CLI from one a stale volume has been pinning for
+  # months — the usual first question when a container behaves unlike the host.
+  # Non-fatal by construction: the substitution swallows its own failure, and
+  # pipefail makes the `|| echo '?'` fire when the binary itself exits nonzero.
+  echo "🌱 seed: claude already installed for $SEED_USER ($(as_user bash -lc 'claude --version 2>/dev/null' || echo '?')) — skipping CLI install"
 elif [ -n "${CLAUDE_CLI_INSTALL_CMD:-}" ]; then
   echo "🌱 seed: installing Claude Code CLI via pinned CLAUDE_CLI_INSTALL_CMD"
   as_user bash -lc "$CLAUDE_CLI_INSTALL_CMD" ||
@@ -438,7 +443,7 @@ fi
 # Testing config.toml therefore latches: config present, `codex` missing, and
 # the installer skipped on every subsequent start.
 if as_user test -x "$SEED_HOME/.local/bin/codex"; then
-  echo "🌱 seed: codex already present"
+  echo "🌱 seed: codex already present ($(as_user "$SEED_HOME/.local/bin/codex" --version 2>/dev/null || echo '?'))"
 elif [ -x "$DOTFILES_HOME/ai/codex/install.sh" ]; then
   echo "🌱 seed: linking Codex config"
   as_user bash "$DOTFILES_HOME/ai/codex/install.sh" || echo "⚠️  seed: codex install failed (non-fatal)"
@@ -461,7 +466,7 @@ fi
 # nvim-dist/bin/nvim) still passes, while a directory — which `-x` alone reports
 # as executable — no longer counts as "already installed" and silently skips.
 if as_user test -f "$SEED_HOME/.local/bin/nvim" && as_user test -x "$SEED_HOME/.local/bin/nvim"; then
-  echo "🌱 seed: nvim already present"
+  echo "🌱 seed: nvim already present ($(as_user "$SEED_HOME/.local/bin/nvim" --version 2>/dev/null | head -1 || echo '?'))"
 elif [ -r "$DOTFILES_HOME/config/versions.env" ]; then
   # shellcheck source=/dev/null
   . "$DOTFILES_HOME/config/versions.env"
@@ -527,7 +532,7 @@ elif [ -r "$DOTFILES_HOME/config/versions.env" ]; then
       mv "$NVIM_DIST.new" "$NVIM_DIST" &&
       as_user ln -sf "$NVIM_DIST/bin/nvim" "$SEED_HOME/.local/bin/nvim" &&
       as_user test -x "$SEED_HOME/.local/bin/nvim"; then
-      echo "🌱 seed: neovim ready"
+      echo "🌱 seed: neovim ready ($(as_user "$SEED_HOME/.local/bin/nvim" --version 2>/dev/null | head -1 || echo '?'))"
     else
       echo "⚠️  seed: neovim install failed (non-fatal; EDITOR falls back to vim)"
     fi

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -423,8 +423,9 @@ if as_user test -x "$SEED_HOME/.local/bin/claude" || as_user bash -lc 'command -
   # Report the version, not just presence. "already installed" alone cannot
   # distinguish a current CLI from one a stale volume has been pinning for
   # months — the usual first question when a container behaves unlike the host.
-  # Non-fatal by construction: the substitution swallows its own failure, and
-  # pipefail makes the `|| echo '?'` fire when the binary itself exits nonzero.
+  # Non-fatal by construction: stderr is discarded and `|| echo '?'` fires on the
+  # non-zero exit from `as_user bash -lc`, so a stale or broken CLI degrades to
+  # `(?)` rather than taking the seed down under `set -e`.
   echo "🌱 seed: claude already installed for $SEED_USER ($(as_user bash -lc 'claude --version 2>/dev/null' || echo '?')) — skipping CLI install"
 elif [ -n "${CLAUDE_CLI_INSTALL_CMD:-}" ]; then
   echo "🌱 seed: installing Claude Code CLI via pinned CLAUDE_CLI_INSTALL_CMD"
@@ -466,6 +467,9 @@ fi
 # nvim-dist/bin/nvim) still passes, while a directory — which `-x` alone reports
 # as executable — no longer counts as "already installed" and silently skips.
 if as_user test -f "$SEED_HOME/.local/bin/nvim" && as_user test -x "$SEED_HOME/.local/bin/nvim"; then
+  # Same `(?)` fallback as the claude guard above, but here it rests on pipefail:
+  # without it `head -1` would report success and mask nvim's own failure, and the
+  # parens would come out empty instead. Applies to the "neovim ready" line too.
   echo "🌱 seed: nvim already present ($(as_user "$SEED_HOME/.local/bin/nvim" --version 2>/dev/null | head -1 || echo '?'))"
 elif [ -r "$DOTFILES_HOME/config/versions.env" ]; then
   # shellcheck source=/dev/null


### PR DESCRIPTION
## What

The three "already present" guards in `templates/local-seed.sh` proved presence and stopped there. This makes them print the version too, at four call sites:

| Line | Before | After |
|---|---|---|
| claude guard | `claude already installed for $SEED_USER` | `… ($(as_user bash -lc 'claude --version'))` |
| codex guard | `codex already present` | `… ($(as_user "$SEED_HOME/.local/bin/codex" --version))` |
| nvim guard | `nvim already present` | `… ($(as_user … nvim --version \| head -1))` |
| neovim install success | `neovim ready` | same shape |

## Why

On a warm container, presence is the wrong half of the answer. A persisted named volume can pin a months-old binary indefinitely, and the seed log is the first thing anyone reads when a container behaves unlike the host — it said only that *something* was there. "Is it current?" then costs a shell into the container.

Promoted from a project seed that has carried this shape in production; the drift audit that surfaced it flagged these as AHEAD of the template.

## Safety

Non-fatal by construction under `set -euo pipefail`. stderr is discarded and `|| echo '?'` degrades to `(?)`. The two piped nvim forms depend on `pipefail` to see the binary's own nonzero exit through `head -1` — without it the pipeline would report `head`'s success and print empty parens. Verified empirically with a missing binary in both the piped and unpiped shapes: both print `(?)` and execution continues.

The claude guard goes through `as_user bash -lc` because that guard already allows the CLI to live anywhere on the user's `PATH`, not just at `$SEED_HOME/.local/bin`. The other two have a known path and invoke it directly.

## Gating

All four lines sit at 423/446/469/535, above the sentinel gate at 889 — always-run blocks. No `SEED_VERSION` bump: the header rule ties bumps to changes in *gated* steps.

## Expected fallout

`bin/seed-drift` will report BEHIND on these blocks for project seeds still carrying the bare echoes. That is the promotion landing, not a regression — each seed picks it up on its next catch-up pass.

## Verification

- `bash -n`, `shellcheck -x -S warning -e SC1091`, `shfmt -d -i 2 -ci` — all clean
- `bats tests/project_claude_setup_seed.bats tests/seed_drift.bats tests/nvim_treesitter_guard.bats` — pass, no failures

## Deliberately excluded

The drift audit also surfaced an extra marketplace registry entry as a promotion candidate. Left out — it is site-specific rather than template material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Startup status messages now display the installed versions of Claude, Codex, and Neovim.
  * Neovim version details use the first available line of its version output for clearer reporting.
  * Version lookup failures are shown as `?`, ensuring status messages remain informative even when version details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->