### PR TITLE
feat(seed): promote the slabledger self-check into the template

### DIFF
--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -279,13 +279,36 @@ else
   # damage shows up later as overlay files appearing in `git status`, with no
   # error anywhere. rename(2) within the same directory is atomic: readers see
   # either the old file or the new one.
-  {
+  #
+  # mktemp rather than a fixed "$GITIGNORE.tmp", for the same reason the plugin
+  # registry repair below uses one: `tee` opens by path with no O_EXCL, so two
+  # seeds sharing this home land on the SAME inode, and the first rename hands
+  # the second an open descriptor pointing at the live ~/.gitignore — which it
+  # then writes through, corrupting the file this block just published. That
+  # would make the atomicity claim above false in exactly the case it is meant
+  # to cover. An exclusive create per run cannot collide.
+  gi_tmp="$(as_user mktemp "$GITIGNORE.seed.XXXXXX")"
+  # Remove the temp on either failure: `set -e` aborts the seed on the very next
+  # line, so without these each failed start would strand one in the home dir
+  # for good — the fixed path at least got overwritten by the following run.
+  if ! {
     printf '%s\n' "$new_gitignore"
     printf '%s\n' "$GI_MARK_BEGIN"
     [ -n "$overlay_links" ] && printf '%s\n' "$overlay_links"
     printf '%s\n' "$GI_MARK_END"
-  } | as_user tee "$GITIGNORE.tmp" >/dev/null
-  as_user mv -f "$GITIGNORE.tmp" "$GITIGNORE"
+  } | as_user tee "$gi_tmp" >/dev/null; then
+    as_user rm -f "$gi_tmp"
+    echo "⚠️  seed: could not write ~/.gitignore overlay list — leaving original"
+    exit 1
+  fi
+  # mktemp creates 0600, so carry the live file's mode across rather than let
+  # the rename silently tighten it.
+  as_user chmod --reference="$GITIGNORE" "$gi_tmp" 2>/dev/null || true
+  if ! as_user mv -f "$gi_tmp" "$GITIGNORE"; then
+    as_user rm -f "$gi_tmp"
+    echo "⚠️  seed: could not replace ~/.gitignore — leaving original"
+    exit 1
+  fi
   n="$(printf '%s' "$overlay_links" | grep -c . || true)"
   echo "🌱 seed: refreshed ~/.gitignore overlay-symlink list ($n entries)"
 fi

--- a/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
+++ b/ai/marketplace/plugins/my/skills/project-claude-setup/templates/local-seed.sh
@@ -215,6 +215,17 @@ fi
 # `git status` and `git add`. The host can afford the broad patterns because its
 # overlay files are personal symlinks; the container cannot.
 GITIGNORE="$SEED_HOME/.gitignore"
+# `test -f` FOLLOWS symlinks, so a ~/.gitignore that arrived as a link — a stale
+# overlay shim, or an image that points the remoteUser's home dotfiles at a
+# baked-in copy — satisfies the guard below and is then written THROUGH by the
+# rewrite further down, editing whatever it targets instead of this file. That
+# target sits outside the container-local home and may be read-only, in which
+# case the tee fails and takes the whole seed with it under `set -e`. Drop the
+# link so the seed always owns a real file here.
+if as_user test -L "$GITIGNORE"; then
+  as_user rm -f "$GITIGNORE"
+  echo "🌱 seed: replaced symlinked ~/.gitignore with a container-local file"
+fi
 if ! as_user test -f "$GITIGNORE"; then
   as_user tee "$GITIGNORE" >/dev/null <<'GITEOF'
 .DS_Store
@@ -261,12 +272,20 @@ else
     -not -path './node_modules/*' 2>/dev/null | sed 's#^\./##' | sort)"
   # Rewrite the marked block: strip any existing one, then append the current set.
   new_gitignore="$(as_user sed "/^${GI_MARK_BEGIN}$/,/^${GI_MARK_END}$/d" "$GITIGNORE")"
+  # Write to a sibling temp and rename, rather than tee-ing over the live file.
+  # `tee` TRUNCATES before it writes, so an interrupted or short write (a killed
+  # start, a full overlay layer) leaves ~/.gitignore empty or half-written — and
+  # git treats a truncated excludes file as simply having fewer patterns, so the
+  # damage shows up later as overlay files appearing in `git status`, with no
+  # error anywhere. rename(2) within the same directory is atomic: readers see
+  # either the old file or the new one.
   {
     printf '%s\n' "$new_gitignore"
     printf '%s\n' "$GI_MARK_BEGIN"
     [ -n "$overlay_links" ] && printf '%s\n' "$overlay_links"
     printf '%s\n' "$GI_MARK_END"
-  } | as_user tee "$GITIGNORE" >/dev/null
+  } | as_user tee "$GITIGNORE.tmp" >/dev/null
+  as_user mv -f "$GITIGNORE.tmp" "$GITIGNORE"
   n="$(printf '%s' "$overlay_links" | grep -c . || true)"
   echo "🌱 seed: refreshed ~/.gitignore overlay-symlink list ($n entries)"
 fi
@@ -820,14 +839,32 @@ plugin_home_repair() {
 plugin_home_repair
 
 # ---------------------------------------------------------------------------
-# DRIFT CHECK — runs on BOTH the gated-skip and reseed paths.
-# Compares CONTENT against the host mount rather than trusting the sentinel, so
-# it reports staleness no matter the cause — including a seed still running the
-# old layout where this copy sat below the gate. This is the check that turns
-# "why is my model wrong" from a debugging session into a line in the log.
-# Advisory only: never exits nonzero, so a false positive cannot block startup.
+# SELF-CHECK — runs on BOTH the gated-skip and reseed paths.
+# Reports what a human would otherwise verify by hand after a rebuild. A
+# persisted volume can drift from the mounts without the sentinel ever changing,
+# so every check compares OBSERVED STATE against the host mount or the live
+# filesystem rather than trusting the sentinel. Advisory only: never exits
+# nonzero, so a false positive cannot block startup. Read it in the start log.
+#
+# Deliberately NOT checked here: the Vekil endpoint variables and the `codex`
+# function. Those only materialize in an INTERACTIVE LOGIN shell, which this
+# script is not — asserting them here would fail even when the hook is correct.
+# Verify those with: docker compose exec app zsh -lic 'print $ANTHROPIC_BASE_URL'
+#
+# Everything asserted below is established by the ALWAYS-RUN block above, which
+# is why the single invocation after this definition — above the gate — is
+# sufficient. Do not move checks here for anything installed below the gate:
+# on the gated-skip path those steps never ran this launch.
 # ---------------------------------------------------------------------------
-config_drift_check() {
+self_check() {
+  local fails=0
+  echo "🔎 seed self-check:"
+
+  # a0) Authored config actually matches the host mount. This is the check that
+  # turns "why is my model wrong" from a debugging session into a line in the
+  # log: it compares CONTENT against $SEED_CLAUDE rather than trusting the
+  # sentinel, so it reports staleness no matter the cause — including a seed
+  # still running the old layout where the copy sat below the gate.
   local drift=""
   # The SAME five seed-owned paths the copy above manages. Comparing a subset
   # would pass while commands/ or skills/ were stale.
@@ -856,16 +893,192 @@ config_drift_check() {
     echo "   FAIL  ~/.claude differs from host mount:$drift"
     echo "         seed may predate the always-run config copy — re-copy"
     echo "         local-seed.sh from the project-claude-setup skill"
+    fails=$((fails + 1))
   else
     echo "   PASS  authored ~/.claude matches host mount"
+  fi
+
+  # a1) ~/.dotfiles actually converged on the host copy. env.zsh exports
+  # ANTHROPIC_MODEL, which OUTRANKS settings.json, so drift here silently
+  # overrides every other piece of config the seed gets right — including the
+  # a0 check immediately above, which would still say PASS.
+  if [ -d "$SEED_DOTFILES" ]; then
+    if cmp -s "$SEED_DOTFILES/ai/vekil/env.zsh" "$DOTFILES_HOME/ai/vekil/env.zsh"; then
+      echo "   PASS  ~/.dotfiles/ai/vekil/env.zsh matches host"
+    else
+      echo "   FAIL  ~/.dotfiles/ai/vekil/env.zsh differs from host"
+      echo "         seed may predate the rsync converge — re-copy local-seed.sh"
+      echo "         from the project-claude-setup skill"
+      fails=$((fails + 1))
+    fi
+  fi
+
+  # a) The zshrc hook landed (written by the always-run block above).
+  if grep -Fq 'ai/vekil/env.zsh' "$ZSHRC" 2>/dev/null; then
+    echo "   PASS  ~/.zshrc contains the vekil hook"
+  else
+    echo "   FAIL  ~/.zshrc missing the vekil hook"
+    fails=$((fails + 1))
+  fi
+
+  # b) The hook TARGET exists and parses. `zsh -n` parses without executing, so
+  # this says nothing about proxy readiness — it separates "hook well-formed"
+  # from "Vekil answering", which otherwise present as the same empty variable.
+  if [ -f "$DOTFILES_HOME/ai/vekil/env.zsh" ] &&
+    zsh -n "$DOTFILES_HOME/ai/vekil/env.zsh" 2>/dev/null; then
+    echo "   PASS  ~/.dotfiles/ai/vekil/env.zsh exists and parses"
+  else
+    echo "   FAIL  ~/.dotfiles/ai/vekil/env.zsh missing or malformed"
+    fails=$((fails + 1))
+  fi
+
+  # c) The host-seed mount exposes ONLY the allowlist. This is the SECURITY
+  # assertion: anything unexpected here means the compose override regressed to
+  # a whole-directory mount, and host credentials and session transcripts are
+  # readable from inside the container.
+  if [ -d "$SEED_CLAUDE" ]; then
+    local expected="CLAUDE.md commands config settings.json skills"
+    local actual
+    actual="$(ls -A "$SEED_CLAUDE" 2>/dev/null | sort | tr '\n' ' ' | sed 's/ $//')"
+    if [ "$actual" = "$expected" ]; then
+      echo "   PASS  $SEED_CLAUDE exposes exactly the allowlist"
+    else
+      echo "   FAIL  $SEED_CLAUDE contents unexpected"
+      echo "         expected: $expected"
+      echo "         actual:   $actual"
+      fails=$((fails + 1))
+    fi
+    # Belt-and-braces: name the files that must never be reachable, so a future
+    # allowlist edit that adds one of them is caught by name and not just by the
+    # set comparison above.
+    local leaked=""
+    for bad in .credentials.json history.jsonl projects; do
+      [ -e "$SEED_CLAUDE/$bad" ] && leaked="$leaked $bad"
+    done
+    if [ -n "$leaked" ]; then
+      echo "   FAIL  host runtime state reachable in container:$leaked"
+      fails=$((fails + 1))
+    fi
+  else
+    echo "   WARN  no $SEED_CLAUDE mount present"
+  fi
+
+  # d) The container-local home is writable BY THE SEED USER, not stranded as
+  # root:root. Tested through as_user on purpose: this script may be running as
+  # root, for whom a root-owned ~/.claude is writable and the check would pass
+  # while every later `claude` invocation fails.
+  if as_user test -w "$CLAUDE_HOME"; then
+    echo "   PASS  ~/.claude writable by $SEED_USER"
+  else
+    echo "   FAIL  ~/.claude not writable by $SEED_USER"
+    fails=$((fails + 1))
+  fi
+
+  # e) The claude CLI binary actually resolves. This is the check that catches
+  # the ephemeral-vs-persisted split: the binary lives in the writable layer and
+  # is wiped on rebuild, so a regression that moves its install back under the
+  # version gate shows up here as a FAIL on the second start, not the first.
+  #
+  # PATH is pinned inline rather than reusing the marketplace PATH variable:
+  # that one is assigned below the gate, where the marketplace block needs it,
+  # and does not exist yet here — hoisting it would abort the seed under
+  # `set -u`. as_user is non-interactive and never sources ~/.zshrc, the only
+  # place ~/.local/bin joins PATH, so without this the check reports a false
+  # FAIL. (Named indirectly on purpose: spelling the variable here would make
+  # the catch-up audit's anchor for that row match this paragraph too.)
+  local claude_bin
+  if claude_bin="$(as_user env PATH="$SEED_HOME/.local/bin:$PATH" \
+    sh -c 'command -v claude' 2>/dev/null)"; then
+    echo "   PASS  claude CLI on PATH ($claude_bin)"
+  else
+    echo "   FAIL  claude CLI not on PATH"
+    fails=$((fails + 1))
+  fi
+
+  # f) The global gitignore that ~/.gitconfig points at is actually READABLE.
+  # Git silently treats a dangling excludesfile as empty, so the failure mode is
+  # invisible: personal overlay files (CLAUDE.local.md, .claude/) quietly appear
+  # as untracked in every repo. Resolve the configured path and read it.
+  # --global, not a plain --get: the seed's own write is global, and this script
+  # runs from an arbitrary cwd that need not be a repo at all.
+  local ex_raw ex_path
+  ex_raw="$(as_user git config --global --get core.excludesFile 2>/dev/null || true)"
+  if [ -z "$ex_raw" ]; then
+    echo "   WARN  git core.excludesFile unset (no global gitignore configured)"
+  else
+    ex_path="${ex_raw/#\~/$SEED_HOME}"
+    if [ -r "$ex_path" ] && grep -q 'CLAUDE.local.md' "$ex_path" 2>/dev/null; then
+      echo "   PASS  global gitignore readable at $ex_path"
+    else
+      echo "   FAIL  core.excludesFile=$ex_raw not readable — overlay files will show as untracked"
+      fails=$((fails + 1))
+    fi
+  fi
+
+  # g) The stable link root resolves to THIS container's dotfiles checkout. This
+  # is the check that catches the dangling-overlay-link bug directly: without it
+  # .claude/skills and CLAUDE.md are broken symlinks and Claude Code silently
+  # loses the project's skills and instructions.
+  if [ -L "$STABLE_LINK_ROOT" ] && [ -d "$STABLE_LINK_ROOT" ]; then
+    echo "   PASS  $STABLE_LINK_ROOT -> $(readlink "$STABLE_LINK_ROOT")"
+  else
+    echo "   FAIL  $STABLE_LINK_ROOT missing or not a directory symlink"
+    fails=$((fails + 1))
+  fi
+
+  # h) No overlay symlink in the workspace dangles. Matches on -xtype l (BROKEN
+  # links) rather than testing which ones resolve: the inverted form prints the
+  # HEALTHY links, so a real break prints nothing — which reads as success to
+  # anyone scanning for empty output.
+  if [ -d "$WORKSPACE" ]; then
+    local broken
+    broken="$(cd "$WORKSPACE" &&
+      find . -maxdepth 3 -lname '*dotfiles/projects/*' -xtype l 2>/dev/null)"
+    if [ -z "$broken" ]; then
+      echo "   PASS  no dangling overlay symlinks in $WORKSPACE"
+    else
+      echo "   FAIL  dangling overlay symlinks in $WORKSPACE:"
+      # Unquoted on purpose: split the newline-separated list into one line each.
+      # shellcheck disable=SC2086
+      printf '         %s\n' $broken
+      fails=$((fails + 1))
+    fi
+  fi
+
+  # i) Managed git hooks. Advisory (WARN, not FAIL): a missing commit-msg hook
+  # costs a stripped trailer, not a broken container.
+  local hooks_cfg
+  hooks_cfg="$(as_user git config --global --get core.hooksPath 2>/dev/null || true)"
+  if [ -n "$hooks_cfg" ] && [ -x "$hooks_cfg/commit-msg" ]; then
+    echo "   PASS  core.hooksPath -> $hooks_cfg"
+  else
+    echo "   WARN  core.hooksPath unset or commit-msg not executable"
+  fi
+
+  # j) EDITOR's target. WARN, not FAIL: core/env.zsh falls back to vim, so a
+  # missing nvim degrades rather than breaks — but a DANGLING ~/.local/bin/nvim
+  # does break `git commit`, and only this distinguishes the two.
+  if [ -f "$SEED_HOME/.local/bin/nvim" ] && [ -x "$SEED_HOME/.local/bin/nvim" ]; then
+    echo "   PASS  nvim installed ($("$SEED_HOME/.local/bin/nvim" --version 2>/dev/null | head -1))"
+  elif [ -e "$SEED_HOME/.local/bin/nvim" ] || [ -L "$SEED_HOME/.local/bin/nvim" ]; then
+    echo "   FAIL  ~/.local/bin/nvim exists but is not executable — EDITOR=nvim breaks git commit"
+    fails=$((fails + 1))
+  else
+    echo "   WARN  nvim not installed (EDITOR falls back to vim)"
+  fi
+
+  if [ "$fails" -eq 0 ]; then
+    echo "   → all checks passed"
+  else
+    echo "   → $fails check(s) FAILED (advisory; container still starting)"
   fi
   return 0
 }
 
 # Invoked here, ABOVE the gate, so it runs on BOTH paths — the gated-skip branch
-# below and the reseed path. Placed after the copy so it verifies the result of
-# this run rather than the previous one.
-config_drift_check
+# below and the reseed path. Placed after the copy and the installs so it
+# verifies the result of this run rather than the previous one.
+self_check
 
 # --- Versioned gate --------------------------------------------------------
 # Skip the gated INSTALL steps only when the sentinel already records this

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -227,16 +227,21 @@ FIX
 }
 
 @test "sd_scan puts the real template core.excludesFile block in one paragraph" {
+  # Two paragraphs carry the anchor: the config-writing block near the top, and
+  # self_check's check (f), which reads the same key back. Take the FIRST — this
+  # test guards the config block against being split by sd_scan mis-reading the
+  # `<<<` in GI_MARK_END as a heredoc (see the test two above), and `head -1`
+  # keeps that guard pointed at the block it was written for.
   run env SEED_DRIFT_SOURCE_ONLY=1 bash -c '
     source "$1"
     scan=$(sd_scan "$2")
-    para=$(printf "%s\n" "$scan" | awk -F"\t" "\$3 == \"C\" && index(\$4, \"core.excludesFile\") { print \$1 }")
+    para=$(printf "%s\n" "$scan" | awk -F"\t" "\$3 == \"C\" && index(\$4, \"core.excludesFile\") { print \$1 }" | head -1)
     printf "%s\n" "$scan" | awk -F"\t" -v p="$para" "\$1 == p { print \$2 }" |
       awk "NR == 1 { first = \$0 } { last = \$0 } END { print first, last }"
   ' _ "$SEED_DRIFT" "$REAL_TEMPLATE"
 
   [ "$status" -eq 0 ]
-  [ "$output" = "204 236" ]
+  [ "$output" = "204 247" ]
 }
 
 @test "sd_scan excludes herestrings and recognizes every delimiter form" {


### PR DESCRIPTION
Three changes lifted from `slabledger`'s `local-seed.sh`, which had drifted **AHEAD** of the template. Found by `bin/seed-drift` during a catch-up pass on that project's seed; the seed itself was left untouched.

All three land in the **always-run** block, so `SEED_VERSION` is deliberately **not** bumped — their targets don't persist in the named volume, and a bump would only force pointless reseeds.

## 1. `config_drift_check` → `self_check`

The old function verified one thing: `~/.claude` matches the host mount. That becomes check `a0`; eleven more join it, each corresponding to a failure that has actually cost a debugging session.

| | Check | Why it exists |
|---|---|---|
| `a1` | `~/.dotfiles/ai/vekil/env.zsh` matches host | `env.zsh` exports `ANTHROPIC_MODEL`, which **outranks** `settings.json` — drifts silently while `a0` still says PASS |
| `a` | `~/.zshrc` carries the vekil hook | |
| `b` | hook target exists and parses (`zsh -n`) | separates "hook malformed" from "Vekil not answering" — same empty variable otherwise |
| `c` | `/host-seed/.claude` exposes **exactly** the allowlist | **security assertion.** Plus a by-name check that `.credentials.json`, `history.jsonl`, `projects/` are unreachable — fails loudly if the compose override regresses to a whole-directory mount |
| `d` | `~/.claude` writable **by the seed user** | via `as_user`: as root the naive test passes while every later `claude` call fails |
| `e` | `claude` CLI resolves | catches the ephemeral-vs-persisted split on the *second* start |
| `f` | `core.excludesFile` readable | git treats a dangling one as empty — overlay files silently show as untracked |
| `g` | stable link root is a directory symlink | |
| `h` | no dangling overlay symlink in the workspace | matches `-xtype l`; the inverted form prints healthy links, so a real break prints nothing and reads as success |
| `i` | `core.hooksPath` | WARN — costs a stripped trailer, not a container |
| `j` | nvim installed **vs dangling** | WARN vs FAIL: a dangling `~/.local/bin/nvim` breaks `git commit`; a missing one falls back to vim |

Advisory throughout — returns 0 unconditionally, so a false positive can't stop a container coming up. Still invoked **once, above the gate**, so it runs on both the gated-skip and reseed paths. Everything it asserts is established by the always-run block above it.

## 2. Drop a symlinked `~/.gitignore` before writing it

`test -f` **follows symlinks**, so a `~/.gitignore` arriving as a link satisfied the existing guard and the rewrite then wrote *through* it.

Verified against the pre-change template — link pointing at a read-only file:

```
tee: /tmp/.../home/.gitignore: Permission denied
OLD-BLOCK-EXIT=1
```

Under `set -e` that takes down the whole seed and surfaces as an unrelated-looking container start error. With the guard: link dropped, host-owned target untouched, seed continues.

## 3. Make the gitignore rewrite atomic

`tee` **truncates before writing**, so an interrupted write left the file empty or partial. Git reads a truncated excludes file as simply having fewer patterns — no error, and the damage shows up later as overlay files in `git status`. Now writes `.tmp` and renames.

## Knock-on effects worth knowing

- `self_check` reads `core.excludesFile`, `core.hooksPath`, and the overlay `-lname` glob, so **those three audit anchors now match two paragraphs** in the template instead of one. `sd_extract` unions them — which is what makes `seed-drift` report `self_check` drift at all, since there's no table row for it. Seeds that already carry `self_check` (slabledger) converge; seeds that don't now read `BEHIND` on those three, correctly.
- A comment in check `e` was reworded to avoid the literal token `SEED_PATH`, which would otherwise have pulled an above-the-gate paragraph into that anchor's window — the one row documented as living *below* the gate.
- `tests/seed_drift.bats` pinned that anchor to a single paragraph. It now takes the first match, keeping it aimed at the block it was written to guard.

## Verification

- `make check` passes; **bats 469/469**, no failures (baseline was also 469).
- `shellcheck -x -S warning`, `shfmt -d -i 2 -ci`, `bash -n` all clean on the template; confirmed the template is in scope for all three via `bin/list-check-files`.
- `self_check` executed standalone under `set -euo pipefail` in three scenarios — nothing present, everything present, and a seeded credential leak plus dangling overlay links. Returned 0 in all three; named every regression:

```
FAIL  host runtime state reachable in container: .credentials.json history.jsonl projects
FAIL  dangling overlay symlinks in /tmp/.../workspace:
      ./.claude
      ./CLAUDE.md
```

- Gitignore block exercised against a read-only symlinked target and re-run for idempotence: one marker pair, no leftover `.tmp`.

## Not in this PR

- No `catch-up-local-seed.md` table row for `self_check` — the block table is pinned at ten rows by `tests/seed_drift.bats`, and adding one changes the audit for every project. Worth deciding separately.
- slabledger's busybox-`diff` fallback in check `a0` (for images whose `diff` lacks `--no-dereference`) was left behind as out of scope here.
- No project seed was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup diagnostics for authored configuration, dotfiles, shell hooks, Git settings, CLI availability, ownership, host-seed permissions, workspace links, overlay links, hooks, and Neovim.
  * Fixed handling of symlinked Git ignore files during local setup.
  * Made overlay-ignore updates safer by applying them atomically, reducing the risk of incomplete configuration files.
  * Startup checks now run consistently before version validation, helping surface configuration issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->