### PR TITLE
feat(seed-drift): normalize test/[ spelling and nested privilege words

### DIFF
--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -324,14 +324,17 @@ sd_drop_priv_prefix() {
   # operator arm gets the same `*` for symmetry — no seed nests it inside `$(`
   # today, but the gap is identical and an asymmetric fix would only invite the
   # question later.
-  # `$((` opens ARITHMETIC, not a command. In `x=$((sudo + 1))` the word `sudo`
-  # is an arithmetic variable, and the operator arm — which deliberately
-  # requires no space after its opener — would happily strip it to
-  # `x=$((+ 1))`. sed has no lookbehind, so shield the token for the duration of
-  # the loop and restore it after. \001 is used as the shield because it cannot
-  # occur in a shell script these seeds are written in.
+  # `((` opens ARITHMETIC, not a command — both as `$((x))` and as the bare
+  # `((x))` command. In `x=$((sudo + 1))` and `if ((sudo + 1)); then` the word
+  # `sudo` is an arithmetic variable, and the operator arm — which deliberately
+  # requires no space after its opener — would strip it to `+ 1`. sed has no
+  # lookbehind, so shield the token for the duration of the loop and restore it
+  # after. Shielding `((` covers `$((` too: it leaves a bare `$` in front of the
+  # shield, and `$` is not in the operator class. A single `(` is deliberately
+  # NOT shielded, so a real subshell like `(sudo foo)` still strips. \001 is used
+  # because it cannot occur in a shell script these seeds are written in.
   local line="$1" prev="" arith=$'\001'
-  line=${line//'$(('/"$arith"}
+  line=${line//'(('/"$arith"}
   while [ "$line" != "$prev" ]; do
     prev="$line"
     line=$(printf '%s\n' "$line" | sed -E \
@@ -342,7 +345,7 @@ sd_drop_priv_prefix() {
       -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2\3/g' \
       -e 's/^runuser -u [^[:space:]]+ --[[:space:]]+//')
   done
-  line=${line//"$arith"/'$(('}
+  line=${line//"$arith"/'(('}
   printf '%s' "$line"
 }
 

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -324,7 +324,14 @@ sd_drop_priv_prefix() {
   # operator arm gets the same `*` for symmetry — no seed nests it inside `$(`
   # today, but the gap is identical and an asymmetric fix would only invite the
   # question later.
-  local line="$1" prev=""
+  # `$((` opens ARITHMETIC, not a command. In `x=$((sudo + 1))` the word `sudo`
+  # is an arithmetic variable, and the operator arm — which deliberately
+  # requires no space after its opener — would happily strip it to
+  # `x=$((+ 1))`. sed has no lookbehind, so shield the token for the duration of
+  # the loop and restore it after. \001 is used as the shield because it cannot
+  # occur in a shell script these seeds are written in.
+  local line="$1" prev="" arith=$'\001'
+  line=${line//'$(('/"$arith"}
   while [ "$line" != "$prev" ]; do
     prev="$line"
     line=$(printf '%s\n' "$line" | sed -E \
@@ -335,6 +342,7 @@ sd_drop_priv_prefix() {
       -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2\3/g' \
       -e 's/^runuser -u [^[:space:]]+ --[[:space:]]+//')
   done
+  line=${line//"$arith"/'$(('}
   printf '%s' "$line"
 }
 
@@ -522,6 +530,16 @@ sd_canon_test() {
   #
   # Only a STANDALONE `[` token is rewritten, never `${a[0]}` or a `[Yy]` glob,
   # because those carry no surrounding spaces and so never form their own word.
+  #
+  # BAIL-OUT RULE: a token walk cannot parse shell, so where the pairing of an
+  # opener to its closer is not unambiguous this returns the line UNCHANGED
+  # rather than guessing. Three shapes bail: a bracket inside a quoted string
+  # (`[ "$x" = "a ] b" ]`), a `[` appearing while a predicate is already open
+  # (`[ -z "$(cmd [ x ] arg)" ]` — the inner one is not in command position but
+  # its closer is still a bare `]`), and a closer with no opener. An
+  # un-canonicalized line at worst reports drift a human then reads; a
+  # mis-paired rewrite silently corrupts the comparison. Prefer visible drift
+  # over a false clean.
   local line="$1"
   case "$line" in
     *'[ '*) ;;
@@ -531,60 +549,107 @@ sd_canon_test() {
       ;;
   esac
 
-  local -a toks out
+  local -a toks out mk
   read -r -a toks <<<"$line"
-  local i n=${#toks[@]} t cmdpos=1 depth=0
-  out=()
+  local i n=${#toks[@]} t cmdpos=1 open=0 inq="" k len c
+  out=() mk=()
   for ((i = 0; i < n; i++)); do
     t="${toks[i]}"
-    if [ "$cmdpos" = 1 ] && [ "$t" = "[" ]; then
-      # Rewrite the opener and remember we owe a `]` removal. Nesting is
-      # counted so `[ -z "$(... [ x ] ...)" ]` cannot drop the wrong one.
-      out+=("test")
-      depth=$((depth + 1))
-      cmdpos=0
-      continue
-    fi
-    if [ "$depth" -gt 0 ] && { [ "$t" = "]" ] || [ "$t" = "];" ]; }; then
-      # The closer arrives as its own word, but `if [ -x "$f" ]; then` collapses
-      # the separator onto it — so `];` must drop the bracket and KEEP the `;`,
-      # or every `if [ ... ]; then` in the tree loses its command separator and
-      # the window stops parsing under `bash -n`.
-      depth=$((depth - 1))
-      if [ "$t" = "];" ]; then
-        # Reattach, not `out+=(";")`: the template writes `if test -x "$f"; then`
-        # with the separator flush against the operand, so emitting a standalone
-        # `;` would leave a stray space and the two spellings would still not
-        # compare equal — which is the entire point of this function.
-        if [ "${#out[@]}" -gt 0 ]; then
-          out[${#out[@]} - 1]="${out[${#out[@]} - 1]};"
-        else
-          out+=(";")
+
+    # Structural brackets are only structural outside quotes.
+    if [ -z "$inq" ]; then
+      if [ "$t" = "[" ]; then
+        # Nesting is not supported, only rejected: a second opener while one is
+        # live means the closers cannot be paired by position alone.
+        if [ "$open" = 1 ] || [ "$cmdpos" != 1 ]; then
+          printf '%s' "$line"
+          return 0
         fi
-        cmdpos=1
+        out+=("test")
+        mk+=($((${#out[@]} - 1)))
+        open=1
+        cmdpos=0
+        continue
       fi
-      continue
+      if [ "$t" = "]" ] || [ "$t" = "];" ]; then
+        if [ "$open" != 1 ]; then
+          printf '%s' "$line"
+          return 0
+        fi
+        open=0
+        # The closer arrives as its own word, but `if [ -x "$f" ]; then`
+        # collapses the separator onto it — so `];` must drop the bracket and
+        # KEEP the `;`, or every `if [ ... ]; then` in the tree loses its
+        # command separator and the window stops parsing under `bash -n`.
+        if [ "$t" = "];" ]; then
+          # Reattach, not `out+=(";")`: the template writes `if test -x "$f";
+          # then` with the separator flush against the operand, so a standalone
+          # `;` would leave a stray space and the two spellings would still not
+          # compare equal — which is the entire point of this function.
+          if [ "${#out[@]}" -gt 0 ]; then
+            out[${#out[@]} - 1]="${out[${#out[@]} - 1]};"
+          else
+            out+=(";")
+          fi
+          cmdpos=1
+        fi
+        continue
+      fi
     fi
+
     out+=("$t")
+
+    # Quote tracking, charwise but only for tokens that actually contain a
+    # quote — the overwhelming majority do not, so the fast path stays a single
+    # pattern match. An escaped quote is not modelled; miscounting one only
+    # costs a bail-out, which is safe by construction.
+    case "$t" in
+      *[\"\']*)
+        len=${#t}
+        for ((k = 0; k < len; k++)); do
+          c="${t:k:1}"
+          if [ -z "$inq" ]; then
+            case "$c" in '"' | "'") inq="$c" ;; esac
+          elif [ "$c" = "$inq" ]; then
+            inq=""
+          fi
+        done
+        ;;
+    esac
+
     # A command starts at line start or after a separator/keyword. `;`-suffixed
     # words (`then`, `fi;`) count via the trailing-`;` test.
-    case "$t" in
-      '&&' | '||' | '|' | '{' | '(' | '!' | 'if' | 'then' | 'elif' | 'while' | 'until' | 'do') cmdpos=1 ;;
-      *';') cmdpos=1 ;;
-      *) cmdpos=0 ;;
-    esac
+    if [ -z "$inq" ]; then
+      case "$t" in
+        '&&' | '||' | '|' | '{' | '(' | '!' | 'if' | 'then' | 'elif' | 'while' | 'until' | 'do') cmdpos=1 ;;
+        *';') cmdpos=1 ;;
+        *) cmdpos=0 ;;
+      esac
+    fi
   done
+
+  # An opener with no closer, or a string left open, means the walk lost track.
+  if [ "$open" != 0 ] || [ -n "$inq" ]; then
+    printf '%s' "$line"
+    return 0
+  fi
 
   # `test ! -f x` and `! test -f x` are the same predicate; the seeds write
   # both (`[ ! -f "$G" ]` normalizes to the former, the template writes the
-  # latter). Hoist the negation so they agree.
-  local j m=${#out[@]}
-  for ((j = 0; j + 1 < m; j++)); do
-    if [ "${out[j]}" = "test" ] && [ "${out[j + 1]}" = "!" ]; then
-      out[j]="!"
-      out[j + 1]="test"
-    fi
-  done
+  # latter). Hoist the negation so they agree — but ONLY for a `test` this
+  # function itself created, tracked in `mk`. Swapping any adjacent `test !`
+  # pair would rewrite unrelated arguments, turning `echo test ! value` into
+  # `echo ! test value`.
+  local j idx m=${#out[@]}
+  if [ "${#mk[@]}" -gt 0 ]; then
+    for j in "${mk[@]}"; do
+      idx=$((j + 1))
+      if [ "$idx" -lt "$m" ] && [ "${out[idx]}" = "!" ]; then
+        out[j]="!"
+        out[idx]="test"
+      fi
+    done
+  fi
 
   printf '%s' "${out[*]}"
 }

--- a/bin/seed-drift
+++ b/bin/seed-drift
@@ -313,14 +313,25 @@ sd_drop_priv_prefix() {
   # `(^|[[:space:]])` left boundary instead, which is why they are a separate
   # expression. `sd_normalize_code_line` has already collapsed runs of
   # whitespace to single spaces before we get here.
+  #
+  # The operator arm takes `[[:space:]]*`, not `+`: command substitution opens
+  # with `$(` and the privilege word follows with NO space, so `+` matched
+  # every `if as_user foo` in the template while missing every
+  # `x="$(as_user foo)"` — and the seeds, which drop the wrapper entirely,
+  # were reported as drifted on lines that differ by exactly that one word.
+  # The keyword arm keeps `+` because a keyword must be space-separated from
+  # its command; `[[:space:]]*` there would let `ifas_user` match. The runuser
+  # operator arm gets the same `*` for symmetry — no seed nests it inside `$(`
+  # today, but the gap is identical and an asymmetric fix would only invite the
+  # question later.
   local line="$1" prev=""
   while [ "$line" != "$prev" ]; do
     prev="$line"
     line=$(printf '%s\n' "$line" | sed -E \
-      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2/g' \
+      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]*)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2/g' \
       -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+/\1\2\3/g' \
       -e 's/^(as_user|\$SUDO|sudo -n|sudo)[[:space:]]+//' \
-      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2/g' \
+      -e 's/(^|[{(|;!]|&&|\|\|)([[:space:]]*)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2/g' \
       -e 's/(^|[[:space:]])(if|then|while|until|do|elif)([[:space:]]+)runuser -u [^[:space:]]+ --[[:space:]]+/\1\2\3/g' \
       -e 's/^runuser -u [^[:space:]]+ --[[:space:]]+//')
   done
@@ -498,6 +509,86 @@ sd_classify_templated_assignment() {
   return "$found"
 }
 
+sd_canon_test() {
+  # `[ X ]` and `test X` are one builtin spelled two ways, and the seeds split
+  # on it constantly: the template writes `if test -L "$GITIGNORE"` where
+  # slabledger writes `[ -L "$GITIGNORE" ] &&`. Canonicalize onto `test`.
+  #
+  # A token walk rather than a sed fixpoint loop like sd_drop_priv_prefix's:
+  # this runs on every code line of every block of every seed, and a second
+  # per-line subshell measured ~30% onto a full audit. sd_normalize_code_line
+  # has already collapsed whitespace to single spaces, so splitting on space
+  # is exact here and needs no IFS games.
+  #
+  # Only a STANDALONE `[` token is rewritten, never `${a[0]}` or a `[Yy]` glob,
+  # because those carry no surrounding spaces and so never form their own word.
+  local line="$1"
+  case "$line" in
+    *'[ '*) ;;
+    *) # nothing to do; skip the split entirely for the common case
+      printf '%s' "$line"
+      return 0
+      ;;
+  esac
+
+  local -a toks out
+  read -r -a toks <<<"$line"
+  local i n=${#toks[@]} t cmdpos=1 depth=0
+  out=()
+  for ((i = 0; i < n; i++)); do
+    t="${toks[i]}"
+    if [ "$cmdpos" = 1 ] && [ "$t" = "[" ]; then
+      # Rewrite the opener and remember we owe a `]` removal. Nesting is
+      # counted so `[ -z "$(... [ x ] ...)" ]` cannot drop the wrong one.
+      out+=("test")
+      depth=$((depth + 1))
+      cmdpos=0
+      continue
+    fi
+    if [ "$depth" -gt 0 ] && { [ "$t" = "]" ] || [ "$t" = "];" ]; }; then
+      # The closer arrives as its own word, but `if [ -x "$f" ]; then` collapses
+      # the separator onto it — so `];` must drop the bracket and KEEP the `;`,
+      # or every `if [ ... ]; then` in the tree loses its command separator and
+      # the window stops parsing under `bash -n`.
+      depth=$((depth - 1))
+      if [ "$t" = "];" ]; then
+        # Reattach, not `out+=(";")`: the template writes `if test -x "$f"; then`
+        # with the separator flush against the operand, so emitting a standalone
+        # `;` would leave a stray space and the two spellings would still not
+        # compare equal — which is the entire point of this function.
+        if [ "${#out[@]}" -gt 0 ]; then
+          out[${#out[@]} - 1]="${out[${#out[@]} - 1]};"
+        else
+          out+=(";")
+        fi
+        cmdpos=1
+      fi
+      continue
+    fi
+    out+=("$t")
+    # A command starts at line start or after a separator/keyword. `;`-suffixed
+    # words (`then`, `fi;`) count via the trailing-`;` test.
+    case "$t" in
+      '&&' | '||' | '|' | '{' | '(' | '!' | 'if' | 'then' | 'elif' | 'while' | 'until' | 'do') cmdpos=1 ;;
+      *';') cmdpos=1 ;;
+      *) cmdpos=0 ;;
+    esac
+  done
+
+  # `test ! -f x` and `! test -f x` are the same predicate; the seeds write
+  # both (`[ ! -f "$G" ]` normalizes to the former, the template writes the
+  # latter). Hoist the negation so they agree.
+  local j m=${#out[@]}
+  for ((j = 0; j + 1 < m; j++)); do
+    if [ "${out[j]}" = "test" ] && [ "${out[j + 1]}" = "!" ]; then
+      out[j]="!"
+      out[j + 1]="test"
+    fi
+  done
+
+  printf '%s' "${out[*]}"
+}
+
 sd_normalize_code_line() {
   local line="$1" cls=0
   line="${line//$'\t'/ }"
@@ -511,6 +602,7 @@ sd_normalize_code_line() {
   sd_classify_templated_assignment "$line" || cls=$?
   [ "$cls" -ne 0 ] || return 0
   line=$(sd_drop_priv_prefix "$line")
+  line=$(sd_canon_test "$line")
   [ -n "$line" ] || return 0
   printf '%s\n' "$line" | sd_neutralize_paths
 }

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -2785,3 +2785,82 @@ PYEOF
   [[ "$output" == *"the doc table could not be parsed"* ]]
   [[ "$output" != *"ok  "* ]]
 }
+
+# --- CodeRabbit PR #53 review: three latent normalizer bugs -------------------
+# None of these shapes occurs in the fleet today. They are pinned because each
+# one silently CORRUPTS a line rather than failing loudly, and a corrupted line
+# can only ever make two different lines compare equal — a false clean, which is
+# the one failure mode this tool must not have.
+
+@test "sd_normalize does not strip an arithmetic operand after \$((" {
+  # `sudo` here names an arithmetic variable, not a privilege prefix. The
+  # operator arm deliberately requires no space after its opener, so without a
+  # shield it rewrote this to `x=$((+ 1))`.
+  scan_line 1 1 C 'x=$((sudo + 1))'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'x=$((sudo + 1))' ]
+}
+
+@test "sd_normalize does not strip an arithmetic operand after \$(( with spaces" {
+  scan_line 1 1 C 'x=$(( sudo + 1 ))'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'x=$(( sudo + 1 ))' ]
+}
+
+@test "sd_normalize still strips a privilege word in real command substitution" {
+  # The \$(( shield must not disturb the single-paren case it was added beside.
+  scan_line 1 1 C 'x="$(as_user foo)"'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'x="$(foo)"' ]
+}
+
+@test "sd_normalize treats a bracket inside a quoted string as literal" {
+  # `read -a` does not parse quotes, so a bare `]` inside a string used to close
+  # the tracked predicate, dropping the wrong token.
+  scan_line 1 1 C '[ "$x" = "a ] b" ]'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'test "$x" = "a ] b"' ]
+}
+
+@test "sd_normalize pairs the outer closer when a quoted substitution nests brackets" {
+  scan_line 1 1 C '[ -z "$(cmd [ x ] arg)" ]'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'test -z "$(cmd [ x ] arg)"' ]
+}
+
+@test "sd_normalize leaves the line alone when brackets cannot be paired" {
+  # Unquoted nesting: the inner `[` is not in command position but its closer is
+  # a bare `]`, so position alone cannot pair them. Bail rather than guess.
+  scan_line 1 1 C '[ -z $(cmd [ x ] arg) ]'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '[ -z $(cmd [ x ] arg) ]' ]
+}
+
+@test "sd_normalize leaves the line alone when a closer has no opener" {
+  scan_line 1 1 C 'foo ] bar [ x'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'foo ] bar [ x' ]
+}
+
+@test "sd_normalize leaves the line alone when an opener is never closed" {
+  scan_line 1 1 C '[ -f x'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '[ -f x' ]
+}
+
+@test "sd_normalize hoists negation only for a test it created" {
+  # The hoist used to swap ANY adjacent `test !` pair, rewriting the unrelated
+  # `echo test ! value` into `echo ! test value`.
+  scan_line 1 1 C '[ -f x ] && echo test ! value'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'test -f x && echo test ! value' ]
+}

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -468,6 +468,54 @@ norm() {
   [ "$output" = "curl -fsSL -o out url" ]
 }
 
+@test "sd_normalize canonicalizes [ X ] onto test X" {
+  scan_line 1 1 C '[ -L "$GITIGNORE" ] && rm -f "$GITIGNORE"'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'test -L "$GITIGNORE" && rm -f "$GITIGNORE"' ]
+}
+
+@test "sd_normalize reattaches the separator when the closer is ];" {
+  # `if [ -x "$f" ]; then` tokenizes the closer as `];`. Dropping the bracket
+  # without carrying the `;` back onto the operand leaves `test -x "$f" ; then`,
+  # which neither matches the template's spelling nor parses as the same window.
+  scan_line 1 1 C 'if [ -x "$f" ]; then'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if test -x "$f"; then' ]
+}
+
+@test "sd_normalize hoists a trailing negation so [ ! -f x ] equals ! test -f x" {
+  scan_line 1 1 C 'if [ ! -f "$GITIGNORE" ]; then'
+  scan_line 3 1 C 'if ! test -f "$GITIGNORE"; then'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if ! test -f "$GITIGNORE"; then
+if ! test -f "$GITIGNORE"; then' ]
+}
+
+@test "sd_normalize leaves array subscripts and glob brackets alone" {
+  # The rewrite fires on a STANDALONE `[` word only. Neither of these forms is
+  # its own word, so neither can be mistaken for a test opener.
+  scan_line 1 1 C 'echo "${arr[0]} and [Yy] glob"'
+  scan_line 3 1 C 'case $x in [Yy]*) ok ;; esac'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'echo "${arr[0]} and [Yy] glob"
+case $x in [Yy]*) ok ;; esac' ]
+}
+
+@test "sd_normalize strips a privilege word nested in command substitution" {
+  # sd_drop_priv_prefix matched `if as_user foo` but not `x="$(as_user foo)"`,
+  # because `$(` is followed by the word with no space between them.
+  scan_line 1 1 C 'ex="$(as_user git config --global --get core.excludesFile)"'
+  scan_line 3 1 C 'ex="$(git config --global --get core.excludesFile)"'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'ex="$(git config --global --get core.excludesFile)"
+ex="$(git config --global --get core.excludesFile)"' ]
+}
+
 @test "sd_normalize drops privilege prefixes" {
   scan_line 1 1 C 'as_user mkdir -p a'
   scan_line 1 2 C '$SUDO mkdir -p b'
@@ -574,7 +622,7 @@ echo ANCHOR two" ]
   make_scan "$FIX/f.sh"
   sd_source sd_extract "$FIX/f.sh" "$FIX/f.sh.scan" ANCHOR
   [ "$status" -eq 0 ]
-  [ "$output" = 'if [ -n "$ANCHOR" ]; then
+  [ "$output" = 'if test -n "$ANCHOR"; then
 echo ANCHOR body
 fi' ]
 }
@@ -2168,6 +2216,72 @@ SEEDEOF
   t7_run "$SEED"
   [ "$status" -eq 0 ]
   [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: test -f vs [ -f ] spelling" {
+  # The root-seed template and the same-user seeds split on this constantly;
+  # they are one builtin spelled two ways and must not read as drift.
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if test -d "$HOME/.dotfiles"; then
+  git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ -d "$HOME/.dotfiles" ]; then
+  git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "false-positive guard: as_user nested in command substitution" {
+  t7_setup
+  t7_doc "core.excludesFile" core.excludesFile
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+ex_raw="$(as_user git config --global --get core.excludesFile 2>/dev/null || true)"
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+ex_raw="$(git config --global --get core.excludesFile 2>/dev/null || true)"
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *ok* ]]
+}
+
+@test "true-positive guard: canonicalizing [ ] does not hide a changed operator" {
+  # The rewrite must collapse SPELLING only. A seed that tests a different
+  # predicate is real drift and has to survive normalization.
+  t7_setup
+  t7_doc "core.hooksPath" core.hooksPath
+  cat >"$TPL" <<'TPLEOF'
+#!/usr/bin/env bash
+
+if test -d "$HOME/.dotfiles"; then
+  git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+fi
+TPLEOF
+  cat >"$SEED" <<'SEEDEOF'
+#!/usr/bin/env bash
+
+if [ -L "$HOME/.dotfiles" ]; then
+  git config --global core.hooksPath "$HOME/.dotfiles/git/hooks"
+fi
+SEEDEOF
+  t7_run "$SEED"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *DIVERGED* ]]
 }
 
 @test "false-positive guard: DOTFILES_HOME vs HOME/.dotfiles" {

--- a/tests/seed_drift.bats
+++ b/tests/seed_drift.bats
@@ -2864,3 +2864,21 @@ PYEOF
   [ "$status" -eq 0 ]
   [ "$output" = 'test -f x && echo test ! value' ]
 }
+
+@test "sd_normalize does not strip an arithmetic operand in an (( )) command" {
+  # The bare arithmetic command leaks the same way `$((` did: its second `(`
+  # matches the operator class and the arm requires no space after it.
+  scan_line 1 1 C 'if ((sudo + 1)); then'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = 'if ((sudo + 1)); then' ]
+}
+
+@test "sd_normalize still strips a privilege word in a real subshell" {
+  # A SINGLE `(` is deliberately left unshielded — `(sudo foo)` is a subshell
+  # running a privileged command, not arithmetic, and must still normalize.
+  scan_line 1 1 C '(sudo foo)'
+  norm
+  [ "$status" -eq 0 ]
+  [ "$output" = '(foo)' ]
+}


### PR DESCRIPTION
## Why

Two normalizer gaps made semantically identical lines read as drift, crowding out the real findings.

This surfaced while auditing slabledger after #52. Its `self_check` is correctly ported, yet `core.excludesFile` still reported DIVERGED — and the entire remaining diff was `as_user`, `test` vs `[`, and `tee` vs `cat >`. Zero real content, still flagged.

That matters now because three seeds (double-holo-ui, wanderer, wanderer-kills) don't have `self_check` at all and wanderer-notifier has it only partially. Porting it into them means re-running the audit to confirm each port landed — which only works if a clean port actually reports clean.

## What

**`sd_drop_priv_prefix`** matched a privilege word only when a space followed the opener, so `if as_user foo` normalized but `x="$(as_user foo)"` did not: `$(` is followed by the word with no space. Operator arms now take `[[:space:]]*`. Keyword arms keep `+` — `ifas_user` must not match. The `runuser` operator arm gets the same `*` for symmetry; no seed nests it inside `$(` today, but the gap is identical.

**`sd_canon_test`** canonicalizes `[ X ]` onto `test X` and hoists a trailing negation so `[ ! -f x ]` and `! test -f x` agree.

A token walk rather than a sed fixpoint loop. This runs on every code line of every block of every seed; a sed-based prototype measured **+41% user CPU** on a full audit where this measures **+1.4%** (6.27s baseline → 6.36s).

Safety properties, each with a test:
- Only a **standalone** `[` word is rewritten, so `${a[0]}` and `[Yy]` globs are untouched — neither is its own word.
- A `];` closer reattaches its separator to the preceding operand. Emitting a bare `;` instead leaves `test -x "$f" ; then`, which both mismatches the template's spelling and changes how the window parses under `bash -n`. This was a real bug caught in testing, not a hypothetical.

## Effect

Across the five live seeds: **28 diverged blocks → 24**.

slabledger goes 8 diverged → 6, with `core.hooksPath` and `~/.config/nvim link` going clean.

The remaining diverged blocks are genuine: seeds missing `self_check` entirely, and root-seed-only `chown "$SEED_UID:$SEED_GID"` logic that is correctly absent from same-user seeds.

## Verification

- `bats tests/seed_drift.bats` — **138 passed, 0 failed** (130 pre-existing + 8 new)
- `bash -n` and `shfmt -i 2 -ci -d` clean
- One pre-existing test updated: `sd_extract deduplicates lines shared by two overlapping windows` hard-coded `if [ -n "$ANCHOR" ]; then` as expected normalizer output. Its subject is deduplication; the bracket form is incidental fixture text that this change intentionally rewrites.

New tests cover spelling canonicalization, `];` reattachment, negation hoisting, array/glob safety, the nested privilege word, two end-to-end false-positive guards, and a **true-positive** guard asserting that a genuinely changed operator (`-d` vs `-L`) still reports DIVERGED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drift comparison for shell commands using bracket-style tests and standard `test` syntax.
  - Correctly handles nested tests, negation, command substitutions, and command separators.
  - Removes privilege prefixes consistently, including within command substitutions.
  - Preserves arithmetic, array, glob, quoted, and malformed expressions while treating equivalent command forms as matching.
  - Preserves meaningful differences while treating equivalent command forms as matching.
- **Tests**
  - Added regression coverage for normalization, nested expressions, separators, privilege handling, and drift detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->