### PR TITLE
feat(claude): opt out of commit, PR, and session-URL attribution

### DIFF
--- a/ai/claude/settings.json
+++ b/ai/claude/settings.json
@@ -75,6 +75,11 @@
     "defaultMode": "acceptEdits"
   },
   "model": "claude-fable-5[1m]",
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/ai/marketplace/plugins/my/skills/overnight-improve/SKILL.md
+++ b/ai/marketplace/plugins/my/skills/overnight-improve/SKILL.md
@@ -114,7 +114,7 @@ You are running one iteration of an autonomous overnight improvement loop. The s
 - You may NOT: force-push, switch/merge/delete branches, run `git clean -fd`, run any `--no-verify` variant, touch any other branch.
 - During PHASE 2 (wrap-up) ONLY, you MAY `git push -u origin HEAD`, run `gh pr create`, run additional `git push` commands for follow-up commits, and invoke the `coderabbit:autofix` skill. These permissions do NOT apply during normal iteration work — only inside the wrap-up phase below.
 - You may run any read-only command (tests, lint, typecheck, build).
-- Commits must include the `Co-Authored-By: Claude` trailer and a clear subject `improve: <finding title>`.
+- Commits must use a clear subject `improve: <finding title>`. Do not hand-write a `Co-Authored-By` trailer — commit attribution is governed by the `attribution` setting in `~/.claude/settings.json`.
 
 == STATE TRACKING ==
 
@@ -195,7 +195,7 @@ W4. Address CodeRabbit in rounds. CodeRabbit (`coderabbitai[bot]`) auto-reviews 
 
 Use the `coderabbit:autofix` skill in batch mode against the PR for each round (Claude Code). On Pi, if `coderabbit:autofix` is not installed, fetch the latest review with `gh pr view "$PR" --comments` and apply fixes inline; if there is no clear automated path for a comment, skip it and log `manual: <comment-id> deferred` rather than silently dropping it. After each round:
 - Re-run all gates (the same ones from step 5)
-- If gates pass and there are file changes, commit with subject `improve: address coderabbit review (round <N>)` (with Co-Authored-By trailer) and push
+- If gates pass and there are file changes, commit with subject `improve: address coderabbit review (round <N>)` and push
 - If gates fail after autofix, `git reset --hard HEAD` and log `autofix broke <gate>, rolled back` — break the loop, do NOT push a broken commit
 
 Stop conditions for the wrap loop (any breaks):


### PR DESCRIPTION
## What

Set `attribution` in the global Claude settings so Claude Code emits no byline anywhere:

```json
"attribution": {
  "commit": "",
  "pr": "",
  "sessionUrl": false
},
```

`attribution` supersedes the deprecated `includeCoAuthoredBy` (Claude Code 2.0.62). The `sessionUrl` sub-key is the recent addition (2.1.183) — it omits the claude.ai session link from commits and PRs created in web and Remote Control sessions.

Also drops the hand-written `Co-Authored-By: Claude` mandate from `overnight-improve` (two places), which directly contradicted `commit: ""`. Attribution is now governed in one place.

## Propagation

No further changes were needed to reach every project:

- `~/.claude/settings.json` symlinks to `ai/claude/settings.json`, and user settings apply to all projects unless a project overrides the key. All six overlays under `.dotfiles/projects/` define only `permissions` — nothing shadows `attribution`.
- `project-claude-setup` never writes `attribution`; its Step 5 confines project overlays to permission allowlists.
- Devcontainers already mount `~/.claude/settings.json` read-only at `/host-seed/.claude/settings.json` and copy it in the seed's **always-run** block — deliberately not behind the `SEED_VERSION` gate, per the clause-2 reasoning in `project-claude-setup/SKILL.md`. Containers pick this up on next start with no version bump and no drift-detector change.

## Note

`core/git/git-hooks.symlink/commit-msg` already stripped `Co-authored-by:` trailers host-wide, so `commit: ""` overlaps with it. The setting still adds value: it makes the intent declarative rather than a post-hoc scrub, and covers PR bodies and session URLs the hook cannot touch.

## Verification

- `jq -e '.attribution' ai/claude/settings.json` parses clean.
- `bats tests/repository_hygiene.bats tests/project_claude_setup_seed.bats tests/seed_drift.bats tests/feature_workflow_policy.bats` — 220 ok, 0 failures.
- `bats tests/git_commit_msg_hook.bats` — 6 ok.

## Reviewer focus

The `overnight-improve` wording change — confirm that removing the trailer requirement from autonomous overnight commits is what you want, since those are the commits most likely to benefit from explicit marking.
