### PR TITLE
fix(dev): keep devcontainer up from being stopped by SIGTTIN

### DIFF
--- a/tools/dev/lib/container.sh
+++ b/tools/dev/lib/container.sh
@@ -47,7 +47,13 @@ dev_container_up() {
   local out_file err_file status=0
   out_file=$(mktemp)
   err_file=$(mktemp)
-  timeout "$timeout_s" "${argv[@]}" >"$out_file" 2>"$err_file" || status=$?
+  # </dev/null is load-bearing: GNU timeout runs its child in a NEW process
+  # group, which is a background group on the invoking terminal. If the CLI
+  # then reads its inherited-tty stdin, the kernel stops it with SIGTTIN and
+  # the whole `dev open` hangs silently forever — the timeout clock keeps
+  # ticking against a process that is asleep, not slow. The up call is
+  # non-interactive by design (dev-autostart runs it with no tty at all).
+  timeout "$timeout_s" "${argv[@]}" </dev/null >"$out_file" 2>"$err_file" || status=$?
 
   local json="" line
   while IFS= read -r line; do


### PR DESCRIPTION
## Summary

First real-terminal run of `dev <workspace>` hung silently forever. Root cause: GNU `timeout` puts `devcontainer up` in a new (background) process group, and a first-run stdin read from the CLI pipeline drew SIGTTIN — kernel-stopped, so even the 300s timeout never fired. Diagnosed live from /proc (state `Tl`, `do_signal_stop`, fd 0 = the user's tty).

One-line fix: `</dev/null` on the up invocation, with a comment naming the mechanism. The call is non-interactive by design — dev-autostart already runs it with no tty.

Untestable-by-stubs class: the suite's stubs never read stdin, so 705 green tests couldn't see it.

## Verification
- shellcheck/shfmt clean on container.sh
- dev_runtime_container + dev_commands + dev_lifecycle: 75/75
- Audited: this is the only timeout-wrapped (new-pgroup) invocation in the platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)