### PR TITLE
feat(dev): route agent windows through the vekil proxy when it is up

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -82,7 +82,7 @@ dev_main() {
     cmd_file="$DEV_DOTFILES_ROOT/tools/dev/commands/open.sh"
   fi
 
-  for lib in resolve config events state fold reconcile runtime container backend-tmux; do
+  for lib in resolve config events state fold reconcile runtime vekil container backend-tmux; do
     # shellcheck source=/dev/null
     source "$DEV_DOTFILES_ROOT/tools/dev/lib/${lib}.sh"
   done

--- a/tests/dev_backend_tmux.bats
+++ b/tests/dev_backend_tmux.bats
@@ -5,6 +5,7 @@ load test_helper
 setup() {
   setup_dev_test
   source "$REPO_ROOT/tools/dev/lib/events.sh"
+  source "$REPO_ROOT/tools/dev/lib/vekil.sh"
   source "$REPO_ROOT/tools/dev/lib/container.sh"
   source "$REPO_ROOT/tools/dev/lib/backend-tmux.sh"
   export TEST_WT="$TEST_ROOT/workspace/proj"

--- a/tests/dev_commands.bats
+++ b/tests/dev_commands.bats
@@ -274,6 +274,7 @@ dev_open_load_libs() {
   source "$REPO_ROOT/tools/dev/lib/fold.sh"
   source "$REPO_ROOT/tools/dev/lib/reconcile.sh"
   source "$REPO_ROOT/tools/dev/lib/runtime.sh"
+  source "$REPO_ROOT/tools/dev/lib/vekil.sh"
   source "$REPO_ROOT/tools/dev/lib/container.sh"
   source "$REPO_ROOT/tools/dev/lib/backend-tmux.sh"
   source "$REPO_ROOT/tools/dev/commands/open.sh"

--- a/tests/dev_runtime_container.bats
+++ b/tests/dev_runtime_container.bats
@@ -209,7 +209,10 @@ JSON
 
 # --- Task 10: container -----------------------------------------------------
 
-load_container() { source "$REPO_ROOT/tools/dev/lib/container.sh"; }
+load_container() {
+  source "$REPO_ROOT/tools/dev/lib/vekil.sh"
+  source "$REPO_ROOT/tools/dev/lib/container.sh"
+}
 
 CFG_AUTO='{"devcontainer":{"enabled":"auto","start_timeout":300}}'
 
@@ -501,4 +504,65 @@ JSON
   run dev_runtime_kind "$WT"
   [ "$status" -eq 0 ]
   [ "$output" = compose ]
+}
+
+# --- vekil proxy overlay -----------------------------------------------------
+
+# Ready proxy state + a curl stub answering the readyz probe.
+vekil_ready_fixture() {
+  export VEKIL_STATE_DIR="$TEST_ROOT/vekil"
+  mkdir -p "$VEKIL_STATE_DIR"
+  printf '127.0.0.1\n' >"$VEKIL_STATE_DIR/proxy-host"
+  : >"$VEKIL_STATE_DIR/proxy-ready"
+  stub_command curl 'exit 0'
+}
+
+@test "an agent window gets the vekil env when the proxy is ready" {
+  load_container
+  vekil_ready_fixture
+  rec='{"worktree":"/w","container":{"status":"none","id":null}}'
+  run dev_window_inner_command "$rec" '{"name":"agent-1","agent":"claude","location":"host"}' '{}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ANTHROPIC_BASE_URL='http://127.0.0.1:1337'"* ]]
+  [[ "$output" == *"ANTHROPIC_API_KEY='dummy'"* ]]
+  [[ "$output" == *"; exec claude"* ]]
+}
+
+@test "a container-located agent reaches the proxy as host.docker.internal" {
+  load_container
+  vekil_ready_fixture
+  rec='{"worktree":"/w","container":{"status":"ready","id":"cid1","user":"node","workdir":"/w"}}'
+  run dev_window_inner_command "$rec" '{"name":"agent-1","agent":"claude","location":null}' '{}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ANTHROPIC_BASE_URL='http://host.docker.internal:1337'"* ]]
+}
+
+@test "no vekil env is injected when the readyz probe fails" {
+  load_container
+  vekil_ready_fixture
+  stub_command curl 'exit 7'
+  rec='{"worktree":"/w","container":{"status":"none","id":null}}'
+  run dev_window_inner_command "$rec" '{"name":"agent-1","agent":"claude","location":"host"}' '{}'
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ANTHROPIC_BASE_URL"* ]]
+}
+
+@test "a declared environment key beats the vekil overlay" {
+  load_container
+  vekil_ready_fixture
+  rec='{"worktree":"/w","container":{"status":"none","id":null}}'
+  run dev_window_inner_command "$rec" '{"name":"agent-1","agent":"claude","location":"host"}' \
+    '{"ANTHROPIC_MODEL":"claude-fable-5"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ANTHROPIC_MODEL='claude-fable-5'"* ]]
+  [[ "$output" != *"claude-opus-5"* ]]
+}
+
+@test "command windows get no vekil overlay" {
+  load_container
+  vekil_ready_fixture
+  rec='{"worktree":"/w","container":{"status":"none","id":null}}'
+  run dev_window_inner_command "$rec" '{"name":"shell","command":"make test","location":"host"}' '{}'
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ANTHROPIC_BASE_URL"* ]]
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -36,6 +36,10 @@ setup_dev_test() {
   export DEV_REPO_ROOT="$TEST_ROOT/workspace"
   export DEV_OVERLAY_ROOT="$TEST_ROOT/overlay"
   export DEV_TMUX_SOCKET="devtest-$$-$BATS_TEST_NUMBER"
+  # Point the vekil probe at a directory that does not exist, so tests never
+  # see the developer machine's real proxy state (XDG_STATE_HOME can leak in
+  # from the invoking environment; HOME scoping alone does not cover it).
+  export VEKIL_STATE_DIR="$TEST_ROOT/no-vekil"
   mkdir -p "$DEV_STATE_ROOT/workspaces" "$DEV_STATE_ROOT/events" \
     "$DEV_STATE_ROOT/locks" "$DEV_REPO_ROOT" "$DEV_OVERLAY_ROOT"
 }

--- a/tools/dev/lib/container.sh
+++ b/tools/dev/lib/container.sh
@@ -213,6 +213,16 @@ dev_window_inner_command() {
   agent=$(jq -r '.agent // ""' <<<"$window_json")
   command=$(jq -r '.command // ""' <<<"$window_json")
 
+  # Agent windows exec their process directly, so shell init never wires the
+  # vekil proxy env the way an interactive shell would (ai/vekil/env.zsh).
+  # Merge the overlay UNDER the declared environment: explicit keys win, and
+  # an unreachable proxy contributes {} so agents fall back to direct.
+  if [[ -n "$agent" ]]; then
+    local vekil_env
+    vekil_env=$(dev_vekil_env_json "$location")
+    env_json=$(jq -nc --argjson v "$vekil_env" --argjson e "$env_json" '$v + $e')
+  fi
+
   # jq's @sh quotes each value for POSIX sh, so a value containing a space,
   # quote or newline survives intact.
   assignments=$(jq -r 'to_entries | map("\(.key)=" + (.value | tostring | @sh))

--- a/tools/dev/lib/vekil.sh
+++ b/tools/dev/lib/vekil.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# vekil.sh — route agent windows through the vekil proxy when it is up.
+#
+# ai/vekil/env.zsh wires ANTHROPIC_*/OPENAI_* into INTERACTIVE zsh, which is
+# how agents reached the proxy before this platform: the old flow ended in a
+# login shell. dev's agent panes exec the agent directly through `sh -c`
+# (deliberately: the pane's process IS the agent, and alpine images have no
+# zsh), so shell init never runs and the agent silently connected straight to
+# the provider. This is the bash port of env.zsh's core decision, evaluated
+# host-side at open/respawn time.
+#
+# Semantics kept from env.zsh:
+#   - proxy not ready -> inject NOTHING, the agent falls back to direct.
+#   - inside a container the proxy is reachable as host.docker.internal;
+#     readiness is still probed host-side, where dev always runs.
+#   - injected values are defaults: an explicit `environment:` key in the
+#     merged workspace config wins (jq `$vekil + $declared`).
+#
+# The env is baked into the pane command at creation, so a proxy that dies
+# later leaves existing panes pointed at it until the next open/respawn —
+# unlike the zsh hook, which re-evaluates per new shell. Accepted trade.
+
+# Probes once per process; later calls reuse the verdict.
+DEV_VEKIL_PROBE=""
+DEV_VEKIL_HOST=""
+DEV_VEKIL_PORT=""
+
+dev_vekil_probe() {
+  if [[ -n "$DEV_VEKIL_PROBE" ]]; then
+    [[ "$DEV_VEKIL_PROBE" == ok ]]
+    return
+  fi
+  DEV_VEKIL_PROBE=fail
+
+  local port host state_dir
+  port="${VEKIL_PORT:-1337}"
+  [[ "$port" =~ ^[0-9]+$ ]] && ((port >= 1 && port <= 65535)) || return 1
+
+  state_dir="${VEKIL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/vekil}"
+  [[ -f "$state_dir/proxy-host" && -r "$state_dir/proxy-host" ]] || return 1
+  [[ -f "$state_dir/proxy-ready" ]] || return 1
+  host=$(<"$state_dir/proxy-host")
+  [[ -n "$host" && "$host" != *[[:space:]]* ]] || return 1
+
+  command -v curl >/dev/null 2>&1 || return 1
+  curl --fail --silent --connect-timeout 0.5 --max-time 1 \
+    "http://${host}:${port}/readyz" >/dev/null 2>&1 || return 1
+
+  DEV_VEKIL_PROBE=ok
+  DEV_VEKIL_HOST="$host"
+  DEV_VEKIL_PORT="$port"
+}
+
+# Prints the env overlay for one window location as a JSON object; {} when the
+# proxy is not ready, so callers can merge unconditionally.
+dev_vekil_env_json() {
+  local location="$1" host
+  if ! dev_vekil_probe; then
+    printf '{}\n'
+    return 0
+  fi
+  # dev runs on the host, but a container-located pane reaches the host's
+  # proxy through Docker's gateway alias, exactly as env.zsh decides when it
+  # finds itself inside a container.
+  if [[ "$location" == host ]]; then
+    host="$DEV_VEKIL_HOST"
+  else
+    host=host.docker.internal
+  fi
+  jq -nc --arg h "$host" --arg p "$DEV_VEKIL_PORT" '{
+    ANTHROPIC_BASE_URL: "http://\($h):\($p)",
+    ANTHROPIC_API_KEY: "dummy",
+    ANTHROPIC_MODEL: "claude-opus-5",
+    CLAUDE_CODE_DISABLE_ADVISOR_TOOL: "1",
+    OPENAI_BASE_URL: "http://\($h):\($p)/v1",
+    OPENAI_API_KEY: "dummy"
+  }'
+}


### PR DESCRIPTION
## Summary

Agent panes exec their process directly through `sh -c`, so `ai/vekil/env.zsh` (interactive-zsh only) never ran and agents connected straight to Anthropic. This adds `tools/dev/lib/vekil.sh` — a bash port of env.zsh's core decision, evaluated host-side at open/respawn:

- readyz probe (state dir + curl, 0.5s connect timeout, memoized per process); not ready → inject nothing, agent falls back to direct — vekil's degradation semantics
- ready → merge `ANTHROPIC_BASE_URL/API_KEY/MODEL`, `CLAUDE_CODE_DISABLE_ADVISOR_TOOL`, and the OpenAI pair **under** the declared workspace `environment:` (explicit keys win)
- container-located windows get `host.docker.internal`, host windows get the proxy-host file's address
- agent windows only, applied at the single env-application site (invariant 7)

Known trade (documented in the lib header): env is baked at pane creation, so a proxy dying later leaves existing panes pointed at it until the next open/respawn — the zsh hook re-evaluates per shell.

## Verification
- 5 new tests (ready injection, container host alias, probe-failure non-injection, declared-key precedence, command windows untouched); `setup_dev_test` scopes `VEKIL_STATE_DIR` so the suite is hermetic against the dev machine's real proxy
- Full suite 710/710; shellcheck/shfmt clean on all touched files

