### PR TITLE
feat(dev): declarative multi-pane windows with a tiled dashboard default

### DIFF
--- a/docs/superpowers/plans/2026-08-04-multi-pane-windows.md
+++ b/docs/superpowers/plans/2026-08-04-multi-pane-windows.md
@@ -508,7 +508,7 @@ In `tools/dev/dev-event`, inside `dev_event_data_from_pairs`'s loop, after `valu
 
 In `tools/dev/dev.tmux.conf`, extend the pane-died hook line (keep it one line, same quoting pattern as the current one):
 
-```
+```tmux
 set-hook -gw pane-died "run-shell -b \"~/.dotfiles/tools/dev/dev-event '#{@dev_workspace_id}' '#{@dev_slug}' '#{session_name}' '#{@dev_worktree}' pane.died 'window=#{window_name}' 'pane=#{@dev_pane}'\""
 ```
 

--- a/docs/superpowers/plans/2026-08-04-multi-pane-windows.md
+++ b/docs/superpowers/plans/2026-08-04-multi-pane-windows.md
@@ -50,14 +50,13 @@ EOF
   [ "$(jq 'has("environment")' <<<"$win")" = "false" ]
 }
 
-@test "config: panes normalize with per-pane defaults and window environment is kept" {
+@test "config: panes normalize with per-pane defaults; window environment survives on single-pane windows" {
   mkdir -p "$DEV_OVERLAY_ROOT/proj"
   cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
 version: 1
 windows:
   - name: main
     layout: tiled
-    environment: {WIN: "1"}
     panes:
       - name: agent-1
         agent: claude
@@ -65,14 +64,42 @@ windows:
       - name: shell
         command: null
         environment: {PANE: "2"}
+  - name: solo
+    command: null
+    environment: {WIN: "1"}
 EOF
   run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
   [ "$status" -eq 0 ]
   win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
   [ "$(jq -r '.layout' <<<"$win")" = "tiled" ]
-  [ "$(jq -r '.environment.WIN' <<<"$win")" = "1" ]
   [ "$(jq -c '.panes[0]' <<<"$win")" = '{"agent":"claude","command":null,"cwd":null,"focus":true,"location":null,"name":"agent-1"}' ]
   [ "$(jq -r '.panes[1].environment.PANE' <<<"$win")" = "2" ]
+  # the spec §7.1 fix: window-level environment is kept for single-pane windows
+  [ "$(jq -r '.windows[] | select(.name == "solo") | .environment.WIN' <<<"$output")" = "1" ]
+}
+
+@test "config: a layer defining an inherited pane twice fails loudly, never silently collapses" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: main
+    panes:
+      - name: shell
+        command: null
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: main
+    panes:
+      - name: shell
+        cwd: a
+      - name: shell
+        cwd: b
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 5 ]
+  [[ "$output" == *"shell"* ]]   # bats `run` folds stderr into $output
 }
 
 @test "config: panes merge by name across layers, never by index" {
@@ -171,6 +198,9 @@ EOF
   [ "$status" -eq 5 ]
   run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"bad name","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
   [ "$status" -eq 5 ]
+  # exclusive schema: window-level environment is a single-pane key (spec §5)
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"environment":{"A":"1"},"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
 }
 ```
 
@@ -180,6 +210,39 @@ Run: `bats tests/dev_config_merge.bats`
 Expected: the new tests FAIL (panes dropped by normalization, validation exits 0).
 
 - [ ] **Step 3: Implement in `tools/dev/lib/config.sh`**
+
+Add a per-layer duplicate check and call it from `dev_config_merged`'s loop
+right after `layer=$(dev_config_layer_json "$file")`. This must run on the
+LAYER, not the merged result: by-name merging keeps only the last duplicate,
+so post-merge validation can never see one (spec §5):
+
+```bash
+# By-name merging collapses duplicate names before post-merge validation can
+# see them: a layer that defines an inherited pane twice would silently keep
+# only the last patch. So duplicates are detected per layer, while the layer
+# is still a layer. The post-merge duplicate checks in dev_config_validate
+# stay as defense in depth for hand-fed JSON.
+dev_config_layer_dup_check() {
+  local file="$1" layer="$2" problem
+  problem=$(jq -r '
+    ([(.windows // []) | group_by(.name)[] | select(length > 1)
+       | "window \(.[0].name) is defined more than once"]
+     + [(.windows // [])[] | .name as $w
+        | ((.panes // []) | group_by(.name)[] | select(length > 1))
+        | "pane \($w)/\(.[0].name) is defined more than once"])
+    | first // ""' <<<"$layer") || return 1
+  [[ -z "$problem" ]] && return 0
+  printf 'invalid workspace config in %s: %s\n' "$file" "$problem" >&2
+  return 5
+}
+```
+
+and in `dev_config_merged`:
+
+```bash
+    layer="$(dev_config_layer_json "$file")" || return 1
+    dev_config_layer_dup_check "$file" "$layer" || return $?
+```
 
 Replace `DEV_CONFIG_MERGE_JQ`'s `merge_windows` with pane-aware merging (jq `*` replaces arrays wholesale, so `panes` needs the same by-name treatment windows get):
 
@@ -482,6 +545,24 @@ set-hook -gw pane-died "run-shell -b \"~/.dotfiles/tools/dev/dev-event '#{@dev_w
   line=$(grep '"event":"pane.died"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
   [ "$(jq -r '.data | has("pane")' <<<"$line")" = "false" ]
 }
+
+@test "pane-died from a fast-exiting split still carries the pane name (atomic stamp)" {
+  setup_hook_session
+  dev_tmux source-file "$REPO_ROOT/tools/dev/dev.tmux.conf"
+  dev_tmux new-window -d -t "=proj:" -n w2 "sleep 30" \
+    ';' set-window-option -t "=proj:=w2" remain-on-exit on
+  # the command exits immediately: if the stamp were a second invocation, the
+  # hook could fire first and emit an identity-less pane.died (spec §2)
+  dev_tmux split-window -t "=proj:=w2" 'exit 1' \
+    ';' set-option -p -t "=proj:=w2" @dev_pane fast
+  for _ in $(seq 1 50); do
+    grep -q '"pane":"fast"' "$DEV_STATE_ROOT/events/events.jsonl" 2>/dev/null && break
+    sleep 0.1
+  done
+  line=$(grep '"pane":"fast"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.event' <<<"$line")" = "pane.died" ]
+  [ "$(jq -r '.data.window' <<<"$line")" = "w2" ]
+}
 ```
 
 (Adapt the session bootstrap to whatever the neighboring hook tests in `dev_install.bats` actually do — reuse their helper if one exists, including the `~/.dotfiles` symlink they set up so `run-shell` finds `dev-event`. If `#{@dev_pane}` turns out NOT to interpolate in the hook context on tmux 3.4, STOP and flag it: the fallback design is interpolating `#{pane_id}` and resolving it in `dev-event`, which is a spec change requiring user sign-off.)
@@ -508,7 +589,7 @@ git commit -m "feat(dev): pane discriminator on pane.died, omitted when unstampe
 - Test: `tests/dev_backend_tmux.bats`
 
 **Interfaces:**
-- Produces: `dev_backend_query` window objects become `{name, panes: [{alive, pane, id}]}` — `pane` is the `@dev_pane` logical name or null; `id` is the opaque backend pane handle (tmux `%id`), valid only while the pane exists, never persisted. Existing consumers reading `.panes[].alive` are untouched.
+- Produces: `dev_backend_query` window objects become `{name, panes: [{alive, pane, pane_id}]}` — `pane` is the `@dev_pane` logical name or null; `pane_id` is the opaque backend pane handle (tmux `%id`, the spec §4 name), valid only while the pane exists, never persisted. Existing consumers reading `.panes[].alive` are untouched.
 
 - [ ] **Step 1: Write the failing test** — append to `tests/dev_backend_tmux.bats`:
 
@@ -527,7 +608,7 @@ git commit -m "feat(dev): pane discriminator on pane.died, omitted when unstampe
   win=$(jq -c '.windows[] | select(.name == "w1")' <<<"$output")
   [ "$(jq -r '.panes | length' <<<"$win")" -eq 3 ]
   [ "$(jq -r '[.panes[].pane] | sort | join(",")' <<<"$win")" = ",agent-1,shell" ]
-  [ "$(jq -r '[.panes[] | select(.pane == "shell") | .id] | first' <<<"$win")" = "$pid" ]
+  [ "$(jq -r '[.panes[] | select(.pane == "shell") | .pane_id] | first' <<<"$win")" = "$pid" ]
   [ "$(jq -r '[.panes[] | select(.pane == null)] | length' <<<"$win")" -eq 1 ]
 }
 ```
@@ -537,7 +618,7 @@ git commit -m "feat(dev): pane discriminator on pane.died, omitted when unstampe
 - [ ] **Step 2: Run to verify failure**
 
 Run: `bats tests/dev_backend_tmux.bats`
-Expected: new test FAILS (`pane`/`id` fields absent).
+Expected: new test FAILS (`pane`/`pane_id` fields absent).
 
 - [ ] **Step 3: Implement** — in `dev_backend_query`, change the format and the jq. `window_name` stays last to absorb spaces; `@dev_pane`'s validated charset (`[A-Za-z0-9._-]`) keeps the middle fields splittable, with `-` as the unset placeholder:
 
@@ -554,10 +635,10 @@ Expected: new test FAILS (`pane`/`id` fields absent).
     | map({name: .[0].name,
            panes: map({alive: (.dead == "0"),
                        pane: (if .pn == "-" then null else .pn end),
-                       id: .pid})})
+                       pane_id: .pid})})
 ```
 
-Add to the function comment: `id` is an opaque, ephemeral backend handle for targeting a live pane (respawn, select); it is never written to events or records — logical identity is `pane`.
+Add to the function comment: `pane_id` is an opaque, ephemeral backend handle for targeting a live pane (respawn, select); it is never written to events or records — logical identity is `pane`.
 
 - [ ] **Step 4: Run the tests**
 
@@ -582,7 +663,7 @@ git commit -m "feat(dev): backend query exposes pane logical names and handles"
 
 **Interfaces:**
 - Consumes: Task 1's normalized `panes`/`layout`/`environment`; Task 4's query shape; `dev_window_location` / `dev_container_exec_prefix` / `dev_window_workdir` / `dev_window_inner_command` from `container.sh` — a pane object has exactly the fields those functions read from a window object, so pane JSON is passed where window JSON goes today.
-- Produces: panes-form windows built and repaired; events `window.created {window, panes: [names]}` (no `location`/`command` — spec's §4.4 amendment), `pane.created {window, pane, location, command}` (declared command), `agent.started {window, pane, command}`. Effective environment is `global * window.environment * pane.environment` (single-pane windows: `global * window.environment` — the spec §7.1 fix).
+- Produces: panes-form windows built and repaired; events `window.created {window, panes: [names]}` (no `location`/`command` — spec's §4.4 amendment), `pane.created {window, pane, location, command}` (declared command), `agent.started {window, pane, command}`. Effective environment: panes-form panes get `global * pane.environment` (the exclusive schema forbids window-level `environment` beside `panes` — Task 1 validates that); single-pane windows get `global * window.environment` (the spec §7.1 fix).
 
 - [ ] **Step 1: Write the failing tests** — append to `tests/dev_backend_tmux.bats`:
 
@@ -662,6 +743,19 @@ fixture_pane_config() {
   [ "$(jq -r '[.panes[] | select(.pane == "shell")] | length' <<<"$win")" -eq 1 ]
 }
 
+@test "apply_layout survives fast-exiting pane commands: dead, held, and stamped" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  cfg=$(jq -c '.windows[0].panes[2].command = "exit 5"' <<<"$(fixture_pane_config)")
+  dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
+  run dev_backend_query "proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  # the window survives and all four panes exist; the fast-exiting one is dead
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 4 ]
+  dead=$(jq -c '.panes[] | select(.alive | not)' <<<"$win")
+  [ "$(jq -r '.pane' <<<"$dead")" = "shell" ]
+}
+
 @test "apply_layout leaves undeclared panes alone and single-pane window env includes window environment" {
   dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
   cfg=$(jq -c '.windows[0].panes |= .[0:2]' <<<"$(fixture_pane_config)")
@@ -709,17 +803,21 @@ Add a helper above `dev_backend_apply_layout`:
 # panes — unstamped, or stamped with a name the config no longer declares —
 # are invisible here: never matched, never split into, never killed (§1.2).
 #
-# The first pane's stamp is chained into the new-window invocation: the window
-# target resolves to its active (sole) pane, and the chain keeps the
-# remain-on-exit guarantee atomic exactly as the single-pane path does. Later
-# splits need no such chain: remain-on-exit is already on for the window, so a
-# fast-exiting command leaves a dead, held, still-targetable pane — the
-# capture-then-stamp two-step cannot lose the pane, only stamp a dead one,
-# which is precisely what repair wants to find.
+# EVERY stamp is chained into the same tmux invocation as the pane's creation.
+# For the first pane the chain rides new-window (the window target resolves to
+# its active — sole — pane) alongside remain-on-exit, exactly like the
+# single-pane path. For splits the window cannot be destroyed (remain-on-exit
+# is already on, so a fast-exiting command leaves a dead, held pane), but a
+# SECOND race remains: the pane-died hook can fire before a separate second
+# invocation stamps @dev_pane, and an unstamped death event has no pane
+# identity for the fold to route. So split-window runs WITHOUT -d — the new
+# pane becomes the window's active pane — and the chained set-option's window
+# target resolves to it inside one atomic server request. The active-pane
+# side effect is corrected by the focus pass at the end of apply_layout.
 dev_backend_ensure_pane_window() {
   local session_name="$1" window_json="$2" record_json="$3" global_env="$4" exists="$5"
-  local workspace_id slug worktree wname layout window_env stamped
-  local pane_json pname pane_env location workdir inner pane_cmd pid created=0
+  local workspace_id slug worktree wname layout stamped
+  local pane_json pname pane_env location workdir inner pane_cmd created=0
   local -a prefix
   local ev_id ev_ts data line
 
@@ -728,7 +826,6 @@ dev_backend_ensure_pane_window() {
   worktree=$(jq -r '.worktree' <<<"$record_json")
   wname=$(jq -r '.name' <<<"$window_json")
   layout=$(jq -r '.layout // "main-vertical"' <<<"$window_json")
-  window_env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$window_json")
 
   if [[ "$exists" -eq 1 ]]; then
     stamped=$(dev_tmux list-panes -t "=$session_name:=$wname" \
@@ -743,7 +840,10 @@ dev_backend_ensure_pane_window() {
     if [[ -n "$stamped" ]] && printf '%s\n' "$stamped" | grep -Fxq -- "$pname"; then
       continue
     fi
-    pane_env=$(jq -c --argjson w "$window_env" '$w * (.environment // {})' <<<"$pane_json")
+    # global * pane.environment only: the exclusive schema forbids window-level
+    # environment beside panes (validated in config), so there is no window
+    # layer to merge here.
+    pane_env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$pane_json")
     location=$(dev_window_location "$record_json" "$pane_json") || return 1
     mapfile -t prefix < <(dev_container_exec_prefix "$record_json" "$pane_json") || return 1
     [[ ${#prefix[@]} -gt 0 ]] || return 1
@@ -771,9 +871,8 @@ dev_backend_ensure_pane_window() {
         "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
       dev_event_append "$line"
     else
-      pid=$(dev_tmux split-window -d -P -F '#{pane_id}' \
-        -t "=$session_name:=$wname" -c "$workdir" "$pane_cmd") || return 1
-      dev_tmux set-option -p -t "$pid" @dev_pane "$pname" || return 1
+      dev_tmux split-window -t "=$session_name:=$wname" -c "$workdir" "$pane_cmd" \
+        ';' set-option -p -t "=$session_name:=$wname" @dev_pane "$pname" || return 1
     fi
     created=$((created + 1))
 
@@ -872,7 +971,7 @@ git commit -m "feat(dev): build and repair panes-form windows with stamped ident
 - Test: `tests/dev_backend_tmux.bats`
 
 **Interfaces:**
-- Consumes: Task 4's `id` handle; the `fixture_pane_config` bats helper Task 5 added to `tests/dev_backend_tmux.bats`.
+- Consumes: Task 4's `pane_id` handle; the `fixture_pane_config` bats helper Task 5 added to `tests/dev_backend_tmux.bats`.
 - Produces: `dev_backend_respawn_pane <session> <window> <command> [container_id] [pane_handle] [pane_name]` — with a handle it respawns exactly that pane; `pane_name` (when non-empty) is added to the `pane.respawned` event data. Still the SOLE emitter of `pane.respawned`.
 
 - [ ] **Step 1: Write the failing test** — append to `tests/dev_backend_tmux.bats`:
@@ -974,7 +1073,7 @@ git commit -m "feat(dev): pane-handle targeting for respawn, pane on the event"
 - Test: `tests/dev_commands.bats`
 
 **Interfaces:**
-- Consumes: Task 4 query (`pane`, `id`), Task 6 respawn signature, Task 1 config shape.
+- Consumes: Task 4 query (`pane`, `pane_id`), Task 6 respawn signature, Task 1 config shape.
 - Produces: dead declared panes respawn on EVERY `dev open` (gate removed); env parity `global * window.environment * pane.environment` with creation.
 
 - [ ] **Step 1: Write the failing test** — append to `tests/dev_commands.bats`, reusing its scenario scaffolding (fake `DEV_DOTFILES_ROOT` root, stubbed agent commands, real tmux). The exact bootstrap must copy what the existing "open after a container loss … respawns dead panes" test does, minus the container parts:
@@ -996,7 +1095,45 @@ git commit -m "feat(dev): pane-handle targeting for respawn, pane on the event"
   [ "$(dev_tmux list-panes -t '=demo:=shell' -F '#{pane_dead}')" = "0" ]
   grep -q '"event":"pane.respawned"' "$DEV_STATE_ROOT/events/events.jsonl"
 }
+
+@test "re-open respawns one dead agent pane of two and leaves the other agent untouched" {
+  scenario_setup_demo_workspace
+  mkdir -p "$DEV_OVERLAY_ROOT/demo"
+  cat >"$DEV_OVERLAY_ROOT/demo/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: dash
+    layout: tiled
+    panes:
+      - name: agent-1
+        agent: sleep 30
+      - name: agent-2
+        agent: sleep 30
+EOF
+  run dev open demo --no-attach
+  [ "$status" -eq 0 ]
+
+  victim=$(dev_tmux list-panes -t '=demo:=dash' -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "agent-2" {print $1; exit}')
+  dev_tmux respawn-pane -k -t "$victim" 'exit 1'
+  for _ in $(seq 1 50); do
+    [ "$(dev_tmux display-message -p -t "$victim" '#{pane_dead}')" = "1" ] && break
+    sleep 0.1
+  done
+
+  run dev open demo --no-attach
+  [ "$status" -eq 0 ]
+  [ "$(dev_tmux display-message -p -t "$victim" '#{pane_dead}')" = "0" ]
+
+  record=$(cat "$DEV_STATE_ROOT"/workspaces/*.json)
+  [ "$(jq -r '.agents[] | select(.pane == "agent-2") | .state' <<<"$record")" = "started" ]
+  # agent-1 never died: exactly one lifecycle event for it, the start
+  [ "$(jq -r '.agents[] | select(.pane == "agent-1") | .state' <<<"$record")" = "started" ]
+  [ "$(grep -c '"pane":"agent-1"' "$DEV_STATE_ROOT/events/events.jsonl")" -eq 2 ]  # pane.created + agent.started only
+}
 ```
+
+(The last assertion counts `pane.created` + `agent.started` for agent-1 — if the pane-died hook is active in this scenario's tmux server and fires for agent-2's kill, that adds agent-2 events, not agent-1's. Adjust the exact count only if `scenario_setup_demo_workspace` sources the hook conf; the invariant under test is that agent-1 gained no death/respawn events.)
 
 (If no shared bootstrap function exists, extract one from the container-loss test rather than duplicating the ~15 setup lines; name it `scenario_setup_demo_workspace` and have both tests call it.)
 
@@ -1057,7 +1194,7 @@ dev_open_respawn_dead() {
     fi
   done < <(jq -r '.windows[] | .name as $w | (.panes | length) as $n
     | .panes[] | select(.alive | not)
-    | [$w, (.pane // "-"), .id, ($n | tostring)] | @tsv' <<<"$query")
+    | [$w, (.pane // "-"), .pane_id, ($n | tostring)] | @tsv' <<<"$query")
 }
 ```
 

--- a/docs/superpowers/plans/2026-08-04-multi-pane-windows.md
+++ b/docs/superpowers/plans/2026-08-04-multi-pane-windows.md
@@ -1,0 +1,1282 @@
+# Declarative Multi-Pane Windows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a `dev` workspace window declare multiple named panes (any of which may run an agent), built by `dev open`, repaired on every re-open, with pane-qualified agent state — per the approved spec `docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md`.
+
+**Architecture:** Config gains an exclusive `panes:` window form (normalized conditionally so panes-less digests never change). Pane identity is a pane-scoped tmux user option `@dev_pane`; events gain an optional `pane` field routed by the fold on `(window, pane // null)`. Only `backend-tmux.sh` touches tmux; every pane command still flows through `dev_container_exec_prefix` + `dev_window_inner_command`.
+
+**Tech Stack:** bash + jq + yq, tmux 3.4, bats tests (real tmux via `DEV_TMUX_SOCKET`).
+
+## Global Constraints
+
+- Only `tools/dev/lib/backend-tmux.sh` may invoke tmux (spec §4; repo invariant).
+- Every pane command goes through `dev_container_exec_prefix` + `dev_window_inner_command` — no second quoting/env path; events record the **declared** command, never the rendered one (secrets rule).
+- `dev open` never destroys: no `kill-pane`, `kill-window`, `kill-session` outside `dev stop`.
+- tmux targets: `-t "=session:"` (trailing colon) for pane-resolving commands, `=session:=window` for windows; concrete panes by `%id` handle only, never by index.
+- A panes-less config must normalize to byte-identical JSON (same sha256 digest) as today — new keys (`panes`, `layout`, `environment`) appear in normalized output **only when present**.
+- Shell style: `shfmt -i 2 -ci`; `shellcheck -x -S warning -e SC1091` must pass.
+- Run make as `/usr/bin/make` (bare `make` is broken under this zsh). Full checks: `/usr/bin/make lint` and `bats tests/dev_*.bats`.
+- bats tests use `setup_dev_test` from `tests/test_helper.bash`; tmux tests run a real server on socket `$DEV_TMUX_SOCKET` and must kill it in `teardown`.
+- Commit after every green task; conventional-commit messages (`feat(dev): …`, `test(dev): …`).
+
+---
+
+### Task 1: Config — panes normalization, merge, validation
+
+**Files:**
+- Modify: `tools/dev/lib/config.sh`
+- Test: `tests/dev_config_merge.bats`
+
+**Interfaces:**
+- Produces: normalized window objects that MAY carry `panes` (array of `{name, agent, command, cwd, location, focus[, environment]}`), `layout` (string), `environment` (object) — each key present only when declared. `dev_config_validate` gains the multi-pane rules. Later tasks read `.panes`, `.layout`, `.environment` with `// null` / `// {}` fallbacks.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/dev_config_merge.bats` (it already loads config.sh; follow its existing test style):
+
+```bash
+@test "config: panes-less window normalizes without panes/layout/environment keys (digest stability)" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: solo
+    command: null
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "solo")' <<<"$output")
+  [ "$(jq 'has("panes")' <<<"$win")" = "false" ]
+  [ "$(jq 'has("layout")' <<<"$win")" = "false" ]
+  [ "$(jq 'has("environment")' <<<"$win")" = "false" ]
+}
+
+@test "config: panes normalize with per-pane defaults and window environment is kept" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: main
+    layout: tiled
+    environment: {WIN: "1"}
+    panes:
+      - name: agent-1
+        agent: claude
+        focus: true
+      - name: shell
+        command: null
+        environment: {PANE: "2"}
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.layout' <<<"$win")" = "tiled" ]
+  [ "$(jq -r '.environment.WIN' <<<"$win")" = "1" ]
+  [ "$(jq -c '.panes[0]' <<<"$win")" = '{"agent":"claude","command":null,"cwd":null,"focus":true,"location":null,"name":"agent-1"}' ]
+  [ "$(jq -r '.panes[1].environment.PANE' <<<"$win")" = "2" ]
+}
+
+@test "config: panes merge by name across layers, never by index" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: main
+    panes:
+      - name: agent-1
+        agent: claude
+      - name: shell
+        command: null
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: main
+    panes:
+      - name: shell
+        cwd: sub
+      - name: extra
+        command: htop
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 3 ]
+  [ "$(jq -r '.panes[] | select(.name == "shell") | .cwd' <<<"$win")" = "sub" ]
+  [ "$(jq -r '.panes[] | select(.name == "agent-1") | .agent' <<<"$win")" = "claude" ]
+  [ "$(jq -r '.panes[] | select(.name == "extra") | .command' <<<"$win")" = "htop" ]
+}
+
+@test "config: converting an agent window to panes without nulling agent fails loudly" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: agent-1
+    agent: claude
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: agent-1
+    panes:
+      - name: a
+        agent: claude
+EOF
+  config=$(dev_config_merged "proj" "$TEST_ROOT/workspace/proj")
+  run dev_config_validate "$config"
+  [ "$status" -eq 5 ]
+  [[ "$output" == *"agent-1"* && "$output" == *"panes"* ]]
+}
+
+@test "config: agent: null alongside panes converts cleanly; a shell window converts silently" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: agent-1
+    agent: claude
+  - name: shell
+    command: null
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: agent-1
+    agent: null
+    panes:
+      - name: a
+        agent: claude
+  - name: shell
+    panes:
+      - name: s
+        command: null
+EOF
+  config=$(dev_config_merged "proj" "$TEST_ROOT/workspace/proj")
+  run dev_config_validate "$config"
+  [ "$status" -eq 0 ]
+}
+
+@test "config: multi-pane validation failures are loud and name the offender" {
+  bad() {
+    jq -nc --argjson w "$1" '{version: 1, windows: [$w]}'
+  }
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"layout":"tiled"}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"layout":"mosaic","panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"a","agent":"x","command":"y","cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false},{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":true},{"name":"b","agent":null,"command":null,"cwd":null,"location":null,"focus":true}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"bad name","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bats tests/dev_config_merge.bats`
+Expected: the new tests FAIL (panes dropped by normalization, validation exits 0).
+
+- [ ] **Step 3: Implement in `tools/dev/lib/config.sh`**
+
+Replace `DEV_CONFIG_MERGE_JQ`'s `merge_windows` with pane-aware merging (jq `*` replaces arrays wholesale, so `panes` needs the same by-name treatment windows get):
+
+```bash
+# windows merge by the name key, never by position (spec 4.1), and panes
+# within a window merge the same way. IN(), not inside(): inside() is
+# substring matching on strings and would swallow a new window whose name is
+# a substring of an existing one.
+DEV_CONFIG_MERGE_JQ='
+def by_name($ws): reduce $ws[] as $w ({}; .[$w.name] = $w);
+def merge_named($base; $over):
+  (by_name($over)) as $om
+  | ($base | map(.name)) as $bn
+  | ($base | map(. * ($om[.name] // {})))
+    + ($over | map(select((.name | IN($bn[])) | not)));
+def merge_window($b; $o):
+  ($b * $o)
+  | if ($b.panes? != null) and ($o.panes? != null)
+    then .panes = merge_named($b.panes; $o.panes)
+    else . end;
+def merge_windows($base; $over):
+  (by_name($over)) as $om
+  | ($base | map(.name)) as $bn
+  | ($base | map(merge_window(.; ($om[.name] // {}))))
+    + ($over | map(select((.name | IN($bn[])) | not)));
+($a.windows // []) as $bw
+| ($b.windows // []) as $ow
+| ($a * $b)
+| .windows = merge_windows($bw; $ow)
+'
+```
+
+Extend the window map in `DEV_CONFIG_NORMALIZE_JQ`. The conditional additions are load-bearing: adding `panes`/`layout`/`environment` keys unconditionally would change the normalized JSON — and the sha256 digest — of every existing config, spuriously reporting drift (spec §1):
+
+```bash
+DEV_CONFIG_NORMALIZE_JQ='
+def norm_pane:
+  { name: .name,
+    agent: (.agent // null),
+    command: (.command // null),
+    cwd: (.cwd // null),
+    location: (.location // null),
+    focus: (.focus // false) }
+  + (if .environment != null then {environment: .environment} else {} end);
+{ version: (.version // 1),
+  autostart: (.autostart // false),
+  devcontainer: ((.devcontainer // {}) | {
+      enabled: (.enabled // "auto"),
+      config: (.config // null),
+      start_timeout: (.start_timeout // 300) }),
+  environment: (.environment // {}),
+  windows: ((.windows // []) | map(
+    { name: .name,
+      agent: (.agent // null),
+      command: (.command // null),
+      cwd: (.cwd // null),
+      location: (.location // null),
+      focus: (.focus // false) }
+    + (if .environment != null then {environment: .environment} else {} end)
+    + (if .layout != null then {layout: .layout} else {} end)
+    + (if .panes != null then {panes: (.panes | map(norm_pane))} else {} end))) }
+'
+```
+
+Append to the `problems` list in `dev_config_validate` (value-based mixed-shape check — normalization gives every window all single-pane keys, so key presence cannot distinguish an explicit null from an inherited one; spec §5):
+
+```jq
++ ((.windows // []) | map(select(.panes != null
+    and (.agent != null or .command != null or .cwd != null
+         or .location != null or ((.environment // null) != null)))
+    | "window \(.name) mixes panes with single-pane keys; null them explicitly in the overlay"))
++ ((.windows // []) | map(select(.panes != null and (.panes | length) == 0)
+    | "window \(.name) declares an empty panes list"))
++ ((.windows // []) | map(select((.layout // null) != null and .panes == null)
+    | "window \(.name) sets layout without panes"))
++ ((.windows // []) | map(select((.layout // null) != null
+    and ((.layout | IN("even-horizontal","even-vertical","main-horizontal","main-vertical","tiled")) | not))
+    | "window \(.name) has invalid layout \(.layout | tostring)"))
++ ((.windows // []) | map(. as $w | (.panes // [])[]
+    | select(.agent != null and .command != null)
+    | "pane \($w.name)/\(.name) sets both agent and command"))
++ ((.windows // []) | map(. as $w | (.panes // [])[]
+    | select(.name == null or ((.name | tostring) | test("^[A-Za-z0-9._-]+$") | not))
+    | "a pane in window \($w.name) has an invalid name; use [A-Za-z0-9._-]"))
++ ((.windows // []) | map(. as $w | (.panes // [])[]
+    | select(.location != null and ((.location | IN("container","host")) | not))
+    | "pane \($w.name)/\(.name) has invalid location \(.location | tostring)"))
++ ((.windows // []) | map(. as $w | ((.panes // []) | group_by(.name)[] | select(length > 1))
+    | "pane \($w.name)/\(.[0].name) is defined more than once"))
++ ((.windows // []) | map(select(((.panes // []) | map(select(.focus == true)) | length) > 1)
+    | "window \(.name) has more than one focused pane"))
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bats tests/dev_config_merge.bats`
+Expected: all PASS (old tests included — the merge rewrite must not break them).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/lib/config.sh tests/dev_config_merge.bats
+git commit -m "feat(dev): panes-aware config normalization, merge, and validation"
+```
+
+---
+
+### Task 2: Fold — pane-qualified agent state
+
+**Files:**
+- Modify: `tools/dev/lib/fold.sh`
+- Test: `tests/dev_fold.bats`
+
+**Interfaces:**
+- Consumes: event `data` may carry `pane` (string) on `pane.died`, `pane.respawned`, `agent.started`, `agent.exited`, `agent.failed`.
+- Produces: `agents[]` entries `{window, pane, command, state}` with `pane: null` for single-pane windows. Matching key is `(window, data.pane // null)` for every pane/agent event.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/dev_fold.bats` (it defines `mkevent` and a base record helper; reuse them):
+
+```bash
+@test "fold: pane-qualified events route to the matching agent only" {
+  rec=$(base_record)
+  out=$(dev_fold_apply "$rec" "$(mkevent aaaa000000000020 2026-08-03T15:00:00.000Z agent.started '{"window":"main","pane":"agent-1","command":"claude"}')")
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000021 2026-08-03T15:01:00.000Z agent.started '{"window":"main","pane":"agent-2","command":"claude"}')")
+  [ "$(jq -r '.agents | length' <<<"$out")" -eq 2 ]
+  # the helper shell dying in the same window must not touch either agent
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000022 2026-08-03T15:02:00.000Z pane.died '{"window":"main","pane":"shell"}')")
+  [ "$(jq -r '[.agents[].state] | unique | join(",")' <<<"$out")" = "started" ]
+  # the right agent pane dying flips only that agent
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000023 2026-08-03T15:03:00.000Z pane.died '{"window":"main","pane":"agent-2"}')")
+  [ "$(jq -r '.agents[] | select(.pane == "agent-2") | .state' <<<"$out")" = "exited" ]
+  [ "$(jq -r '.agents[] | select(.pane == "agent-1") | .state' <<<"$out")" = "started" ]
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000024 2026-08-03T15:04:00.000Z pane.respawned '{"window":"main","pane":"agent-2"}')")
+  [ "$(jq -r '.agents[] | select(.pane == "agent-2") | .state' <<<"$out")" = "started" ]
+  # agent.exited and agent.failed route by pane too
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000025 2026-08-03T15:05:00.000Z agent.failed '{"window":"main","pane":"agent-1","reason":"crash"}')")
+  [ "$(jq -r '.agents[] | select(.pane == "agent-1") | .state' <<<"$out")" = "failed" ]
+}
+
+@test "fold: legacy pane-less events still key by window with pane null" {
+  rec=$(base_record)
+  out=$(dev_fold_apply "$rec" "$(mkevent aaaa000000000030 2026-08-03T15:10:00.000Z agent.started '{"window":"agent-1","command":"claude"}')")
+  [ "$(jq -c '.agents[0] | {window, pane, state}' <<<"$out")" = '{"window":"agent-1","pane":null,"state":"started"}' ]
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000031 2026-08-03T15:11:00.000Z pane.died '{"window":"agent-1","exit_status":1}')")
+  [ "$(jq -r '.agents[0].state' <<<"$out")" = "exited" ]
+}
+```
+
+(If `tests/dev_fold.bats` names its record helper differently — check its top — use that name; do not invent a second fixture.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bats tests/dev_fold.bats`
+Expected: new tests FAIL (second `agent.started` for `main` overwrites the first; `pane` absent from entries).
+
+- [ ] **Step 3: Implement in `tools/dev/lib/fold.sh`**
+
+Replace `agent_has`/`agent_upsert` and their call sites; keep every transition an absolute assignment:
+
+```jq
+def agent_matches($d): .window == $d.window and ((.pane // null) == ($d.pane // null));
+def agent_has($d): any(.agents[]; agent_matches($d));
+
+def agent_upsert($d; $patch):
+  if ($d.window // null) == null then .
+  elif agent_has($d) then
+    .agents = [.agents[] | if agent_matches($d) then . + $patch else . end]
+  else
+    .agents = (.agents
+      + [{window: $d.window, pane: ($d.pane // null), command: null, state: null} + $patch])
+  end;
+```
+
+Update the transitions to pass `$d` instead of `$d.window`:
+
+```jq
+elif $ev.event == "pane.died" then
+  if agent_has($d) then agent_upsert($d; {state: "exited"}) else . end
+elif $ev.event == "pane.respawned" then
+  if agent_has($d) then agent_upsert($d; {state: "started"}) else . end
+...
+elif $ev.event == "agent.started" then
+  agent_upsert($d; {command: $d.command, state: "started"})
+elif $ev.event == "agent.exited" then
+  agent_upsert($d; {state: "exited"})
+elif $ev.event == "agent.failed" then
+  agent_upsert($d; {state: "failed"})
+```
+
+Add to the invariant comment block at the top of the file: identity for agent state is `(window, data.pane // null)`; legacy pane-less events and records fold identically with `pane: null` (spec §3).
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bats tests/dev_fold.bats`
+Expected: all PASS, including the pre-existing legacy tests (they assert window-keyed behavior, which `pane: null` preserves — if one asserts an exact `agents[0]` object without `pane`, update that assertion to include `"pane":null` and note it in the commit message as the ADR-2-additive field).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/lib/fold.sh tests/dev_fold.bats
+git commit -m "feat(dev): pane-qualified agent identity in the event fold"
+```
+
+---
+
+### Task 3: dev-event `pane=` skip + pane-died hook
+
+**Files:**
+- Modify: `tools/dev/dev-event`
+- Modify: `tools/dev/dev.tmux.conf`
+- Test: `tests/dev_state_events.bats` (unit), `tests/dev_install.bats` (hook integration)
+
+**Interfaces:**
+- Produces: `pane.died` events carry `"pane": "<logical name>"` when the dying pane has `@dev_pane` set, and are byte-identical to today's when it is not. Depends on Task 5 stamping `@dev_pane` (the integration test stamps manually, so this task is independently testable).
+
+- [ ] **Step 1: Write the failing unit test** — append to `tests/dev_state_events.bats`:
+
+```bash
+@test "dev-event: an empty pane= pair is skipped; a non-empty one is recorded" {
+  run "$REPO_ROOT/tools/dev/dev-event" ws1 proj sess "$TEST_ROOT/workspace/proj" \
+    pane.died 'window=agent-1' 'pane='
+  [ "$status" -eq 0 ]
+  line=$(tail -n 1 "$DEV_STATE_ROOT/events/events.jsonl")
+  [ "$(jq -r '.data | has("pane")' <<<"$line")" = "false" ]
+  [ "$(jq -r '.data.window' <<<"$line")" = "agent-1" ]
+
+  run "$REPO_ROOT/tools/dev/dev-event" ws1 proj sess "$TEST_ROOT/workspace/proj" \
+    pane.died 'window=main' 'pane=shell'
+  [ "$status" -eq 0 ]
+  line=$(tail -n 1 "$DEV_STATE_ROOT/events/events.jsonl")
+  [ "$(jq -r '.data.pane' <<<"$line")" = "shell" ]
+
+  # other keys keep record-everything behavior, empty or not
+  run "$REPO_ROOT/tools/dev/dev-event" ws1 proj sess "$TEST_ROOT/workspace/proj" \
+    workspace.attached 'client='
+  [ "$status" -eq 0 ]
+  line=$(tail -n 1 "$DEV_STATE_ROOT/events/events.jsonl")
+  [ "$(jq -r '.data.client' <<<"$line")" = "" ]
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bats tests/dev_state_events.bats`
+Expected: FAIL — `has("pane")` is `true` with value `""`.
+
+- [ ] **Step 3: Implement**
+
+In `tools/dev/dev-event`, inside `dev_event_data_from_pairs`'s loop, after `value` is extracted:
+
+```bash
+    # `pane=` with an empty value is skipped — and ONLY pane. The pane-died
+    # hook interpolates #{@dev_pane} unconditionally, and single-pane windows
+    # are never stamped, so this is what keeps their pane.died bytes identical
+    # to the pre-panes era (spec §3). Every other key keeps record-everything
+    # behavior: an empty client or exit_status is an observation, not noise.
+    if [[ "$key" == pane && -z "$value" ]]; then
+      continue
+    fi
+```
+
+In `tools/dev/dev.tmux.conf`, extend the pane-died hook line (keep it one line, same quoting pattern as the current one):
+
+```
+set-hook -gw pane-died "run-shell -b \"~/.dotfiles/tools/dev/dev-event '#{@dev_workspace_id}' '#{@dev_slug}' '#{session_name}' '#{@dev_worktree}' pane.died 'window=#{window_name}' 'pane=#{@dev_pane}'\""
+```
+
+- [ ] **Step 4: Write the failing hook integration test** — append to `tests/dev_install.bats`, following the existing hook tests there (they `dev_backend_create` a session, `source-file` the conf, and poll the event log). This is also the spec §2 verification item: does the window-scoped `pane-died` hook interpolate the dying pane's `@dev_pane`?
+
+```bash
+@test "pane-died hook reports the dying pane's @dev_pane and omits it when unstamped" {
+  setup_hook_session   # or inline the same session/bootstrap the neighboring hook tests use
+  dev_tmux source-file "$REPO_ROOT/tools/dev/dev.tmux.conf"
+
+  # window w1: one stamped pane, one unstamped
+  dev_tmux new-window -d -t "=proj:" -n w1 "sleep 30" \
+    ';' set-window-option -t "=proj:=w1" remain-on-exit on
+  pid=$(dev_tmux split-window -d -P -F '#{pane_id}' -t "=proj:=w1" "sleep 30")
+  dev_tmux set-option -p -t "$pid" @dev_pane helper
+
+  dev_tmux respawn-pane -k -t "$pid" 'exit 1'
+  for _ in $(seq 1 50); do
+    grep -q '"pane":"helper"' "$DEV_STATE_ROOT/events/events.jsonl" 2>/dev/null && break
+    sleep 0.1
+  done
+  line=$(grep '"pane":"helper"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.event' <<<"$line")" = "pane.died" ]
+  [ "$(jq -r '.data.window' <<<"$line")" = "w1" ]
+
+  # the unstamped pane dies -> event has window only, no pane key
+  upid=$(dev_tmux list-panes -t "=proj:=w1" -F '#{pane_id} #{?#{@dev_pane},s,-}' | awk '$2 == "-" {print $1; exit}')
+  dev_tmux respawn-pane -k -t "$upid" 'exit 1'
+  for _ in $(seq 1 50); do
+    n=$(grep -c '"event":"pane.died"' "$DEV_STATE_ROOT/events/events.jsonl" 2>/dev/null || echo 0)
+    [ "$n" -ge 2 ] && break
+    sleep 0.1
+  done
+  line=$(grep '"event":"pane.died"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.data | has("pane")' <<<"$line")" = "false" ]
+}
+```
+
+(Adapt the session bootstrap to whatever the neighboring hook tests in `dev_install.bats` actually do — reuse their helper if one exists, including the `~/.dotfiles` symlink they set up so `run-shell` finds `dev-event`. If `#{@dev_pane}` turns out NOT to interpolate in the hook context on tmux 3.4, STOP and flag it: the fallback design is interpolating `#{pane_id}` and resolving it in `dev-event`, which is a spec change requiring user sign-off.)
+
+- [ ] **Step 5: Run both test files**
+
+Run: `bats tests/dev_state_events.bats tests/dev_install.bats`
+Expected: all PASS.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/dev-event tools/dev/dev.tmux.conf tests/dev_state_events.bats tests/dev_install.bats
+git commit -m "feat(dev): pane discriminator on pane.died, omitted when unstamped"
+```
+
+---
+
+### Task 4: Backend query — pane names and handles
+
+**Files:**
+- Modify: `tools/dev/lib/backend-tmux.sh` (`dev_backend_query`)
+- Test: `tests/dev_backend_tmux.bats`
+
+**Interfaces:**
+- Produces: `dev_backend_query` window objects become `{name, panes: [{alive, pane, id}]}` — `pane` is the `@dev_pane` logical name or null; `id` is the opaque backend pane handle (tmux `%id`), valid only while the pane exists, never persisted. Existing consumers reading `.panes[].alive` are untouched.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/dev_backend_tmux.bats`:
+
+```bash
+@test "query reports pane logical names and handles; unstamped panes report pane:null" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_tmux new-window -d -t "=proj:" -n w1 "sleep 30" \
+    ';' set-window-option -t "=proj:=w1" remain-on-exit on \
+    ';' set-option -p -t "=proj:=w1" @dev_pane agent-1
+  pid=$(dev_tmux split-window -d -P -F '#{pane_id}' -t "=proj:=w1" "sleep 30")
+  dev_tmux set-option -p -t "$pid" @dev_pane shell
+  dev_tmux split-window -d -t "=proj:=w1" "sleep 30"   # unstamped
+
+  run dev_backend_query "proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "w1")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 3 ]
+  [ "$(jq -r '[.panes[].pane] | sort | join(",")' <<<"$win")" = ",agent-1,shell" ]
+  [ "$(jq -r '[.panes[] | select(.pane == "shell") | .id] | first' <<<"$win")" = "$pid" ]
+  [ "$(jq -r '[.panes[] | select(.pane == null)] | length' <<<"$win")" -eq 1 ]
+}
+```
+
+(`[.panes[].pane] | sort | join(",")` renders null as empty — hence the leading comma.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bats tests/dev_backend_tmux.bats`
+Expected: new test FAILS (`pane`/`id` fields absent).
+
+- [ ] **Step 3: Implement** — in `dev_backend_query`, change the format and the jq. `window_name` stays last to absorb spaces; `@dev_pane`'s validated charset (`[A-Za-z0-9._-]`) keeps the middle fields splittable, with `-` as the unset placeholder:
+
+```bash
+  if ! panes=$(dev_tmux list-panes -s -t "=$session_name:" \
+    -F '#{pane_dead} #{window_index} #{pane_id} #{?#{@dev_pane},#{@dev_pane},-} #{window_name}' 2>/dev/null); then
+```
+
+```jq
+    (split("\n")
+     | map(select(length > 0))
+     | map(capture("^(?<dead>[01]) (?<idx>[0-9]+) (?<pid>%[0-9]+) (?<pn>[^ ]+) (?<name>.*)$")))
+    | group_by(.idx | tonumber)
+    | map({name: .[0].name,
+           panes: map({alive: (.dead == "0"),
+                       pane: (if .pn == "-" then null else .pn end),
+                       id: .pid})})
+```
+
+Add to the function comment: `id` is an opaque, ephemeral backend handle for targeting a live pane (respawn, select); it is never written to events or records — logical identity is `pane`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bats tests/dev_backend_tmux.bats`
+Expected: all PASS (existing query tests only read `alive`/`name`).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/lib/backend-tmux.sh tests/dev_backend_tmux.bats
+git commit -m "feat(dev): backend query exposes pane logical names and handles"
+```
+
+---
+
+### Task 5: Backend — panes-form window creation, missing-pane repair, layout, focus
+
+**Files:**
+- Modify: `tools/dev/lib/backend-tmux.sh` (`dev_backend_apply_layout` + new helper `dev_backend_ensure_pane_window`)
+- Test: `tests/dev_backend_tmux.bats`
+
+**Interfaces:**
+- Consumes: Task 1's normalized `panes`/`layout`/`environment`; Task 4's query shape; `dev_window_location` / `dev_container_exec_prefix` / `dev_window_workdir` / `dev_window_inner_command` from `container.sh` — a pane object has exactly the fields those functions read from a window object, so pane JSON is passed where window JSON goes today.
+- Produces: panes-form windows built and repaired; events `window.created {window, panes: [names]}` (no `location`/`command` — spec's §4.4 amendment), `pane.created {window, pane, location, command}` (declared command), `agent.started {window, pane, command}`. Effective environment is `global * window.environment * pane.environment` (single-pane windows: `global * window.environment` — the spec §7.1 fix).
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/dev_backend_tmux.bats`:
+
+```bash
+fixture_pane_config() {
+  jq -nc '{
+    version: 1, autostart: false,
+    devcontainer: {enabled: "auto", start_timeout: 300},
+    environment: {},
+    windows: [
+      {name: "main", agent: null, command: null, cwd: null, location: null,
+       focus: true, layout: "tiled",
+       panes: [
+         {name: "agent-1", agent: "sleep 30", command: null, cwd: null, location: null, focus: true},
+         {name: "agent-2", agent: "sleep 30", command: null, cwd: null, location: null, focus: false},
+         {name: "shell",   agent: null, command: null, cwd: null, location: null, focus: false},
+         {name: "scratch", agent: null, command: null, cwd: null, location: "host", focus: false}
+       ]}
+    ]}'
+}
+
+@test "apply_layout builds a panes-form window with stamped panes and applies the layout" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+
+  run dev_backend_query "proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 4 ]
+  [ "$(jq -r '[.panes[].pane] | sort | join(",")' <<<"$win")" = "agent-1,agent-2,scratch,shell" ]
+  [ "$(jq -r '[.panes[].alive] | unique | join(",")' <<<"$win")" = "true" ]
+  # remain-on-exit protects the whole window
+  run dev_tmux show-window-options -t "=proj:=main" remain-on-exit
+  [[ "$output" == *on* ]]
+  # the focused pane is the window's active pane
+  [ "$(dev_tmux display-message -p -t '=proj:=main' '#{@dev_pane}')" = "agent-1" ]
+}
+
+@test "apply_layout emits amended window.created, pane.created x4, agent.started with pane" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+  local log="$DEV_STATE_ROOT/events/events.jsonl"
+
+  wc_line=$(grep '"event":"window.created"' "$log")
+  [ "$(jq -r '.data.window' <<<"$wc_line")" = "main" ]
+  [ "$(jq -r '.data | has("location")' <<<"$wc_line")" = "false" ]
+  [ "$(jq -r '.data | has("command")' <<<"$wc_line")" = "false" ]
+  [ "$(jq -r '.data.panes | join(",")' <<<"$wc_line")" = "agent-1,agent-2,shell,scratch" ]
+
+  [ "$(grep -c '"event":"pane.created"' "$log")" -eq 4 ]
+  pc=$(grep '"event":"pane.created"' "$log" | head -n 1)
+  [ "$(jq -r '.data.pane' <<<"$pc")" = "agent-1" ]
+  [ "$(jq -r '.data.command' <<<"$pc")" = "sleep 30" ]
+
+  [ "$(grep -c '"event":"agent.started"' "$log")" -eq 2 ]
+  as_line=$(grep '"event":"agent.started"' "$log" | head -n 1)
+  [ "$(jq -r '.data.pane' <<<"$as_line")" = "agent-1" ]
+}
+
+@test "apply_layout is idempotent for panes-form windows and repairs a missing declared pane" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+
+  before=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id}' | sort)
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+  after=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id}' | sort)
+  [ "$before" = "$after" ]
+
+  # kill one pane outright (as a user would); re-apply recreates exactly it
+  victim=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "shell" {print $1; exit}')
+  dev_tmux kill-pane -t "$victim"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+  run dev_backend_query "proj"
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 4 ]
+  [ "$(jq -r '[.panes[] | select(.pane == "shell")] | length' <<<"$win")" -eq 1 ]
+}
+
+@test "apply_layout leaves undeclared panes alone and single-pane window env includes window environment" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  cfg=$(jq -c '.windows[0].panes |= .[0:2]' <<<"$(fixture_pane_config)")
+  dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
+  # a manual, unstamped split survives a re-apply untouched
+  manual=$(dev_tmux split-window -d -P -F '#{pane_id}' -t "=proj:=main" "sleep 30")
+  dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
+  run dev_tmux list-panes -t "=proj:=main" -F '#{pane_id}'
+  [[ "$output" == *"$manual"* ]]
+
+  # window-level environment reaches a single-pane window's process (spec §7.1 fix)
+  envcfg=$(jq -nc '{
+    version: 1, autostart: false,
+    devcontainer: {enabled: "auto", start_timeout: 300},
+    environment: {},
+    windows: [{name: "envwin", agent: null,
+               command: "printf %s \"$PROBE\" > probe.txt; sleep 30",
+               cwd: null, location: "host", focus: false,
+               environment: {PROBE: "from-window"}}]}')
+  dev_backend_apply_layout "proj" "$envcfg" "$(fixture_record)"
+  for _ in $(seq 1 50); do
+    [ -s "$TEST_WT/probe.txt" ] && break
+    sleep 0.1
+  done
+  [ "$(cat "$TEST_WT/probe.txt")" = "from-window" ]
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bats tests/dev_backend_tmux.bats`
+Expected: new tests FAIL (panes-form windows created as one pane running nothing sensible / no stamps / no events).
+
+- [ ] **Step 3: Implement in `tools/dev/lib/backend-tmux.sh`**
+
+Add a helper above `dev_backend_apply_layout`:
+
+```bash
+# dev_backend_ensure_pane_window <session_name> <window_json> <record_json> \
+#   <global_env_json> <exists 0|1>
+#
+# Creates a panes-form window (first pane rides new-window) and/or the declared
+# panes it is missing, stamps each with the pane-scoped @dev_pane user option,
+# and applies the window's named layout when anything was created. Undeclared
+# panes — unstamped, or stamped with a name the config no longer declares —
+# are invisible here: never matched, never split into, never killed (§1.2).
+#
+# The first pane's stamp is chained into the new-window invocation: the window
+# target resolves to its active (sole) pane, and the chain keeps the
+# remain-on-exit guarantee atomic exactly as the single-pane path does. Later
+# splits need no such chain: remain-on-exit is already on for the window, so a
+# fast-exiting command leaves a dead, held, still-targetable pane — the
+# capture-then-stamp two-step cannot lose the pane, only stamp a dead one,
+# which is precisely what repair wants to find.
+dev_backend_ensure_pane_window() {
+  local session_name="$1" window_json="$2" record_json="$3" global_env="$4" exists="$5"
+  local workspace_id slug worktree wname layout window_env stamped
+  local pane_json pname pane_env location workdir inner pane_cmd pid created=0
+  local -a prefix
+  local ev_id ev_ts data line
+
+  workspace_id=$(jq -r '.workspace_id' <<<"$record_json")
+  slug=$(jq -r '.slug' <<<"$record_json")
+  worktree=$(jq -r '.worktree' <<<"$record_json")
+  wname=$(jq -r '.name' <<<"$window_json")
+  layout=$(jq -r '.layout // "main-vertical"' <<<"$window_json")
+  window_env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$window_json")
+
+  if [[ "$exists" -eq 1 ]]; then
+    stamped=$(dev_tmux list-panes -t "=$session_name:=$wname" \
+      -F '#{?#{@dev_pane},#{@dev_pane},}' 2>/dev/null || true)
+  else
+    stamped=""
+  fi
+
+  while IFS= read -r pane_json; do
+    [[ -n "$pane_json" ]] || continue
+    pname=$(jq -r '.name' <<<"$pane_json")
+    if [[ -n "$stamped" ]] && printf '%s\n' "$stamped" | grep -Fxq -- "$pname"; then
+      continue
+    fi
+    pane_env=$(jq -c --argjson w "$window_env" '$w * (.environment // {})' <<<"$pane_json")
+    location=$(dev_window_location "$record_json" "$pane_json") || return 1
+    mapfile -t prefix < <(dev_container_exec_prefix "$record_json" "$pane_json") || return 1
+    [[ ${#prefix[@]} -gt 0 ]] || return 1
+    inner=$(dev_window_inner_command "$record_json" "$pane_json" "$pane_env") || return 1
+    printf -v pane_cmd '%q ' "${prefix[@]}"
+    printf -v pane_cmd '%s%q' "$pane_cmd" "$inner"
+    if [[ "$location" == host ]]; then
+      workdir=$(dev_window_workdir "$record_json" "$pane_json") || return 1
+    else
+      workdir="$worktree"
+    fi
+
+    if [[ "$exists" -eq 0 ]]; then
+      dev_tmux new-window -d -t "=$session_name:" -n "$wname" -c "$workdir" "$pane_cmd" \
+        ';' set-window-option -t "=$session_name:=$wname" remain-on-exit on \
+        ';' set-option -p -t "=$session_name:=$wname" @dev_pane "$pname" || return 1
+      exists=1
+      ev_id=$(dev_event_id_random)
+      ev_ts=$(dev_now)
+      # §4.4 amendment: a panes-form window.created carries the pane roster and
+      # neither location nor command — a mixed host/container window has no
+      # window-level truth for either (absent means "not known").
+      data=$(jq -c '{window: .name, panes: [.panes[].name]}' <<<"$window_json")
+      line=$(dev_event_build "$ev_id" "$ev_ts" "window.created" \
+        "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
+      dev_event_append "$line"
+    else
+      pid=$(dev_tmux split-window -d -P -F '#{pane_id}' \
+        -t "=$session_name:=$wname" -c "$workdir" "$pane_cmd") || return 1
+      dev_tmux set-option -p -t "$pid" @dev_pane "$pname" || return 1
+    fi
+    created=$((created + 1))
+
+    ev_id=$(dev_event_id_random)
+    ev_ts=$(dev_now)
+    # The DECLARED command, never the rendered one (secrets rule).
+    data=$(jq -c --arg w "$wname" --arg loc "$location" \
+      '{window: $w, pane: .name, location: $loc, command: (.command // .agent // null)}' \
+      <<<"$pane_json")
+    line=$(dev_event_build "$ev_id" "$ev_ts" "pane.created" \
+      "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
+    dev_event_append "$line"
+
+    if [[ "$(jq -r '.agent // ""' <<<"$pane_json")" != "" ]]; then
+      ev_id=$(dev_event_id_random)
+      ev_ts=$(dev_now)
+      data=$(jq -c --arg w "$wname" '{window: $w, pane: .name, command: .agent}' <<<"$pane_json")
+      line=$(dev_event_build "$ev_id" "$ev_ts" "agent.started" \
+        "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
+      dev_event_append "$line"
+    fi
+  done < <(jq -c '.panes[]' <<<"$window_json")
+
+  if [[ "$created" -gt 0 ]]; then
+    # Applied only when a pane was created: re-applying on a no-op open would
+    # stomp the user's manual resizes (spec §4).
+    dev_tmux select-layout -t "=$session_name:=$wname" "$layout" || return 1
+  fi
+  printf '%s\n' "$created"
+}
+```
+
+In `dev_backend_apply_layout`'s window loop, branch on shape and thread window-level environment into the single-pane path too:
+
+```bash
+    win_created=0
+    if [[ "$(jq -r '.panes != null' <<<"$window_json")" == true ]]; then
+      if printf '%s\n' "$existing" | grep -Fxq -- "$name"; then
+        win_created=$(dev_backend_ensure_pane_window "$session_name" "$window_json" \
+          "$record_json" "$env_json" 1) || return 1
+      else
+        win_created=$(dev_backend_ensure_pane_window "$session_name" "$window_json" \
+          "$record_json" "$env_json" 0) || return 1
+      fi
+      created=$((created + win_created))
+      continue
+    fi
+    if printf '%s\n' "$existing" | grep -Fxq -- "$name"; then
+      continue
+    fi
+```
+
+and in the single-pane path replace the `inner=...` line's env argument:
+
+```bash
+    win_env=$(jq -c --argjson g "$env_json" '$g * (.environment // {})' <<<"$window_json")
+    inner=$(dev_window_inner_command "$record_json" "$window_json" "$win_env") || return 1
+```
+
+(Note the existing `existing`/`grep -Fxq` idiom and the dev-holder cleanup + focus block below the loop stay; `created` now counts panes as well as windows, which only feeds the `> 0` holder check.)
+
+After the existing `focus_window` block, add pane focus (re-applied every open, like window focus; validation guarantees at most one per window):
+
+```bash
+  while IFS=$'\t' read -r fw fp; do
+    [[ -n "$fw" ]] || continue
+    pid=$(dev_tmux list-panes -t "=$session_name:=$fw" \
+      -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' 2>/dev/null |
+      awk -v p="$fp" '$2 == p {print $1; exit}')
+    [[ -n "$pid" ]] || continue
+    dev_tmux select-pane -t "$pid" 2>/dev/null || true
+  done < <(printf '%s' "$config_json" | jq -r '
+    (.windows // [])[] | select(.panes != null) | .name as $w
+    | .panes[] | select(.focus == true) | [$w, .name] | @tsv')
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bats tests/dev_backend_tmux.bats`
+Expected: all PASS, including every pre-existing apply_layout test (single-pane events must be byte-shaped exactly as before).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/lib/backend-tmux.sh tests/dev_backend_tmux.bats
+git commit -m "feat(dev): build and repair panes-form windows with stamped identity"
+```
+
+---
+
+### Task 6: Backend — pane-targeted respawn
+
+**Files:**
+- Modify: `tools/dev/lib/backend-tmux.sh` (`dev_backend_respawn_pane`)
+- Test: `tests/dev_backend_tmux.bats`
+
+**Interfaces:**
+- Consumes: Task 4's `id` handle; the `fixture_pane_config` bats helper Task 5 added to `tests/dev_backend_tmux.bats`.
+- Produces: `dev_backend_respawn_pane <session> <window> <command> [container_id] [pane_handle] [pane_name]` — with a handle it respawns exactly that pane; `pane_name` (when non-empty) is added to the `pane.respawned` event data. Still the SOLE emitter of `pane.respawned`.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/dev_backend_tmux.bats`:
+
+```bash
+@test "respawn_pane with a handle revives exactly that pane and stamps survive" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+
+  target=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "agent-2" {print $1; exit}')
+  dev_tmux respawn-pane -k -t "$target" 'exit 7'
+  for _ in $(seq 1 50); do
+    [ "$(dev_tmux display-message -p -t "$target" '#{pane_dead}')" = "1" ] && break
+    sleep 0.1
+  done
+  # make a DIFFERENT pane the window's active pane, to prove targeting is by
+  # handle and not by the old window-target (= active pane) bug
+  other=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "shell" {print $1; exit}')
+  dev_tmux select-pane -t "$other"
+
+  dev_backend_respawn_pane "proj" "main" "sleep 30" "" "$target" "agent-2"
+  [ "$(dev_tmux display-message -p -t "$target" '#{pane_dead}')" = "0" ]
+  [ "$(dev_tmux display-message -p -t "$target" '#{@dev_pane}')" = "agent-2" ]
+
+  line=$(grep '"event":"pane.respawned"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.data.window' <<<"$line")" = "main" ]
+  [ "$(jq -r '.data.pane' <<<"$line")" = "agent-2" ]
+}
+
+@test "respawn_pane without a handle keeps the single-pane event bytes" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_config)" "$(fixture_record)"
+  dev_backend_respawn_pane "proj" "shell" "sleep 30" "cid-1"
+  line=$(grep '"event":"pane.respawned"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.data | has("pane")' <<<"$line")" = "false" ]
+  [ "$(jq -r '.data.container_id' <<<"$line")" = "cid-1" ]
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bats tests/dev_backend_tmux.bats`
+Expected: first new test FAILS (extra args ignored; wrong pane respawned / no `pane` in event).
+
+- [ ] **Step 3: Implement** — change `dev_backend_respawn_pane`'s head and event data:
+
+```bash
+# dev_backend_respawn_pane <session_name> <window> <command> [container_id] \
+#   [pane_handle] [pane_name]
+#
+# With a pane_handle (an id from dev_backend_query) the respawn targets exactly
+# that pane; without one it falls back to the window target, which tmux
+# resolves to the window's ACTIVE pane — correct only for single-pane windows,
+# which is the only caller that omits it. pane_name, when non-empty, is the
+# logical @dev_pane identity and is recorded on the event; the stamp itself
+# survives respawn because the pane object does.
+dev_backend_respawn_pane() {
+  local session_name="$1" window="$2" pane_command="$3" container_id="${4:-}"
+  local pane_handle="${5:-}" pane_name="${6:-}"
+  local target workspace_id slug worktree ev_id ev_ts data line
+  if [[ -n "$pane_handle" ]]; then
+    target="$pane_handle"
+  else
+    target="=$session_name:=$window"
+  fi
+  dev_tmux respawn-pane -k -t "$target" "$pane_command" || return 1
+```
+
+and:
+
+```bash
+  data=$(jq -nc --arg w "$window" --arg p "$pane_name" --arg c "$container_id" \
+    '{window: $w}
+     + (if $p == "" then {} else {pane: $p} end)
+     + (if $c == "" then {} else {container_id: $c} end)')
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bats tests/dev_backend_tmux.bats`
+Expected: all PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/lib/backend-tmux.sh tests/dev_backend_tmux.bats
+git commit -m "feat(dev): pane-handle targeting for respawn, pane on the event"
+```
+
+---
+
+### Task 7: Open — repair on every open, per-pane
+
+**Files:**
+- Modify: `tools/dev/commands/open.sh` (`dev_open_respawn_dead`, `dev_open_ensure_locked`)
+- Test: `tests/dev_commands.bats`
+
+**Interfaces:**
+- Consumes: Task 4 query (`pane`, `id`), Task 6 respawn signature, Task 1 config shape.
+- Produces: dead declared panes respawn on EVERY `dev open` (gate removed); env parity `global * window.environment * pane.environment` with creation.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/dev_commands.bats`, reusing its scenario scaffolding (fake `DEV_DOTFILES_ROOT` root, stubbed agent commands, real tmux). The exact bootstrap must copy what the existing "open after a container loss … respawns dead panes" test does, minus the container parts:
+
+```bash
+@test "plain re-open respawns a dead pane in a host-only workspace (no container loss required)" {
+  scenario_setup_demo_workspace   # reuse/extract the same bootstrap the container-loss respawn test uses
+  run dev open demo --no-attach
+  [ "$status" -eq 0 ]
+
+  dev_tmux respawn-pane -k -t '=demo:=shell' 'exit 3'
+  for _ in $(seq 1 50); do
+    [ "$(dev_tmux list-panes -t '=demo:=shell' -F '#{pane_dead}')" = "1" ] && break
+    sleep 0.1
+  done
+
+  run dev open demo --no-attach
+  [ "$status" -eq 0 ]
+  [ "$(dev_tmux list-panes -t '=demo:=shell' -F '#{pane_dead}')" = "0" ]
+  grep -q '"event":"pane.respawned"' "$DEV_STATE_ROOT/events/events.jsonl"
+}
+```
+
+(If no shared bootstrap function exists, extract one from the container-loss test rather than duplicating the ~15 setup lines; name it `scenario_setup_demo_workspace` and have both tests call it.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bats tests/dev_commands.bats`
+Expected: new test FAILS — the pane stays dead (`repair` gate never fires without container loss).
+
+- [ ] **Step 3: Implement in `tools/dev/commands/open.sh`**
+
+In `dev_open_ensure_locked`, replace the gated call:
+
+```bash
+  if [[ "$repair" -eq 1 && "$created" -eq 0 ]]; then
+    dev_open_respawn_dead "$config" "$record"
+  fi
+```
+
+with an unconditional one (idempotent — only dead declared panes are touched; spec §4 removed the gate deliberately, and a dead agent now respawns on plain `dev <name>`):
+
+```bash
+  dev_open_respawn_dead "$config" "$record"
+```
+
+Rewrite `dev_open_respawn_dead` per-pane:
+
+```bash
+# Only panes the backend reports dead are touched; a live pane is never
+# respawned, so running this on every open is idempotent (spec §4 removed the
+# old container-loss gate). Undeclared panes — unstamped, or stamped with a
+# name the config no longer declares — are skipped: they are drift for
+# `dev status` to report, not ours to touch. A single-pane window with extra
+# manual panes is skipped for the same reason: the window target cannot say
+# which pane is the declared one.
+dev_open_respawn_dead() {
+  local config="$1" record="$2"
+  local query cid global_env win pname handle total wjson pjson env cmd
+  query=$(dev_backend_query "$DEV_OPEN_SESSION")
+  cid=$(jq -r '.container.id // ""' <<<"$record")
+  global_env=$(jq -c '.environment // {}' <<<"$config")
+  while IFS=$'\t' read -r win pname handle total; do
+    [[ -n "$win" ]] || continue
+    wjson=$(jq -c --arg w "$win" 'first(.windows[] | select(.name == $w)) // empty' <<<"$config")
+    [[ -n "$wjson" ]] || continue
+    if [[ "$(jq -r '.panes != null' <<<"$wjson")" == true ]]; then
+      [[ "$pname" != "-" ]] || continue
+      pjson=$(jq -c --arg p "$pname" 'first(.panes[] | select(.name == $p)) // empty' <<<"$wjson")
+      [[ -n "$pjson" ]] || continue
+      env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$wjson")
+      env=$(jq -c --argjson w "$env" '$w * (.environment // {})' <<<"$pjson")
+      cmd=$(dev_open_window_command "$record" "$pjson" "$env") || continue
+      dev_backend_respawn_pane "$DEV_OPEN_SESSION" "$win" "$cmd" "$cid" "$handle" "$pname" || continue
+    else
+      [[ "$total" -eq 1 ]] || continue
+      env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$wjson")
+      cmd=$(dev_open_window_command "$record" "$wjson" "$env") || continue
+      dev_backend_respawn_pane "$DEV_OPEN_SESSION" "$win" "$cmd" "$cid" "$handle" || continue
+    fi
+  done < <(jq -r '.windows[] | .name as $w | (.panes | length) as $n
+    | .panes[] | select(.alive | not)
+    | [$w, (.pane // "-"), .id, ($n | tostring)] | @tsv' <<<"$query")
+}
+```
+
+(`dev_open_window_command` already accepts any window-shaped JSON, so passing the pane object works unchanged — the comment above it in open.sh explains why it must.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bats tests/dev_commands.bats`
+Expected: all PASS — including the container-loss scenario, which now shares the repair path.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/commands/open.sh tests/dev_commands.bats
+git commit -m "feat(dev): repair dead declared panes on every open"
+```
+
+---
+
+### Task 8: Status — pane display and drift reporting
+
+**Files:**
+- Modify: `tools/dev/commands/status.sh`
+- Test: `tests/dev_commands.bats`
+
+**Interfaces:**
+- Consumes: Task 4 query shape; `agents[].pane` from Task 2.
+- Produces: human-readable pane names in window lines, `window/pane` agent labels, and `drift:` lines for undeclared windows and undeclared panes. Nothing machine-readable changes (`dev status` is not a JSON contract).
+
+- [ ] **Step 1: Write the failing test** — append to `tests/dev_commands.bats`:
+
+```bash
+@test "status reports undeclared windows and undeclared panes as drift" {
+  scenario_setup_demo_workspace
+  run dev open demo --no-attach
+  [ "$status" -eq 0 ]
+
+  dev_tmux new-window -d -t '=demo:' -n rogue "sleep 30"
+  dev_tmux split-window -d -t '=demo:=shell' "sleep 30"
+
+  run dev status demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"drift:"*"rogue"* ]]
+  [[ "$output" == *"drift:"*"shell"*"undeclared pane"* ]]
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bats tests/dev_commands.bats`
+Expected: FAILS — status prints no drift lines for windows/panes.
+
+- [ ] **Step 3: Implement in `tools/dev/commands/status.sh`**
+
+Replace the window/agent print block (after the `container:` line) with:
+
+```bash
+  printf '%s' "$query" | jq -r '.windows[]? |
+    "  window \(.name): " + ([.panes[]
+      | (if .pane == null then "" else "\(.pane) " end)
+        + (if .alive then "alive" else "dead" end)] | join(", "))'
+  printf '%s' "$record" | jq -r '.agents[]? |
+    "  agent \(.window)\(if (.pane // null) != null then "/" + .pane else "" end): \(.state) (\(.command // "?"))"'
+
+  # Drift: running windows/panes the merged configuration does not declare.
+  # Reported, never repaired — open never destroys, and status never repairs.
+  printf '%s' "$query" | jq -r --argjson cfg "$(printf '%s' "$config" | jq -c '.windows // []')" '
+    ([$cfg[].name]) as $wnames
+    | .windows[]?
+    | . as $w
+    | if ($w.name | IN($wnames[])) | not then
+        "  drift:      window \($w.name) is running but not declared"
+      else
+        (first($cfg[] | select(.name == $w.name))) as $decl
+        | (if ($decl.panes // null) != null then
+             [$w.panes[] | select(.pane == null or ((.pane | IN($decl.panes[].name)) | not))]
+           elif ($w.panes | length) > 1 then $w.panes[1:]
+           else [] end) as $extra
+        | if ($extra | length) > 0 then
+            "  drift:      window \($w.name) has \($extra | length) undeclared pane(s) (\([$extra[] | .pane // "unnamed"] | join(", ")))"
+          else empty end
+      end'
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bats tests/dev_commands.bats`
+Expected: all PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+/usr/bin/make lint
+git add tools/dev/commands/status.sh tests/dev_commands.bats
+git commit -m "feat(dev): pane-aware status with window and pane drift reporting"
+```
+
+---
+
+### Task 9: Default dashboard, README, test-fixture migration
+
+**Files:**
+- Modify: `tools/dev/default-workspace.yaml`
+- Modify: `tools/dev/README.md`
+- Modify: `tests/dev_commands.bats` (fixture migration + dashboard scenario)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the shipped default is the one-window dashboard; docs describe panes, layouts, focus, the `agent: null` conversion idiom, and migration.
+
+- [ ] **Step 1: Migrate the scenario fixture** — `tests/dev_commands.bats` (line ~25) copies the shipped `default-workspace.yaml` into its fake root. The existing scenarios exercise the single-pane paths and must keep doing so after the default changes: replace the `cp` with a heredoc writing the LEGACY four-window layout into `"$TEST_ROOT/root/tools/dev/default-workspace.yaml"`:
+
+```bash
+  cat >"$TEST_ROOT/root/tools/dev/default-workspace.yaml" <<'EOF'
+version: 1
+autostart: false
+devcontainer:
+  enabled: auto
+  start_timeout: 300
+windows:
+  - name: agent-1
+    agent: claude
+    focus: true
+  - name: agent-2
+    agent: claude
+  - name: shell
+    command: null
+  - name: scratch
+    command: null
+    location: host
+EOF
+```
+
+Run `bats tests/dev_commands.bats` — everything must still pass BEFORE the default changes (this proves the fixture is equivalent). Commit separately:
+
+```bash
+git add tests/dev_commands.bats
+git commit -m "test(dev): pin the legacy default layout in command scenarios"
+```
+
+- [ ] **Step 2: Write the failing dashboard scenario** — append to `tests/dev_commands.bats`; this one copies the REAL shipped default:
+
+```bash
+@test "shipped default opens as a one-window tiled dashboard with four stamped panes" {
+  scenario_setup_demo_workspace
+  cp "$REPO_ROOT/tools/dev/default-workspace.yaml" "$TEST_ROOT/root/tools/dev/default-workspace.yaml"
+  # agent commands must not exit instantly; the scenarios stub `claude`
+  stub_command claude 'exec sleep 30'
+
+  run dev open demo --no-attach
+  [ "$status" -eq 0 ]
+  run dev_tmux list-windows -t '=demo' -F '#{window_name}'
+  [ "$output" = "main" ]
+  run dev_tmux list-panes -t '=demo:=main' -F '#{?#{@dev_pane},#{@dev_pane},-}'
+  [ "$(printf '%s\n' "$output" | sort | tr '\n' ',')" = "agent-1,agent-2,scratch,shell," ]
+
+  record=$(cat "$DEV_STATE_ROOT"/workspaces/*.json)
+  [ "$(jq -r '[.agents[] | select(.window == "main")] | length' <<<"$record")" -eq 2 ]
+  [ "$(jq -r '[.agents[].pane] | sort | join(",")' <<<"$record")" = "agent-1,agent-2" ]
+}
+```
+
+(Adapt the stub/bootstrap details to `scenario_setup_demo_workspace`; if the scenarios already stub `claude`, drop the duplicate stub line.)
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `bats tests/dev_commands.bats`
+Expected: dashboard test FAILS (default still four windows).
+
+- [ ] **Step 4: Ship the dashboard default** — replace `tools/dev/default-workspace.yaml`:
+
+```yaml
+version: 1
+autostart: false
+devcontainer:
+  enabled: auto
+  start_timeout: 300
+windows:
+  - name: main
+    focus: true
+    layout: tiled
+    panes:
+      - name: agent-1
+        agent: claude
+        focus: true
+      - name: agent-2
+        agent: claude
+      - name: shell
+        command: null
+      - name: scratch
+        command: null
+        location: host
+```
+
+- [ ] **Step 5: Update `tools/dev/README.md`** — in the Configuration section: replace the example YAML with the dashboard default above; keep the single-pane form documented ("a window sets `agent:` OR `command:` OR `panes:`"); document per-pane fields (same as single-pane windows, plus required unique `name`, optional `focus`), `layout:` (the five tmux names, default `main-vertical`), the strict conversion idiom (an overlay adding `panes:` to an inherited agent/command window must also null those keys: `agent: null`), migration (a running workspace's next open creates `main` beside the old windows; they are reported as drift; `dev stop <ws>` + `dev <ws>` converts cleanly), the repair change ("re-running `dev` also respawns dead panes — no longer only after container loss"), and one line noting overlays that patched the old default window names (`agent-1` …) by name must be updated. Also update the "Windows also accept cwd and environment" sentence: window-level `environment` now actually applies (it previously was dropped), and panes accept `cwd`/`environment`/`location` per pane.
+
+- [ ] **Step 6: Run the full dev suite and lint**
+
+Run: `bats tests/dev_config_merge.bats tests/dev_fold.bats tests/dev_state_events.bats tests/dev_backend_tmux.bats tests/dev_commands.bats tests/dev_install.bats tests/dev_lifecycle.bats tests/dev_reconcile.bats tests/dev_resolve.bats tests/dev_runtime_container.bats`
+Expected: all PASS.
+Run: `/usr/bin/make lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/dev/default-workspace.yaml tools/dev/README.md tests/dev_commands.bats
+git commit -m "feat(dev): ship the one-window tiled dashboard as the default workspace"
+```
+
+---
+
+### Task 10: Full verification sweep
+
+**Files:** none new.
+
+- [ ] **Step 1: Full test run** — `bats tests` (the whole suite; unrelated suites must be untouched).
+- [ ] **Step 2: Lint** — `/usr/bin/make lint`.
+- [ ] **Step 3: Manual smoke (optional, if a real workspace is at hand)** — `dev <some-workspace> --no-attach` on a plain repo; `dev status` it; kill an agent pane's process and re-open; confirm the pane respawns and `dev list --json | jq '.[] | .agents'` shows `pane` fields.
+- [ ] **Step 4: Spec cross-check** — re-read `docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md` §§1–8 and confirm each has an implementing task; the §2 hook-interpolation verification item is Task 3 Step 4.
+- [ ] **Step 5: Commit any stragglers** and report completion honestly (what ran, what passed, anything skipped).

--- a/docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md
+++ b/docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md
@@ -19,8 +19,8 @@ repairs them; everything else about the platform keeps working.
 3. **Named layouts only** — tmux's five named layouts; no per-split DSL.
 4. **Repair = create missing + respawn dead + report undeclared** — never kill.
 5. **Strict merge** — converting an inherited single-pane window to panes-form
-   requires an explicit `agent: null` (or `command: null` removal); the mixed
-   shape fails validation loudly.
+   requires explicitly nulling every information-carrying single-pane key; the
+   mixed shape fails validation loudly (precise rule in §5).
 6. **Pane focus** — at most one `focus: true` pane per window, re-applied on
    every open like window focus.
 7. **The shipped default becomes a one-window dashboard** — this deliberately
@@ -97,21 +97,47 @@ Pane-resolving tmux commands keep the exact-match discipline: `%pane_id`
 targets are unambiguous by construction; window-level targets stay
 `=session:=window`, session-level stay `=session:`.
 
-## 3. Events and fold (§4.4 changes — all additive)
+## 3. Events and fold (§4.4 changes)
 
 - `pane.died` and `pane.respawned` gain an optional `pane` field. The
-  `pane-died` hook line adds `pane=#{@dev_pane}`; `dev-event` omits the field
-  when the value is empty, so single-pane windows emit today's exact bytes.
+  `pane-died` hook line adds `pane=#{@dev_pane}` unconditionally; `dev-event`
+  is changed to **skip a `pane=` pair whose value is empty** — a targeted
+  rule, not a blanket empty-value filter, because other keys (`client`,
+  `exit_status`) must keep today's record-everything behavior. A regression
+  test asserts a single-pane `pane.died` event is byte-identical to today's.
+- **`window.created` contract amendment:** `location` (currently required)
+  becomes optional. Single-pane windows keep emitting `{window, location,
+  command}` exactly as today. A panes-form window emits `{window,
+  panes: [<pane names>]}` and **omits** `location` and `command` — a
+  dashboard can mix host and container panes, so a window-level location
+  would be a lie; the §4.4 convention "an absent optional field means not
+  known" carries the meaning. Per-pane locations live in `pane.created`. No
+  existing workspace's events change; the amended row applies only to the new
+  config form.
 - New event `pane.created` `{window, pane, location, command}` — the
   **declared** command only, same secrets rule as `window.created` (a rendered
   command embeds `environment` values from `workspace.local.yaml`). The fold
   ignores unknown event types, so old and new events coexist in one log.
-- `agent.started` gains `pane` when emitted for a panes-form window.
+- **All agent lifecycle events** — `agent.started`, `agent.exited`,
+  `agent.failed` — gain optional `pane`, emitted for panes-form windows.
+  Identity is `(window, pane)` everywhere, so exited/failed must route the
+  same way started does.
 - Record schema: `agents[]` entries become `{window, pane, command, state}`
-  with `pane: null` for single-pane windows. The fold matches events to
-  entries on `(window, event.data.pane // null)`. Replaying an existing event
-  log (which has no pane fields anywhere) folds to today's records plus the
-  constant `pane: null` — an added field, allowed by ADR-2.
+  with `pane: null` for single-pane windows. The fold matches every `pane.*`
+  and `agent.*` event to entries on `(window, event.data.pane // null)`.
+  Replaying an existing event log (which has no pane fields anywhere) folds to
+  today's records plus the constant `pane: null` — an added field, allowed by
+  ADR-2.
+- **`applied_digest` decision:** it continues to advance only via
+  `workspace.opened`, i.e. when a session is built. Additive pane/window
+  repair does NOT advance it, even when it happens to fully converge the
+  session: `open` cannot verify that the commands running in *live* panes
+  match a changed config (declared vs. running are not comparable), so an
+  event claiming the digest was applied would overstate what was verified.
+  Consequence, accepted: after a purely-additive config change is repaired
+  into place, `dev status` still reports drift until a stop/reopen.
+  Rejected alternative: a `layout.applied` event advancing the digest — it
+  would trade honest over-reporting for occasional false convergence.
 - `dev list --json`: existing fields untouched; `agents[].pane` added.
   `dev status` gains pane-level drift reporting (see §5).
 
@@ -123,8 +149,18 @@ passed where the window object is passed today (the shapes are identical).
 The vekil agent-env overlay and the secrets rule ride along untouched — there
 is no second quoting/env path.
 
-Per declared window, the single-pane path is completely unchanged. For a
-panes-form window:
+**Repair runs on every open.** Today `dev_open_respawn_dead` is gated behind
+`repair && !created` — it only runs after a *container* was lost, so a normal
+re-open of a host-only workspace never repairs a dead pane. That gate is
+removed: the (generalized) pane-repair pass runs unconditionally after
+`apply_layout` on every open. This is safe because repair is idempotent and
+only ever touches declared panes that are missing or dead; live panes are
+never touched. (This is a deliberate behavior improvement for existing
+single-pane workspaces too: a dead agent window now respawns on plain
+`dev <name>`, not only after container loss.)
+
+Per declared window, the single-pane creation path is completely unchanged.
+For a panes-form window:
 
 - **Window missing** → `new-window` chained with
   `set-window-option remain-on-exit on` exactly as today (one atomic tmux
@@ -158,9 +194,17 @@ Panes merge across layers **by name within their window**, using the window
 algorithm verbatim (patch same names, append new ones, `IN()` not
 `inside()`). New validation, all loud (exit 5):
 
-- a merged window sets `panes` together with any single-pane key
-  (`agent`, `command`, `cwd`, `location`) — names the window; the fix is an
-  explicit `agent: null` / `command: null` in the overlay;
+- a merged window sets `panes` together with any **non-null** single-pane key
+  (`agent`, `command`, `cwd`, `location`, `environment`) — names the window;
+  the fix is explicitly nulling that key in the overlay (`agent: null`, etc.).
+  The check must be value-based, not key-presence-based: normalization gives
+  every window all keys, and jq's merge cannot distinguish an explicit null
+  from an inherited one. The deliberate consequence: a base window that is a
+  plain shell (`command: null`, nothing else set) converts to panes-form with
+  no acknowledgment — `command: null` carries no information beyond the
+  default, so nothing can be silently lost. Any non-null value (an agent, a
+  real command, a `cwd`, a `location`, an `environment`) still fails loudly
+  until the overlay nulls it;
 - duplicate pane names within one window;
 - a pane sets both `agent` and `command`;
 - invalid pane `name` charset or `location` value;
@@ -177,7 +221,11 @@ algorithm verbatim (patch same names, append new ones, `IN()` not
 - **Constraint revision (explicit user choice):** the original constraint was
   "every existing workspace.yaml behaves byte-identically". The machinery
   honors that — any config without `panes` produces identical commands,
-  events, and digests — but the shipped default itself changes.
+  events, and digests — with two named exceptions: (a) the shipped default
+  itself changes, and (b) a panes-less config that declares window-level
+  `environment` gets a one-time digest change and starts actually receiving
+  that environment, because fixing the normalization drop (§7.1) is a
+  behavior fix by definition. No config on this machine hits (b) today.
 - A **running** workspace's next `dev open` creates `main` beside the old four
   windows (open never destroys). The old windows become window-level drift in
   `dev status` until the user runs `dev stop` + `dev <name>`, which is the
@@ -198,8 +246,10 @@ algorithm verbatim (patch same names, append new ones, `IN()` not
    but `DEV_CONFIG_NORMALIZE_JQ` omits `environment` from the window map, so a
    window-level `environment` never reaches `dev_window_inner_command` (only
    the top-level `environment` does). Panes must support `environment`
-   correctly; the window-level fix should ride along in the same change (it is
-   the same jq map) — flagged so it is a decision, not an accident.
+   correctly; the window-level fix rides along in the same change (it is the
+   same jq map). Decided, not accidental — and its compatibility cost is the
+   named exception (b) in §6: affected panes-less configs (none exist on this
+   machine) see a one-time digest change plus the intended behavior fix.
 2. **Active-pane respawn targeting** (§4): `dev_backend_respawn_pane` targets
    the window, i.e. its active pane. Harmless while windows have one pane;
    must become pane-id targeting as part of this work.
@@ -215,9 +265,14 @@ algorithm verbatim (patch same names, append new ones, `IN()` not
 ## Verification strategy (for the implementation plan)
 
 - bats: config normalization byte-identity for panes-less configs (digest
-  unchanged); merge/validation matrix incl. the strict-conversion error;
-  fold replay of a legacy log producing `pane: null` entries; fold routing of
-  pane-qualified `pane.died`/`pane.respawned` to the right agent.
+  unchanged — except the window-`environment` case, asserted separately as a
+  deliberate change); merge/validation matrix incl. the value-based
+  strict-conversion error and the shell-window no-acknowledgment case; fold
+  replay of a legacy log producing `pane: null` entries; fold routing of
+  pane-qualified `pane.died`/`pane.respawned`/`agent.exited`/`agent.failed`
+  to the right agent; `dev-event` drops an empty `pane=` pair and a
+  single-pane `pane.died` line is byte-identical to today's; dead-pane repair
+  runs on a plain re-open with no container loss (gate removal).
 - tmux-integration: dashboard creation with fast-exiting commands (dead held
   panes, window survives); pane repair after killing one agent pane of two;
   undeclared-pane drift; layout not re-applied on no-op open; `@dev_pane`

--- a/docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md
+++ b/docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md
@@ -1,0 +1,226 @@
+# Declarative multi-pane windows — design
+
+Date: 2026-08-04
+Status: approved design, pre-implementation
+
+## Goal
+
+Let one tmux window show several panes declaratively — up to a full dashboard
+(two agents and two shells tiled in a single window), removing the friction of
+switching windows to see each agent. `dev open` builds the panes; re-running it
+repairs them; everything else about the platform keeps working.
+
+## Decisions (all confirmed with the user)
+
+1. **Pane-qualified agent identity** — any pane may set `agent:`; multiple
+   agents per window are supported. Identity is the pair `(window, pane)`.
+2. **Exclusive schema** — a window sets either the existing single-pane keys
+   or `panes:`, never both.
+3. **Named layouts only** — tmux's five named layouts; no per-split DSL.
+4. **Repair = create missing + respawn dead + report undeclared** — never kill.
+5. **Strict merge** — converting an inherited single-pane window to panes-form
+   requires an explicit `agent: null` (or `command: null` removal); the mixed
+   shape fails validation loudly.
+6. **Pane focus** — at most one `focus: true` pane per window, re-applied on
+   every open like window focus.
+7. **The shipped default becomes a one-window dashboard** — this deliberately
+   revises the original "default never changes" constraint; the *machinery*
+   still keeps every no-panes config byte-identical.
+
+## 1. Schema
+
+A window declares **either** the single-pane form (today's `agent`/`command`/
+`cwd`/`location`, completely unchanged) **or** `panes:`. A panes-form window
+accepts only `name`, `focus`, `layout`, `panes`:
+
+```yaml
+windows:
+  - name: main
+    focus: true
+    layout: tiled            # even-horizontal | even-vertical | main-horizontal
+                             # | main-vertical | tiled; default main-vertical
+    panes:
+      - name: agent-1
+        agent: claude
+        focus: true          # at most one focused pane per window
+      - name: agent-2
+        agent: claude
+      - name: shell
+        command: null        # null command = interactive shell
+      - name: scratch
+        command: null
+        location: host
+```
+
+Per-pane fields are exactly the single-pane window fields: `name` (required,
+`[A-Za-z0-9._-]+`), `agent` xor `command`, `cwd`, `location`, `environment`,
+plus `focus`. Pane names must be unique **within their window** only; identity
+everywhere is `(window, pane)`, so every dashboard can have a pane named
+`shell`.
+
+**Normalization** adds the `panes` and `layout` keys **only when present** in
+the merged config. Unconditionally normalizing them (like the other window
+keys) would change the normalized JSON — and therefore the sha256 config
+digest — of every existing workspace, spuriously reporting config drift on the
+next open. This conditional normalization is what keeps constraint 8's
+"byte-identical" promise for existing configs.
+
+## 2. Pane identity in tmux
+
+The durable answer to "which pane is the agent" is a **pane-scoped user
+option** `@dev_pane`, stamped with the logical pane name at pane creation.
+tmux keeps pane options through `respawn-pane` (the pane object survives; only
+its process is replaced), so identity survives respawns. Only kill+recreate
+restamps. tmux pane ids (`%N`) and indexes are never used as identity — only
+as concrete targets resolved fresh from a query.
+
+Stamping does not need the remain-on-exit atomic chain: `remain-on-exit` is
+window-scoped and set atomically with window creation (the existing chained
+invocation), so by the time any `split-window` runs it is already on, and a
+fast-exiting split command leaves a *dead, held, still-targetable* pane — the
+window-destruction race that motivated the original chain cannot occur for
+splits. Mechanics:
+
+- `split-window -P -F '#{pane_id}'` captures the concrete new pane id.
+- `set-option -p -t "%id" @dev_pane <name>` stamps it (a dead pane still
+  accepts options).
+
+Single-pane windows are never stamped, keeping their event stream
+byte-identical to today's.
+
+**Verification item for implementation:** confirm on tmux 3.4 that the
+window-scoped `pane-died` hook's format context interpolates the *dying
+pane's* `#{@dev_pane}`. Fallback if not: interpolate `#{pane_id}` and resolve
+it to the logical name via a query in `dev-event`.
+
+Pane-resolving tmux commands keep the exact-match discipline: `%pane_id`
+targets are unambiguous by construction; window-level targets stay
+`=session:=window`, session-level stay `=session:`.
+
+## 3. Events and fold (§4.4 changes — all additive)
+
+- `pane.died` and `pane.respawned` gain an optional `pane` field. The
+  `pane-died` hook line adds `pane=#{@dev_pane}`; `dev-event` omits the field
+  when the value is empty, so single-pane windows emit today's exact bytes.
+- New event `pane.created` `{window, pane, location, command}` — the
+  **declared** command only, same secrets rule as `window.created` (a rendered
+  command embeds `environment` values from `workspace.local.yaml`). The fold
+  ignores unknown event types, so old and new events coexist in one log.
+- `agent.started` gains `pane` when emitted for a panes-form window.
+- Record schema: `agents[]` entries become `{window, pane, command, state}`
+  with `pane: null` for single-pane windows. The fold matches events to
+  entries on `(window, event.data.pane // null)`. Replaying an existing event
+  log (which has no pane fields anywhere) folds to today's records plus the
+  constant `pane: null` — an added field, allowed by ADR-2.
+- `dev list --json`: existing fields untouched; `agents[].pane` added.
+  `dev status` gains pane-level drift reporting (see §5).
+
+## 4. Build and repair (`dev_backend_apply_layout` + `dev_open_respawn_dead`)
+
+Every pane's command is built by the existing pair
+`dev_container_exec_prefix` + `dev_window_inner_command`, with the pane object
+passed where the window object is passed today (the shapes are identical).
+The vekil agent-env overlay and the secrets rule ride along untouched — there
+is no second quoting/env path.
+
+Per declared window, the single-pane path is completely unchanged. For a
+panes-form window:
+
+- **Window missing** → `new-window` chained with
+  `set-window-option remain-on-exit on` exactly as today (one atomic tmux
+  invocation), stamp the first pane, split+stamp the remaining panes, then one
+  `select-layout <layout>`. Emit `window.created`, `pane.created` × N, and
+  `agent.started` for each agent pane.
+- **Declared pane missing** in a live window → split + stamp + re-apply
+  `select-layout`. Layout is re-applied **only when a pane was created**, so a
+  no-op `dev open` never stomps manual resizes.
+- **Declared pane dead** (remain-on-exit holds it) → `respawn-pane -t "%id"`,
+  the id resolved from the query by `@dev_pane`, command rebuilt through the
+  same path, emitting `pane.respawned {window, pane}`.
+  This fixes a latent bug: today's respawn targets `=session:=window`, which
+  resolves to the window's **active** pane — wrong the moment a window has two.
+- **Undeclared pane** (unstamped, or stamped with a name no longer in config)
+  → invisible to repair: never matched, never split into, never killed;
+  reported by `dev status` as pane drift. This one rule covers manual splits,
+  config-removed panes, and shape conversions of a running window.
+- **Focus**: after the focused window is selected, `select-pane` the focused
+  pane's current `%id`. Re-applied on every open, like window focus.
+
+`dev_backend_query` pane objects gain `pane` (the `@dev_pane` value or null)
+and `pane_id` (for targeting; not part of any durable record). In the
+`list-panes` format string the new fields precede `window_name`, which stays
+last to absorb spaces; `@dev_pane`'s restricted charset keeps the line
+splittable, with a `#{?…}` placeholder for the unset case.
+
+## 5. Merge and validation
+
+Panes merge across layers **by name within their window**, using the window
+algorithm verbatim (patch same names, append new ones, `IN()` not
+`inside()`). New validation, all loud (exit 5):
+
+- a merged window sets `panes` together with any single-pane key
+  (`agent`, `command`, `cwd`, `location`) — names the window; the fix is an
+  explicit `agent: null` / `command: null` in the overlay;
+- duplicate pane names within one window;
+- a pane sets both `agent` and `command`;
+- invalid pane `name` charset or `location` value;
+- more than one `focus: true` pane in a window;
+- `layout` not one of the five tmux names, or present without `panes`;
+- `panes: []` (empty list).
+
+## 6. Default workspace and migration
+
+`default-workspace.yaml` becomes the dashboard shown in §1: one window `main`,
+`layout: tiled`, panes `agent-1`, `agent-2`, `shell`, `scratch` (scratch keeps
+`location: host`). Consequences:
+
+- **Constraint revision (explicit user choice):** the original constraint was
+  "every existing workspace.yaml behaves byte-identically". The machinery
+  honors that — any config without `panes` produces identical commands,
+  events, and digests — but the shipped default itself changes.
+- A **running** workspace's next `dev open` creates `main` beside the old four
+  windows (open never destroys). The old windows become window-level drift in
+  `dev status` until the user runs `dev stop` + `dev <name>`, which is the
+  clean conversion. Their `agents[]` entries persist in the record (keyed by
+  the old window names, `pane: null`) until then — accurate, since those
+  agents really are still running.
+- No project under `~/.dotfiles/projects/` currently has a `workspace.yaml`
+  overlay, so nothing patches `agent-1`-by-name today and the
+  overlay-stops-matching hazard is theoretical. The README should still note
+  that overlays patching the old default window names must be updated when
+  this ships.
+- README configuration section gains the panes-form example and the
+  `agent: null` conversion idiom.
+
+## 7. Pre-existing issues discovered during design
+
+1. **Per-window `environment` is silently dropped.** The README documents it,
+   but `DEV_CONFIG_NORMALIZE_JQ` omits `environment` from the window map, so a
+   window-level `environment` never reaches `dev_window_inner_command` (only
+   the top-level `environment` does). Panes must support `environment`
+   correctly; the window-level fix should ride along in the same change (it is
+   the same jq map) — flagged so it is a decision, not an accident.
+2. **Active-pane respawn targeting** (§4): `dev_backend_respawn_pane` targets
+   the window, i.e. its active pane. Harmless while windows have one pane;
+   must become pane-id targeting as part of this work.
+
+## 8. Explicit exclusions (YAGNI)
+
+- No per-split direction/size DSL; no custom layout strings.
+- No nested panes, no pane-level `autostart`, no per-worktree pane config.
+- No `dev` verb to prune drifted windows/panes; `dev stop` + reopen remains
+  the conversion/cleanup path.
+- No global pane-name uniqueness; identity is always `(window, pane)`.
+
+## Verification strategy (for the implementation plan)
+
+- bats: config normalization byte-identity for panes-less configs (digest
+  unchanged); merge/validation matrix incl. the strict-conversion error;
+  fold replay of a legacy log producing `pane: null` entries; fold routing of
+  pane-qualified `pane.died`/`pane.respawned` to the right agent.
+- tmux-integration: dashboard creation with fast-exiting commands (dead held
+  panes, window survives); pane repair after killing one agent pane of two;
+  undeclared-pane drift; layout not re-applied on no-op open; `@dev_pane`
+  survival across respawn; the `pane-died` hook interpolation check from §2.
+- `dev list --json` contract: existing fields byte-identical for a
+  panes-less workspace.

--- a/docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md
+++ b/docs/superpowers/specs/2026-08-04-multi-pane-windows-design.md
@@ -74,16 +74,21 @@ its process is replaced), so identity survives respawns. Only kill+recreate
 restamps. tmux pane ids (`%N`) and indexes are never used as identity — only
 as concrete targets resolved fresh from a query.
 
-Stamping does not need the remain-on-exit atomic chain: `remain-on-exit` is
-window-scoped and set atomically with window creation (the existing chained
-invocation), so by the time any `split-window` runs it is already on, and a
-fast-exiting split command leaves a *dead, held, still-targetable* pane — the
-window-destruction race that motivated the original chain cannot occur for
-splits. Mechanics:
+Stamping MUST be chained atomically into the same tmux invocation as the
+split. The window-destruction race cannot occur for splits (`remain-on-exit`
+is window-scoped and already on from window creation, so a fast-exiting split
+command leaves a *dead, held, still-targetable* pane) — but a second race
+can: the `pane-died` hook can fire before a separate second invocation stamps
+`@dev_pane`, producing an identity-less death event for a declared pane that
+the fold could not route. Mechanics:
 
-- `split-window -P -F '#{pane_id}'` captures the concrete new pane id.
-- `set-option -p -t "%id" @dev_pane <name>` stamps it (a dead pane still
-  accepts options).
+- `split-window` (without `-d`, so the new pane becomes the window's active
+  pane) chained via tmux's `';'` separator with
+  `set-option -p -t "=session:=window" @dev_pane <name>` — the window target
+  resolves to the active pane, i.e. the pane just created, inside one atomic
+  server request, exactly the pattern the shipped remain-on-exit chain proved.
+- The active-pane side effect is corrected by the focus pass at the end of
+  layout application.
 
 Single-pane windows are never stamped, keeping their event stream
 byte-identical to today's.
@@ -192,7 +197,17 @@ splittable, with a `#{?…}` placeholder for the unset case.
 
 Panes merge across layers **by name within their window**, using the window
 algorithm verbatim (patch same names, append new ones, `IN()` not
-`inside()`). New validation, all loud (exit 5):
+`inside()`).
+
+**Per-layer duplicate detection:** by-name merging collapses duplicate names
+before any post-merge validation can see them (a layer that defines an
+inherited pane twice would silently keep only the last patch), so each YAML
+layer is checked for duplicate window names and duplicate pane names *while
+it is still a layer*, and `dev config`/`dev open` fail with exit 5 naming the
+offending file. The post-merge duplicate checks below remain as defense in
+depth.
+
+New validation, all loud (exit 5):
 
 - a merged window sets `panes` together with any **non-null** single-pane key
   (`agent`, `command`, `cwd`, `location`, `environment`) — names the window;

--- a/tests/dev_backend_tmux.bats
+++ b/tests/dev_backend_tmux.bats
@@ -468,7 +468,7 @@ fixture_pane_config() {
   [ "$(jq -r '.pane' <<<"$dead")" = "shell" ]
 }
 
-@test "apply_layout leaves undeclared panes alone and single-pane window env includes window environment" {
+@test "apply_layout leaves undeclared panes alone" {
   dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
   cfg=$(jq -c '.windows[0].panes |= .[0:2]' <<<"$(fixture_pane_config)")
   dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
@@ -477,7 +477,10 @@ fixture_pane_config() {
   dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
   run dev_tmux list-panes -t "=proj:=main" -F '#{pane_id}'
   [[ "$output" == *"$manual"* ]]
+}
 
+@test "apply_layout injects window-level environment into a single-pane window" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
   # window-level environment reaches a single-pane window's process (spec §7.1 fix)
   envcfg=$(jq -nc '{
     version: 1, autostart: false,

--- a/tests/dev_backend_tmux.bats
+++ b/tests/dev_backend_tmux.bats
@@ -465,3 +465,38 @@ fixture_pane_config() {
   done
   [ "$(cat "$TEST_WT/probe.txt")" = "from-window" ]
 }
+
+@test "respawn_pane with a handle revives exactly that pane and stamps survive" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+
+  target=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "agent-2" {print $1; exit}')
+  dev_tmux respawn-pane -k -t "$target" 'exit 7'
+  for _ in $(seq 1 50); do
+    [ "$(dev_tmux display-message -p -t "$target" '#{pane_dead}')" = "1" ] && break
+    sleep 0.1
+  done
+  # make a DIFFERENT pane the window's active pane, to prove targeting is by
+  # handle and not by the old window-target (= active pane) bug
+  other=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "shell" {print $1; exit}')
+  dev_tmux select-pane -t "$other"
+
+  dev_backend_respawn_pane "proj" "main" "sleep 30" "" "$target" "agent-2"
+  [ "$(dev_tmux display-message -p -t "$target" '#{pane_dead}')" = "0" ]
+  [ "$(dev_tmux display-message -p -t "$target" '#{@dev_pane}')" = "agent-2" ]
+
+  line=$(grep '"event":"pane.respawned"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.data.window' <<<"$line")" = "main" ]
+  [ "$(jq -r '.data.pane' <<<"$line")" = "agent-2" ]
+}
+
+@test "respawn_pane without a handle keeps the single-pane event bytes" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_config)" "$(fixture_record)"
+  dev_backend_respawn_pane "proj" "shell" "sleep 30" "cid-1"
+  line=$(grep '"event":"pane.respawned"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.data | has("pane")' <<<"$line")" = "false" ]
+  [ "$(jq -r '.data.container_id' <<<"$line")" = "cid-1" ]
+}

--- a/tests/dev_backend_tmux.bats
+++ b/tests/dev_backend_tmux.bats
@@ -332,3 +332,21 @@ fixture_config() {
   done
   [ "$clients" = "0" ]
 }
+
+@test "query reports pane logical names and handles; unstamped panes report pane:null" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_tmux new-window -d -t "=proj:" -n w1 "sleep 30" \
+    ';' set-window-option -t "=proj:=w1" remain-on-exit on \
+    ';' set-option -p -t "=proj:=w1" @dev_pane agent-1
+  pid=$(dev_tmux split-window -d -P -F '#{pane_id}' -t "=proj:=w1" "sleep 30")
+  dev_tmux set-option -p -t "$pid" @dev_pane shell
+  dev_tmux split-window -d -t "=proj:=w1" "sleep 30" # unstamped
+
+  run dev_backend_query "proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "w1")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 3 ]
+  [ "$(jq -r '[.panes[].pane] | sort | join(",")' <<<"$win")" = ",agent-1,shell" ]
+  [ "$(jq -r '[.panes[] | select(.pane == "shell") | .pane_id] | first' <<<"$win")" = "$pid" ]
+  [ "$(jq -r '[.panes[] | select(.pane == null)] | length' <<<"$win")" -eq 1 ]
+}

--- a/tests/dev_backend_tmux.bats
+++ b/tests/dev_backend_tmux.bats
@@ -426,6 +426,35 @@ fixture_pane_config() {
   [ "$(jq -r '[.panes[] | select(.pane == "shell")] | length' <<<"$win")" -eq 1 ]
 }
 
+@test "repair-splitting into a pre-existing, name-colliding user window sets remain-on-exit" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  # A bare user window, created WITHOUT remain-on-exit chained (the new-window
+  # branch is never exercised for it), that happens to share its name with a
+  # declared panes-form window. Repair must still protect it.
+  dev_tmux new-window -d -t "=proj:" -n main "sleep 30"
+
+  # Two declared panes, not fixture_pane_config's four: the bare window above
+  # already holds one live pane, and a default 80x24 test terminal has no
+  # room to split five.
+  local cfg
+  cfg=$(jq -nc '{
+    version: 1, autostart: false,
+    devcontainer: {enabled: "auto", start_timeout: 300},
+    environment: {},
+    windows: [
+      {name: "main", agent: null, command: null, cwd: null, location: null,
+       focus: true, layout: "tiled",
+       panes: [
+         {name: "agent-1", agent: "sleep 30", command: null, cwd: null, location: null, focus: true},
+         {name: "shell",   agent: null, command: null, cwd: null, location: null, focus: false}
+       ]}
+    ]}')
+  dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
+
+  run dev_tmux show-window-options -t "=proj:=main" remain-on-exit
+  [[ "$output" == *on* ]]
+}
+
 @test "apply_layout survives fast-exiting pane commands: dead, held, and stamped" {
   dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
   cfg=$(jq -c '.windows[0].panes[2].command = "exit 5"' <<<"$(fixture_pane_config)")

--- a/tests/dev_backend_tmux.bats
+++ b/tests/dev_backend_tmux.bats
@@ -350,3 +350,118 @@ fixture_config() {
   [ "$(jq -r '[.panes[] | select(.pane == "shell") | .pane_id] | first' <<<"$win")" = "$pid" ]
   [ "$(jq -r '[.panes[] | select(.pane == null)] | length' <<<"$win")" -eq 1 ]
 }
+
+fixture_pane_config() {
+  jq -nc '{
+    version: 1, autostart: false,
+    devcontainer: {enabled: "auto", start_timeout: 300},
+    environment: {},
+    windows: [
+      {name: "main", agent: null, command: null, cwd: null, location: null,
+       focus: true, layout: "tiled",
+       panes: [
+         {name: "agent-1", agent: "sleep 30", command: null, cwd: null, location: null, focus: true},
+         {name: "agent-2", agent: "sleep 30", command: null, cwd: null, location: null, focus: false},
+         {name: "shell",   agent: null, command: null, cwd: null, location: null, focus: false},
+         {name: "scratch", agent: null, command: null, cwd: null, location: "host", focus: false}
+       ]}
+    ]}'
+}
+
+@test "apply_layout builds a panes-form window with stamped panes and applies the layout" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+
+  run dev_backend_query "proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 4 ]
+  [ "$(jq -r '[.panes[].pane] | sort | join(",")' <<<"$win")" = "agent-1,agent-2,scratch,shell" ]
+  [ "$(jq -r '[.panes[].alive] | unique | join(",")' <<<"$win")" = "true" ]
+  # remain-on-exit protects the whole window
+  run dev_tmux show-window-options -t "=proj:=main" remain-on-exit
+  [[ "$output" == *on* ]]
+  # the focused pane is the window's active pane
+  [ "$(dev_tmux display-message -p -t '=proj:=main' '#{@dev_pane}')" = "agent-1" ]
+}
+
+@test "apply_layout emits amended window.created, pane.created x4, agent.started with pane" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+  local log="$DEV_STATE_ROOT/events/events.jsonl"
+
+  wc_line=$(grep '"event":"window.created"' "$log")
+  [ "$(jq -r '.data.window' <<<"$wc_line")" = "main" ]
+  [ "$(jq -r '.data | has("location")' <<<"$wc_line")" = "false" ]
+  [ "$(jq -r '.data | has("command")' <<<"$wc_line")" = "false" ]
+  [ "$(jq -r '.data.panes | join(",")' <<<"$wc_line")" = "agent-1,agent-2,shell,scratch" ]
+
+  [ "$(grep -c '"event":"pane.created"' "$log")" -eq 4 ]
+  pc=$(grep '"event":"pane.created"' "$log" | head -n 1)
+  [ "$(jq -r '.data.pane' <<<"$pc")" = "agent-1" ]
+  [ "$(jq -r '.data.command' <<<"$pc")" = "sleep 30" ]
+
+  [ "$(grep -c '"event":"agent.started"' "$log")" -eq 2 ]
+  as_line=$(grep '"event":"agent.started"' "$log" | head -n 1)
+  [ "$(jq -r '.data.pane' <<<"$as_line")" = "agent-1" ]
+}
+
+@test "apply_layout is idempotent for panes-form windows and repairs a missing declared pane" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+
+  before=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id}' | sort)
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+  after=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id}' | sort)
+  [ "$before" = "$after" ]
+
+  # kill one pane outright (as a user would); re-apply recreates exactly it
+  victim=$(dev_tmux list-panes -t "=proj:=main" -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "shell" {print $1; exit}')
+  dev_tmux kill-pane -t "$victim"
+  dev_backend_apply_layout "proj" "$(fixture_pane_config)" "$(fixture_record)"
+  run dev_backend_query "proj"
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 4 ]
+  [ "$(jq -r '[.panes[] | select(.pane == "shell")] | length' <<<"$win")" -eq 1 ]
+}
+
+@test "apply_layout survives fast-exiting pane commands: dead, held, and stamped" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  cfg=$(jq -c '.windows[0].panes[2].command = "exit 5"' <<<"$(fixture_pane_config)")
+  dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
+  run dev_backend_query "proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  # the window survives and all four panes exist; the fast-exiting one is dead
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 4 ]
+  dead=$(jq -c '.panes[] | select(.alive | not)' <<<"$win")
+  [ "$(jq -r '.pane' <<<"$dead")" = "shell" ]
+}
+
+@test "apply_layout leaves undeclared panes alone and single-pane window env includes window environment" {
+  dev_backend_create "proj" "aa11" "proj" "$TEST_WT"
+  cfg=$(jq -c '.windows[0].panes |= .[0:2]' <<<"$(fixture_pane_config)")
+  dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
+  # a manual, unstamped split survives a re-apply untouched
+  manual=$(dev_tmux split-window -d -P -F '#{pane_id}' -t "=proj:=main" "sleep 30")
+  dev_backend_apply_layout "proj" "$cfg" "$(fixture_record)"
+  run dev_tmux list-panes -t "=proj:=main" -F '#{pane_id}'
+  [[ "$output" == *"$manual"* ]]
+
+  # window-level environment reaches a single-pane window's process (spec §7.1 fix)
+  envcfg=$(jq -nc '{
+    version: 1, autostart: false,
+    devcontainer: {enabled: "auto", start_timeout: 300},
+    environment: {},
+    windows: [{name: "envwin", agent: null,
+               command: "printf %s \"$PROBE\" > probe.txt; sleep 30",
+               cwd: null, location: "host", focus: false,
+               environment: {PROBE: "from-window"}}]}')
+  dev_backend_apply_layout "proj" "$envcfg" "$(fixture_record)"
+  for _ in $(seq 1 50); do
+    [ -s "$TEST_WT/probe.txt" ] && break
+    sleep 0.1
+  done
+  [ "$(cat "$TEST_WT/probe.txt")" = "from-window" ]
+}

--- a/tests/dev_commands.bats
+++ b/tests/dev_commands.bats
@@ -22,7 +22,27 @@ stage_dev_root() {
   cp -r "$REPO_ROOT/bin" "$TEST_ROOT/root/bin"
   cp -r "$REPO_ROOT/tools/dev/lib" "$TEST_ROOT/root/tools/dev/lib"
   cp -r "$REPO_ROOT/tools/dev/commands" "$TEST_ROOT/root/tools/dev/commands"
-  cp "$REPO_ROOT/tools/dev/default-workspace.yaml" "$TEST_ROOT/root/tools/dev/default-workspace.yaml"
+  # Pinned to the LEGACY four-window layout (not a cp of the shipped default):
+  # these dispatcher-pattern scenarios exercise the single-pane window paths
+  # and must keep doing so regardless of what the shipped default becomes.
+  cat >"$TEST_ROOT/root/tools/dev/default-workspace.yaml" <<'EOF'
+version: 1
+autostart: false
+devcontainer:
+  enabled: auto
+  start_timeout: 300
+windows:
+  - name: agent-1
+    agent: claude
+    focus: true
+  - name: agent-2
+    agent: claude
+  - name: shell
+    command: null
+  - name: scratch
+    command: null
+    location: host
+EOF
   export DEV_DOTFILES_ROOT="$TEST_ROOT/root"
 }
 
@@ -284,6 +304,41 @@ dev_open_load_libs() {
   source "$REPO_ROOT/tools/dev/commands/status.sh"
 }
 
+# dev_open_load_libs sources the real repo directly and setup_dev_test points
+# DEV_DOTFILES_ROOT at $REPO_ROOT, so these sourced-function scenarios read
+# the actual shipped default-workspace.yaml -- not a copy under stage_dev_root
+# (that fixture only feeds the dispatcher-pattern tests above). Scenarios that
+# assert the legacy single-pane *window* shape (agent-1/agent-2/shell/scratch
+# as windows, not panes of one dashboard window) call this to pin that shape
+# regardless of what the shipped default becomes. config/ is symlinked so
+# devcontainer-CLI-pin lookups still resolve against the real repo.
+dev_open_pin_legacy_default() {
+  local root="$TEST_ROOT/legacy-dotfiles-root"
+  if [ ! -e "$root" ]; then
+    mkdir -p "$root/tools/dev"
+    ln -s "$REPO_ROOT/config" "$root/config"
+    cat >"$root/tools/dev/default-workspace.yaml" <<'EOF'
+version: 1
+autostart: false
+devcontainer:
+  enabled: auto
+  start_timeout: 300
+windows:
+  - name: agent-1
+    agent: claude
+    focus: true
+  - name: agent-2
+    agent: claude
+  - name: shell
+    command: null
+  - name: scratch
+    command: null
+    location: host
+EOF
+  fi
+  export DEV_DOTFILES_ROOT="$root"
+}
+
 dev_open_fixture() {
   local dir="$DEV_REPO_ROOT/$1"
   mkdir -p "$dir"
@@ -306,6 +361,7 @@ dev_open_events() {
 @test "open creates the session with the four default windows and emits workspace.opened" {
   setup_dev_test
   dev_open_load_libs
+  dev_open_pin_legacy_default
   dev_open_stub_attach
   dev_open_fixture demo >/dev/null
 
@@ -334,6 +390,7 @@ dev_open_events() {
 @test "a second open creates nothing, re-runs nothing, and leaves scratch untouched" {
   setup_dev_test
   dev_open_load_libs
+  dev_open_pin_legacy_default
   dev_open_stub_attach
   dev_open_fixture demo >/dev/null
 
@@ -429,6 +486,7 @@ scenario_setup_demo_workspace() {
 
 @test "open after a container loss emits container.replaced then container.ready and respawns dead panes" {
   scenario_setup_demo_workspace
+  dev_open_pin_legacy_default
   local dir ws_id
   dir="$DEV_REPO_ROOT/demo"
   mkdir -p "$dir/.devcontainer"
@@ -507,6 +565,7 @@ esac
 
 @test "plain re-open respawns a dead pane in a host-only workspace (no container loss required)" {
   scenario_setup_demo_workspace
+  dev_open_pin_legacy_default
 
   run dev_cmd_open demo --no-attach
   [ "$status" -eq 0 ]
@@ -527,6 +586,7 @@ esac
 
 @test "re-open respawns one dead agent pane of two and leaves the other agent untouched" {
   scenario_setup_demo_workspace
+  dev_open_pin_legacy_default
   mkdir -p "$DEV_OVERLAY_ROOT/demo"
   cat >"$DEV_OVERLAY_ROOT/demo/workspace.yaml" <<'EOF'
 version: 1
@@ -886,6 +946,7 @@ exit 0
 
 @test "status reports undeclared windows and undeclared panes as drift" {
   scenario_setup_demo_workspace
+  dev_open_pin_legacy_default
 
   run dev_cmd_open demo --no-attach
   [ "$status" -eq 0 ]

--- a/tests/dev_commands.bats
+++ b/tests/dev_commands.bats
@@ -309,35 +309,10 @@ dev_open_load_libs() {
 # the actual shipped default-workspace.yaml -- not a copy under stage_dev_root
 # (that fixture only feeds the dispatcher-pattern tests above). Scenarios that
 # assert the legacy single-pane *window* shape (agent-1/agent-2/shell/scratch
-# as windows, not panes of one dashboard window) call this to pin that shape
-# regardless of what the shipped default becomes. config/ is symlinked so
-# devcontainer-CLI-pin lookups still resolve against the real repo.
-dev_open_pin_legacy_default() {
-  local root="$TEST_ROOT/legacy-dotfiles-root"
-  if [ ! -e "$root" ]; then
-    mkdir -p "$root/tools/dev"
-    ln -s "$REPO_ROOT/config" "$root/config"
-    cat >"$root/tools/dev/default-workspace.yaml" <<'EOF'
-version: 1
-autostart: false
-devcontainer:
-  enabled: auto
-  start_timeout: 300
-windows:
-  - name: agent-1
-    agent: claude
-    focus: true
-  - name: agent-2
-    agent: claude
-  - name: shell
-    command: null
-  - name: scratch
-    command: null
-    location: host
-EOF
-  fi
-  export DEV_DOTFILES_ROOT="$root"
-}
+# as windows, not panes of one dashboard window) call dev_pin_legacy_default_root
+# (test_helper.bash) to pin that shape regardless of what the shipped default
+# becomes.
+dev_open_pin_legacy_default() { dev_pin_legacy_default_root; }
 
 dev_open_fixture() {
   local dir="$DEV_REPO_ROOT/$1"
@@ -959,5 +934,24 @@ exit 0
   [[ "$output" == *"drift:"*"rogue"* ]]
   [[ "$output" == *"drift:"*"shell"*"undeclared pane"* ]]
 
+  dev_tmux kill-server || true
+}
+
+@test "shipped default opens as a one-window tiled dashboard with four stamped panes" {
+  # Unlike the scenarios above, this one deliberately does NOT pin the legacy
+  # layout: it exercises the real shipped tools/dev/default-workspace.yaml
+  # (scenario_setup_demo_workspace already stubs claude to stay alive).
+  scenario_setup_demo_workspace
+
+  run dev_cmd_open demo --no-attach
+  [ "$status" -eq 0 ]
+  run dev_tmux list-windows -t '=demo' -F '#{window_name}'
+  [ "$output" = "main" ]
+  run dev_tmux list-panes -t '=demo:=main' -F '#{?#{@dev_pane},#{@dev_pane},-}'
+  [ "$(printf '%s\n' "$output" | sort | tr '\n' ',')" = "agent-1,agent-2,scratch,shell," ]
+
+  record=$(cat "$DEV_STATE_ROOT"/workspaces/*.json)
+  [ "$(jq -r '[.agents[] | select(.window == "main")] | length' <<<"$record")" -eq 2 ]
+  [ "$(jq -r '[.agents[].pane] | sort | join(",")' <<<"$record")" = "agent-1,agent-2" ]
   dev_tmux kill-server || true
 }

--- a/tests/dev_commands.bats
+++ b/tests/dev_commands.bats
@@ -281,6 +281,7 @@ dev_open_load_libs() {
   source "$REPO_ROOT/tools/dev/commands/attach.sh"
   source "$REPO_ROOT/tools/dev/commands/stop.sh"
   source "$REPO_ROOT/tools/dev/commands/list.sh"
+  source "$REPO_ROOT/tools/dev/commands/status.sh"
 }
 
 dev_open_fixture() {
@@ -879,6 +880,23 @@ exit 0
   [ "$status" -eq 0 ]
   [[ "$output" != *"command not found"* ]]
   [ ! -e "$(dev_open_session_index_path demo)" ]
+
+  dev_tmux kill-server || true
+}
+
+@test "status reports undeclared windows and undeclared panes as drift" {
+  scenario_setup_demo_workspace
+
+  run dev_cmd_open demo --no-attach
+  [ "$status" -eq 0 ]
+
+  dev_tmux new-window -d -t '=demo:' -n rogue "sleep 30"
+  dev_tmux split-window -d -t '=demo:=shell' "sleep 30"
+
+  run dev_cmd_status demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"drift:"*"rogue"* ]]
+  [[ "$output" == *"drift:"*"shell"*"undeclared pane"* ]]
 
   dev_tmux kill-server || true
 }

--- a/tests/dev_commands.bats
+++ b/tests/dev_commands.bats
@@ -25,24 +25,10 @@ stage_dev_root() {
   # Pinned to the LEGACY four-window layout (not a cp of the shipped default):
   # these dispatcher-pattern scenarios exercise the single-pane window paths
   # and must keep doing so regardless of what the shipped default becomes.
-  cat >"$TEST_ROOT/root/tools/dev/default-workspace.yaml" <<'EOF'
-version: 1
-autostart: false
-devcontainer:
-  enabled: auto
-  start_timeout: 300
-windows:
-  - name: agent-1
-    agent: claude
-    focus: true
-  - name: agent-2
-    agent: claude
-  - name: shell
-    command: null
-  - name: scratch
-    command: null
-    location: host
-EOF
+  # The YAML comes from test_helper.bash's single fixture source; this staged
+  # root (which also carries copied platform code) is separate from the
+  # config-only root dev_pin_legacy_default_root builds.
+  dev_legacy_default_yaml >"$TEST_ROOT/root/tools/dev/default-workspace.yaml"
   export DEV_DOTFILES_ROOT="$TEST_ROOT/root"
 }
 

--- a/tests/dev_commands.bats
+++ b/tests/dev_commands.bats
@@ -312,7 +312,6 @@ dev_open_load_libs() {
 # as windows, not panes of one dashboard window) call dev_pin_legacy_default_root
 # (test_helper.bash) to pin that shape regardless of what the shipped default
 # becomes.
-dev_open_pin_legacy_default() { dev_pin_legacy_default_root; }
 
 dev_open_fixture() {
   local dir="$DEV_REPO_ROOT/$1"
@@ -336,7 +335,7 @@ dev_open_events() {
 @test "open creates the session with the four default windows and emits workspace.opened" {
   setup_dev_test
   dev_open_load_libs
-  dev_open_pin_legacy_default
+  dev_pin_legacy_default_root
   dev_open_stub_attach
   dev_open_fixture demo >/dev/null
 
@@ -365,7 +364,7 @@ dev_open_events() {
 @test "a second open creates nothing, re-runs nothing, and leaves scratch untouched" {
   setup_dev_test
   dev_open_load_libs
-  dev_open_pin_legacy_default
+  dev_pin_legacy_default_root
   dev_open_stub_attach
   dev_open_fixture demo >/dev/null
 
@@ -461,7 +460,7 @@ scenario_setup_demo_workspace() {
 
 @test "open after a container loss emits container.replaced then container.ready and respawns dead panes" {
   scenario_setup_demo_workspace
-  dev_open_pin_legacy_default
+  dev_pin_legacy_default_root
   local dir ws_id
   dir="$DEV_REPO_ROOT/demo"
   mkdir -p "$dir/.devcontainer"
@@ -540,7 +539,7 @@ esac
 
 @test "plain re-open respawns a dead pane in a host-only workspace (no container loss required)" {
   scenario_setup_demo_workspace
-  dev_open_pin_legacy_default
+  dev_pin_legacy_default_root
 
   run dev_cmd_open demo --no-attach
   [ "$status" -eq 0 ]
@@ -561,7 +560,7 @@ esac
 
 @test "re-open respawns one dead agent pane of two and leaves the other agent untouched" {
   scenario_setup_demo_workspace
-  dev_open_pin_legacy_default
+  dev_pin_legacy_default_root
   mkdir -p "$DEV_OVERLAY_ROOT/demo"
   cat >"$DEV_OVERLAY_ROOT/demo/workspace.yaml" <<'EOF'
 version: 1
@@ -921,7 +920,7 @@ exit 0
 
 @test "status reports undeclared windows and undeclared panes as drift" {
   scenario_setup_demo_workspace
-  dev_open_pin_legacy_default
+  dev_pin_legacy_default_root
 
   run dev_cmd_open demo --no-attach
   [ "$status" -eq 0 ]

--- a/tests/dev_commands.bats
+++ b/tests/dev_commands.bats
@@ -411,12 +411,25 @@ dev_open_events() {
   dev_tmux kill-server || true
 }
 
-@test "open after a container loss emits container.replaced then container.ready and respawns dead panes" {
+# The common bootstrap for "plain re-open respawns a dead pane" scenarios:
+# stage a demo fixture with sourced libs, a stubbed attach, and a long-lived
+# stand-in for the "claude" binary the default config's agent-1/agent-2
+# windows run (not on PATH here). As tests/dev_backend_tmux.bats:29-37
+# documents, a command that exits races dev_backend_apply_layout setting
+# remain-on-exit -- the window can vanish before the very next tmux call
+# touches it, so the stub must stay alive rather than just exit 0.
+scenario_setup_demo_workspace() {
   setup_dev_test
   dev_open_load_libs
   dev_open_stub_attach
+  dev_open_fixture demo >/dev/null
+  stub_command claude 'exec sleep 30'
+}
+
+@test "open after a container loss emits container.replaced then container.ready and respawns dead panes" {
+  scenario_setup_demo_workspace
   local dir ws_id
-  dir=$(dev_open_fixture demo)
+  dir="$DEV_REPO_ROOT/demo"
   mkdir -p "$dir/.devcontainer"
   printf '{"image":"alpine:3"}\n' >"$dir/.devcontainer/devcontainer.json"
 
@@ -446,13 +459,6 @@ case "$1" in
   *) exit 0 ;;
 esac
 '
-  # The default config's agent windows run the real "claude" binary, which is
-  # not on PATH here. As tests/dev_backend_tmux.bats:29-37 documents, a command
-  # that exits races dev_backend_apply_layout setting remain-on-exit -- the
-  # window can vanish before the very next tmux call touches it. Stubbed as a
-  # long-lived placeholder so agent panes survive both this test's own setup
-  # (which calls apply_layout directly) and the `dev_cmd_open` under test.
-  stub_command claude 'exec sleep 30'
 
   # Seed a record bound to a container that no longer exists.
   local session record
@@ -495,6 +501,66 @@ esac
   [ "$(dev_open_events 'select(.event == "pane.respawned") | .id' | wc -l)" = "1" ]
   [ "$(dev_open_events 'select(.event == "pane.respawned") | .data.container_id')" = "newcid" ]
   [ "$(dev_tmux list-panes -t '=demo:=shell' -F '#{pane_dead}')" = "0" ]
+  dev_tmux kill-server || true
+}
+
+@test "plain re-open respawns a dead pane in a host-only workspace (no container loss required)" {
+  scenario_setup_demo_workspace
+
+  run dev_cmd_open demo --no-attach
+  [ "$status" -eq 0 ]
+
+  dev_tmux respawn-pane -k -t '=demo:=shell' 'exit 3'
+  local i
+  for i in $(seq 1 50); do
+    [ "$(dev_tmux list-panes -t '=demo:=shell' -F '#{pane_dead}')" = "1" ] && break
+    sleep 0.1
+  done
+
+  run dev_cmd_open demo --no-attach
+  [ "$status" -eq 0 ]
+  [ "$(dev_tmux list-panes -t '=demo:=shell' -F '#{pane_dead}')" = "0" ]
+  grep -q '"event":"pane.respawned"' "$DEV_STATE_ROOT/events/events.jsonl"
+  dev_tmux kill-server || true
+}
+
+@test "re-open respawns one dead agent pane of two and leaves the other agent untouched" {
+  scenario_setup_demo_workspace
+  mkdir -p "$DEV_OVERLAY_ROOT/demo"
+  cat >"$DEV_OVERLAY_ROOT/demo/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: dash
+    layout: tiled
+    panes:
+      - name: agent-1
+        agent: sleep 30
+      - name: agent-2
+        agent: sleep 30
+EOF
+  run dev_cmd_open demo --no-attach
+  [ "$status" -eq 0 ]
+
+  local victim
+  victim=$(dev_tmux list-panes -t '=demo:=dash' -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' |
+    awk '$2 == "agent-2" {print $1; exit}')
+  dev_tmux respawn-pane -k -t "$victim" 'exit 1'
+  local i
+  for i in $(seq 1 50); do
+    [ "$(dev_tmux display-message -p -t "$victim" '#{pane_dead}')" = "1" ] && break
+    sleep 0.1
+  done
+
+  run dev_cmd_open demo --no-attach
+  [ "$status" -eq 0 ]
+  [ "$(dev_tmux display-message -p -t "$victim" '#{pane_dead}')" = "0" ]
+
+  local record
+  record=$(cat "$DEV_STATE_ROOT"/workspaces/*.json)
+  [ "$(jq -r '.agents[] | select(.pane == "agent-2") | .state' <<<"$record")" = "started" ]
+  # agent-1 never died: exactly one lifecycle event for it, the start
+  [ "$(jq -r '.agents[] | select(.pane == "agent-1") | .state' <<<"$record")" = "started" ]
+  [ "$(grep -c '"pane":"agent-1"' "$DEV_STATE_ROOT/events/events.jsonl")" -eq 2 ] # pane.created + agent.started only
   dev_tmux kill-server || true
 }
 

--- a/tests/dev_config_merge.bats
+++ b/tests/dev_config_merge.bats
@@ -473,6 +473,9 @@ EOF
   # pass; a pane literally named "-" would read back as pane:null.
   run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"-","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
   [ "$status" -eq 5 ]
+  # only the exact placeholder is reserved: "--" cannot collide and stays valid
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"--","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 0 ]
   # exclusive schema: window-level environment is a single-pane key (spec §5)
   run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"environment":{"A":"1"},"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
   [ "$status" -eq 5 ]

--- a/tests/dev_config_merge.bats
+++ b/tests/dev_config_merge.bats
@@ -469,6 +469,10 @@ EOF
   [ "$status" -eq 5 ]
   run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"bad name","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
   [ "$status" -eq 5 ]
+  # "-" is the unstamped-pane placeholder in dev_backend_query and the focus
+  # pass; a pane literally named "-" would read back as pane:null.
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"-","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
   # exclusive schema: window-level environment is a single-pane key (spec §5)
   run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"environment":{"A":"1"},"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
   [ "$status" -eq 5 ]

--- a/tests/dev_config_merge.bats
+++ b/tests/dev_config_merge.bats
@@ -268,7 +268,10 @@ windows:
   - name: docs
     command: two
 YAML
-  run dev_config_validate "$(dev_config_merged slabledger "$WORKTREE")"
+  # Caught by dev_config_merged's per-layer duplicate check now, not by
+  # post-merge validation: a layer that duplicates a name the merge would
+  # otherwise silently collapse must fail before that collapse happens.
+  run dev_config_merged slabledger "$WORKTREE"
   [ "$status" -eq 5 ]
   [[ "$output" == *"docs"* ]]
   [[ "$output" == *"more than once"* ]]
@@ -294,4 +297,173 @@ YAML
   run dev_config_validate "$(dev_config_merged slabledger "$WORKTREE")"
   [ "$status" -eq 5 ]
   [[ "$output" == *"version must be 1"* ]]
+}
+
+@test "config: panes-less window normalizes without panes/layout/environment keys (digest stability)" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: solo
+    command: null
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "solo")' <<<"$output")
+  [ "$(jq 'has("panes")' <<<"$win")" = "false" ]
+  [ "$(jq 'has("layout")' <<<"$win")" = "false" ]
+  [ "$(jq 'has("environment")' <<<"$win")" = "false" ]
+}
+
+@test "config: panes normalize with per-pane defaults; window environment survives on single-pane windows" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: main
+    layout: tiled
+    panes:
+      - name: agent-1
+        agent: claude
+        focus: true
+      - name: shell
+        command: null
+        environment: {PANE: "2"}
+  - name: solo
+    command: null
+    environment: {WIN: "1"}
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.layout' <<<"$win")" = "tiled" ]
+  [ "$(jq -c '.panes[0]' <<<"$win")" = '{"agent":"claude","command":null,"cwd":null,"focus":true,"location":null,"name":"agent-1"}' ]
+  [ "$(jq -r '.panes[1].environment.PANE' <<<"$win")" = "2" ]
+  # the spec §7.1 fix: window-level environment is kept for single-pane windows
+  [ "$(jq -r '.windows[] | select(.name == "solo") | .environment.WIN' <<<"$output")" = "1" ]
+}
+
+@test "config: a layer defining an inherited pane twice fails loudly, never silently collapses" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: main
+    panes:
+      - name: shell
+        command: null
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: main
+    panes:
+      - name: shell
+        cwd: a
+      - name: shell
+        cwd: b
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 5 ]
+  [[ "$output" == *"shell"* ]] # bats `run` folds stderr into $output
+}
+
+@test "config: panes merge by name across layers, never by index" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: main
+    panes:
+      - name: agent-1
+        agent: claude
+      - name: shell
+        command: null
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: main
+    panes:
+      - name: shell
+        cwd: sub
+      - name: extra
+        command: htop
+EOF
+  run dev_config_merged "proj" "$TEST_ROOT/workspace/proj"
+  [ "$status" -eq 0 ]
+  win=$(jq -c '.windows[] | select(.name == "main")' <<<"$output")
+  [ "$(jq -r '.panes | length' <<<"$win")" -eq 3 ]
+  [ "$(jq -r '.panes[] | select(.name == "shell") | .cwd' <<<"$win")" = "sub" ]
+  [ "$(jq -r '.panes[] | select(.name == "agent-1") | .agent' <<<"$win")" = "claude" ]
+  [ "$(jq -r '.panes[] | select(.name == "extra") | .command' <<<"$win")" = "htop" ]
+}
+
+@test "config: converting an agent window to panes without nulling agent fails loudly" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: agent-1
+    agent: claude
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: agent-1
+    panes:
+      - name: a
+        agent: claude
+EOF
+  config=$(dev_config_merged "proj" "$TEST_ROOT/workspace/proj")
+  run dev_config_validate "$config"
+  [ "$status" -eq 5 ]
+  [[ "$output" == *"agent-1"* && "$output" == *"panes"* ]]
+}
+
+@test "config: agent: null alongside panes converts cleanly; a shell window converts silently" {
+  mkdir -p "$DEV_OVERLAY_ROOT/proj"
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.yaml" <<'EOF'
+version: 1
+windows:
+  - name: agent-1
+    agent: claude
+  - name: shell
+    command: null
+EOF
+  cat >"$DEV_OVERLAY_ROOT/proj/workspace.local.yaml" <<'EOF'
+windows:
+  - name: agent-1
+    agent: null
+    panes:
+      - name: a
+        agent: claude
+  - name: shell
+    panes:
+      - name: s
+        command: null
+EOF
+  config=$(dev_config_merged "proj" "$TEST_ROOT/workspace/proj")
+  run dev_config_validate "$config"
+  [ "$status" -eq 0 ]
+}
+
+@test "config: multi-pane validation failures are loud and name the offender" {
+  bad() {
+    jq -nc --argjson w "$1" '{version: 1, windows: [$w]}'
+  }
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"layout":"tiled"}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"layout":"mosaic","panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"a","agent":"x","command":"y","cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false},{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":true},{"name":"b","agent":null,"command":null,"cwd":null,"location":null,"focus":true}]}')"
+  [ "$status" -eq 5 ]
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"panes":[{"name":"bad name","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
+  # exclusive schema: window-level environment is a single-pane key (spec §5)
+  run dev_config_validate "$(bad '{"name":"m","agent":null,"command":null,"cwd":null,"location":null,"focus":false,"environment":{"A":"1"},"panes":[{"name":"a","agent":null,"command":null,"cwd":null,"location":null,"focus":false}]}')"
+  [ "$status" -eq 5 ]
 }

--- a/tests/dev_config_merge.bats
+++ b/tests/dev_config_merge.bats
@@ -4,6 +4,12 @@ load test_helper
 
 setup() {
   setup_dev_test
+  # This file tests merge mechanics against the default layer as ambient
+  # fixture data (window/pane counts, field-by-field precedence), not the
+  # shape of the real shipped default -- pin it so these keep exercising the
+  # single-pane window baseline regardless of what tools/dev/default-
+  # workspace.yaml ships as (see test_helper.bash).
+  dev_pin_legacy_default_root
   source "$REPO_ROOT/tools/dev/lib/config.sh"
   WORKTREE="$DEV_REPO_ROOT/slabledger"
   mkdir -p "$WORKTREE" "$DEV_OVERLAY_ROOT/slabledger"

--- a/tests/dev_fold.bats
+++ b/tests/dev_fold.bats
@@ -174,7 +174,7 @@ mkevent() {
   rec=$(jq -c '.status = "running"' <<<"$REC")
   out=$(dev_fold_apply "$rec" "$(mkevent aaaa00000000000c 2026-08-03T14:07:00.000Z agent.started '{"window":"agent-1","command":"claude"}')")
   out=$(dev_fold_apply "$out" "$(mkevent aaaa00000000000d 2026-08-03T14:07:01.000Z agent.started '{"window":"agent-2","command":"claude"}')")
-  [ "$(jq -c .agents <<<"$out")" = '[{"window":"agent-1","command":"claude","state":"started"},{"window":"agent-2","command":"claude","state":"started"}]' ]
+  [ "$(jq -c .agents <<<"$out")" = '[{"window":"agent-1","pane":null,"command":"claude","state":"started"},{"window":"agent-2","pane":null,"command":"claude","state":"started"}]' ]
 
   out=$(dev_fold_apply "$out" "$(mkevent aaaa00000000000e 2026-08-03T14:08:00.000Z agent.exited '{"window":"agent-2","exit_status":0}')")
   [ "$(jq -r '.agents[] | select(.window == "agent-2") | .state' <<<"$out")" = exited ]
@@ -313,4 +313,33 @@ mkevent() {
   local out
   out=$(dev_fold_stream "$REC" </dev/null)
   [ "$(jq -S -c . <<<"$out")" = "$(jq -S -c . <<<"$REC")" ]
+}
+
+@test "fold: pane-qualified events route to the matching agent only" {
+  local rec out
+  rec=$(jq -c '.status = "running"' <<<"$REC")
+  out=$(dev_fold_apply "$rec" "$(mkevent aaaa000000000023 2026-08-03T15:00:00.000Z agent.started '{"window":"main","pane":"agent-1","command":"claude"}')")
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000024 2026-08-03T15:01:00.000Z agent.started '{"window":"main","pane":"agent-2","command":"claude"}')")
+  [ "$(jq -r '.agents | length' <<<"$out")" -eq 2 ]
+  # the helper shell dying in the same window must not touch either agent
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000025 2026-08-03T15:02:00.000Z pane.died '{"window":"main","pane":"shell"}')")
+  [ "$(jq -r '[.agents[].state] | unique | join(",")' <<<"$out")" = "started" ]
+  # the right agent pane dying flips only that agent
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000026 2026-08-03T15:03:00.000Z pane.died '{"window":"main","pane":"agent-2"}')")
+  [ "$(jq -r '.agents[] | select(.pane == "agent-2") | .state' <<<"$out")" = "exited" ]
+  [ "$(jq -r '.agents[] | select(.pane == "agent-1") | .state' <<<"$out")" = "started" ]
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000027 2026-08-03T15:04:00.000Z pane.respawned '{"window":"main","pane":"agent-2"}')")
+  [ "$(jq -r '.agents[] | select(.pane == "agent-2") | .state' <<<"$out")" = "started" ]
+  # agent.exited and agent.failed route by pane too
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa000000000028 2026-08-03T15:05:00.000Z agent.failed '{"window":"main","pane":"agent-1","reason":"crash"}')")
+  [ "$(jq -r '.agents[] | select(.pane == "agent-1") | .state' <<<"$out")" = "failed" ]
+}
+
+@test "fold: legacy pane-less events still key by window with pane null" {
+  local rec out
+  rec=$(jq -c '.status = "running"' <<<"$REC")
+  out=$(dev_fold_apply "$rec" "$(mkevent aaaa000000000029 2026-08-03T15:10:00.000Z agent.started '{"window":"agent-1","command":"claude"}')")
+  [ "$(jq -c '.agents[0] | {window, pane, state}' <<<"$out")" = '{"window":"agent-1","pane":null,"state":"started"}' ]
+  out=$(dev_fold_apply "$out" "$(mkevent aaaa00000000002a 2026-08-03T15:11:00.000Z pane.died '{"window":"agent-1","exit_status":1}')")
+  [ "$(jq -r '.agents[0].state' <<<"$out")" = "exited" ]
 }

--- a/tests/dev_install.bats
+++ b/tests/dev_install.bats
@@ -234,6 +234,74 @@ dev_wait_for_event() {
   dev_tmux kill-server || true
 }
 
+# Bootstraps a real tmux server with a holder session (so killing/respawning
+# panes in `proj` never tears the server down before a backgrounded run-shell
+# completes) and a `proj` session stamped with the envelope user options that
+# every hook reads. Callers still source-file dev.tmux.conf themselves, same
+# as the neighboring hook tests above.
+setup_hook_session() {
+  setup_dev_test
+  dev_hook_env
+  source "$REPO_ROOT/tools/dev/lib/backend-tmux.sh"
+
+  dev_tmux new-session -d -s holder
+  dev_tmux new-session -d -s proj
+  dev_tmux set-option -t '=proj:' @dev_workspace_id wsid10
+  dev_tmux set-option -t '=proj:' @dev_slug proj
+  dev_tmux set-option -t '=proj:' @dev_worktree /home/t/proj
+}
+
+@test "pane-died hook reports the dying pane's @dev_pane and omits it when unstamped" {
+  setup_hook_session
+  dev_tmux source-file "$REPO_ROOT/tools/dev/dev.tmux.conf"
+
+  # window w1: one stamped pane, one unstamped
+  dev_tmux new-window -d -t "=proj:" -n w1 "sleep 30" \
+    ';' set-window-option -t "=proj:=w1" remain-on-exit on
+  pid=$(dev_tmux split-window -d -P -F '#{pane_id}' -t "=proj:=w1" "sleep 30")
+  dev_tmux set-option -p -t "$pid" @dev_pane helper
+
+  dev_tmux respawn-pane -k -t "$pid" 'exit 1'
+  for _ in $(seq 1 50); do
+    grep -q '"pane":"helper"' "$DEV_STATE_ROOT/events/events.jsonl" 2>/dev/null && break
+    sleep 0.1
+  done
+  line=$(grep '"pane":"helper"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.event' <<<"$line")" = "pane.died" ]
+  [ "$(jq -r '.data.window' <<<"$line")" = "w1" ]
+
+  # the unstamped pane dies -> event has window only, no pane key
+  upid=$(dev_tmux list-panes -t "=proj:=w1" -F '#{pane_id} #{?#{@dev_pane},s,-}' | awk '$2 == "-" {print $1; exit}')
+  dev_tmux respawn-pane -k -t "$upid" 'exit 1'
+  for _ in $(seq 1 50); do
+    n=$(grep -c '"event":"pane.died"' "$DEV_STATE_ROOT/events/events.jsonl" 2>/dev/null || echo 0)
+    [ "$n" -ge 2 ] && break
+    sleep 0.1
+  done
+  line=$(grep '"event":"pane.died"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.data | has("pane")' <<<"$line")" = "false" ]
+  dev_tmux kill-server || true
+}
+
+@test "pane-died from a fast-exiting split still carries the pane name (atomic stamp)" {
+  setup_hook_session
+  dev_tmux source-file "$REPO_ROOT/tools/dev/dev.tmux.conf"
+  dev_tmux new-window -d -t "=proj:" -n w2 "sleep 30" \
+    ';' set-window-option -t "=proj:=w2" remain-on-exit on
+  # the command exits immediately: if the stamp were a second invocation, the
+  # hook could fire first and emit an identity-less pane.died (spec §2)
+  dev_tmux split-window -t "=proj:=w2" 'exit 1' \
+    ';' set-option -p -t "=proj:=w2" @dev_pane fast
+  for _ in $(seq 1 50); do
+    grep -q '"pane":"fast"' "$DEV_STATE_ROOT/events/events.jsonl" 2>/dev/null && break
+    sleep 0.1
+  done
+  line=$(grep '"pane":"fast"' "$DEV_STATE_ROOT/events/events.jsonl" | tail -n 1)
+  [ "$(jq -r '.event' <<<"$line")" = "pane.died" ]
+  [ "$(jq -r '.data.window' <<<"$line")" = "w2" ]
+  dev_tmux kill-server || true
+}
+
 @test "tmux.conf.symlink sources dev.tmux.conf between idempotency markers" {
   setup_dotfiles_test
   run grep -c '# dev-workspace-config-start' "$REPO_ROOT/tools/tmux/tmux.conf.symlink"

--- a/tests/dev_state_events.bats
+++ b/tests/dev_state_events.bats
@@ -507,6 +507,28 @@ fill_events() {
   done
 }
 
+@test "dev-event: an empty pane= pair is skipped; a non-empty one is recorded" {
+  run "$REPO_ROOT/tools/dev/dev-event" ws1 proj sess "$TEST_ROOT/workspace/proj" \
+    pane.died 'window=agent-1' 'pane='
+  [ "$status" -eq 0 ]
+  line=$(tail -n 1 "$DEV_STATE_ROOT/events/events.jsonl")
+  [ "$(jq -r '.data | has("pane")' <<<"$line")" = "false" ]
+  [ "$(jq -r '.data.window' <<<"$line")" = "agent-1" ]
+
+  run "$REPO_ROOT/tools/dev/dev-event" ws1 proj sess "$TEST_ROOT/workspace/proj" \
+    pane.died 'window=main' 'pane=shell'
+  [ "$status" -eq 0 ]
+  line=$(tail -n 1 "$DEV_STATE_ROOT/events/events.jsonl")
+  [ "$(jq -r '.data.pane' <<<"$line")" = "shell" ]
+
+  # other keys keep record-everything behavior, empty or not
+  run "$REPO_ROOT/tools/dev/dev-event" ws1 proj sess "$TEST_ROOT/workspace/proj" \
+    workspace.attached 'client='
+  [ "$status" -eq 0 ]
+  line=$(tail -n 1 "$DEV_STATE_ROOT/events/events.jsonl")
+  [ "$(jq -r '.data.client' <<<"$line")" = "" ]
+}
+
 @test "state: dev_state_commit rejecting a bad new_json creates no temp files" {
   local rec path dir before_count after_count
   rec=$(dev_state_new "$WS_ID" slabledger slabledger /w)

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -35,12 +35,12 @@ assert_symlink_target() {
 # config/mise/config.toml still resolve. Tests that need the single-pane
 # window shape as a stable fixture (merge mechanics, single-window scenarios)
 # call this; tests proving what the real shipped default does must not.
-dev_pin_legacy_default_root() {
-  local root="$TEST_ROOT/legacy-dotfiles-root"
-  if [ ! -e "$root" ]; then
-    mkdir -p "$root/tools/dev"
-    ln -s "$REPO_ROOT/config" "$root/config"
-    cat >"$root/tools/dev/default-workspace.yaml" <<'EOF'
+# dev_legacy_default_yaml — prints the legacy layout. The single source for
+# every fixture that pins it (this file's root builder, and stage_dev_root in
+# dev_commands.bats, whose staged root also carries copied platform code and
+# so cannot reuse the root this file builds).
+dev_legacy_default_yaml() {
+  cat <<'EOF'
 version: 1
 autostart: false
 devcontainer:
@@ -58,6 +58,14 @@ windows:
     command: null
     location: host
 EOF
+}
+
+dev_pin_legacy_default_root() {
+  local root="$TEST_ROOT/legacy-dotfiles-root"
+  if [ ! -e "$root" ]; then
+    mkdir -p "$root/tools/dev"
+    ln -s "$REPO_ROOT/config" "$root/config"
+    dev_legacy_default_yaml >"$root/tools/dev/default-workspace.yaml"
   fi
   export DEV_DOTFILES_ROOT="$root"
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -27,6 +27,41 @@ assert_symlink_target() {
   [ "$(readlink "$1")" = "$2" ]
 }
 
+# dev_pin_legacy_default_root — points DEV_DOTFILES_ROOT at a fixture root
+# whose tools/dev/default-workspace.yaml is the pre-dashboard legacy layout
+# (four top-level windows: agent-1, agent-2, shell, scratch), regardless of
+# what the real shipped tools/dev/default-workspace.yaml becomes. config/ is
+# symlinked to the real repo so lookups like the devcontainer-CLI pin in
+# config/mise/config.toml still resolve. Tests that need the single-pane
+# window shape as a stable fixture (merge mechanics, single-window scenarios)
+# call this; tests proving what the real shipped default does must not.
+dev_pin_legacy_default_root() {
+  local root="$TEST_ROOT/legacy-dotfiles-root"
+  if [ ! -e "$root" ]; then
+    mkdir -p "$root/tools/dev"
+    ln -s "$REPO_ROOT/config" "$root/config"
+    cat >"$root/tools/dev/default-workspace.yaml" <<'EOF'
+version: 1
+autostart: false
+devcontainer:
+  enabled: auto
+  start_timeout: 300
+windows:
+  - name: agent-1
+    agent: claude
+    focus: true
+  - name: agent-2
+    agent: claude
+  - name: shell
+    command: null
+  - name: scratch
+    command: null
+    location: host
+EOF
+  fi
+  export DEV_DOTFILES_ROOT="$root"
+}
+
 setup_dev_test() {
   setup_dotfiles_test
   # yq lives in /usr/local/bin, which setup_dotfiles_test drops from PATH.

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -46,22 +46,62 @@ devcontainer:
   enabled: auto           # auto | true | false; auto = presence of .devcontainer/
   start_timeout: 300      # seconds for devcontainer up
 windows:
-  - name: agent-1
-    agent: claude         # a window sets agent: OR command:, never both
-    focus: true           # at most one focused window
-  - name: agent-2
-    agent: claude
-  - name: shell
-    command: null         # null command = interactive shell
-  - name: scratch
-    command: null
-    location: host        # host | container; unset = container when one exists
+  - name: main
+    focus: true            # at most one focused window
+    layout: tiled          # tmux layout name applied across the window's panes
+    panes:
+      - name: agent-1
+        agent: claude       # a pane sets agent: OR command:, never both
+        focus: true         # at most one focused pane per window
+      - name: agent-2
+        agent: claude
+      - name: shell
+        command: null       # null command = interactive shell
+      - name: scratch
+        command: null
+        location: host      # host | container; unset = container when one exists
 ```
 
-Windows also accept `cwd` (relative to the worktree) and `environment`
-(a string map, injected into the pane's process). Environment values are never
-written to the event log, so `workspace.local.yaml` is the place for tokens —
-it stays on the machine and out of git.
+This is the shipped default: one tiled window with four panes. A window sets
+`agent:` OR `command:` OR `panes:` — never more than one. The single-pane form
+(a window with `agent:`/`command:` directly, no `panes:` list) is still fully
+supported and is what an overlay typically adds for an extra top-level window.
+
+Panes accept the same fields as single-pane windows — `agent`, `command`,
+`cwd`, `environment`, `location` — plus a required, window-unique `name` and
+an optional `focus`. `layout:` takes any of tmux's five built-in layout names
+(`even-horizontal`, `even-vertical`, `main-horizontal`, `main-vertical`,
+`tiled`); unset defaults to `main-vertical`.
+
+An overlay that adds `panes:` to a window it inherits from a lower layer
+(e.g. adding a second pane to the default's `main` window) must also null out
+that window's single-pane fields — `agent: null` (or `command: null`) — since
+`agent`/`command` and `panes` are mutually exclusive and the merge is by
+field, not by form. This is the strict conversion idiom: without it, the
+merged window carries both an `agent`/`command` and a `panes:` list and fails
+validation.
+
+**Migrating a running workspace:** the shipped default changed from four
+top-level windows (`agent-1`, `agent-2`, `shell`, `scratch`) to one `main`
+window with those as panes. A workspace opened under the old default keeps
+running unchanged — `dev` never destroys — but the next `dev` on it creates
+the new `main` window *beside* the old windows, and `dev status` reports the
+old windows as drift (undeclared, since they're no longer in the merged
+config). `dev stop <name>` followed by `dev <name>` converts cleanly to the
+new layout. Overlays that patched the old default's window names directly
+(`agent-1`, `agent-2`, `shell`, `scratch` as window-level entries) need
+updating to target `main`'s panes instead.
+
+Re-running `dev` also respawns dead panes on every open now — previously this
+only happened after a container replacement; a pane that simply exited or was
+killed is now caught by the very next `dev`, no container loss required.
+
+Windows and panes both accept `cwd` (relative to the worktree) and
+`environment` (a string map, injected into the process). Window-level
+`environment` now actually applies to the window's process — it was
+previously parsed but silently dropped. Environment values are never written
+to the event log, so `workspace.local.yaml` is the place for tokens — it
+stays on the machine and out of git.
 
 `autostart: true` is honored by the `dev-autostart` unit at boot for the
 project's **primary** worktree only, and only after the workspace has been

--- a/tools/dev/commands/open.sh
+++ b/tools/dev/commands/open.sh
@@ -128,25 +128,44 @@ dev_open_container_up() {
                    observed_at: $ts}' <<<"$record"
 }
 
-# Only panes the backend reports dead are touched. A live pane is never respawned.
+# Only panes the backend reports dead are touched; a live pane is never
+# respawned, so running this on every open is idempotent (spec §4 removed the
+# old container-loss gate). Undeclared panes -- unstamped, or stamped with a
+# name the config no longer declares -- are skipped: they are drift for
+# `dev status` to report, not ours to touch. A single-pane window with extra
+# manual panes is skipped for the same reason: the window target cannot say
+# which pane is the declared one.
 dev_open_respawn_dead() {
   local config="$1" record="$2"
-  local query dead cid win wjson cmd env_json
+  local query cid global_env win pname handle total wjson pjson env cmd
   query=$(dev_backend_query "$DEV_OPEN_SESSION")
-  dead=$(jq -r '.windows[] | select([.panes[].alive] | index(false)) | .name' <<<"$query")
-  [[ -n "$dead" ]] || return 0
   cid=$(jq -r '.container.id // ""' <<<"$record")
-  env_json=$(jq -c '.environment // {}' <<<"$config")
-  while IFS= read -r win; do
+  global_env=$(jq -c '.environment // {}' <<<"$config")
+  while IFS=$'\t' read -r win pname handle total; do
     [[ -n "$win" ]] || continue
-    wjson=$(jq -c --arg w "$win" '.windows[] | select(.name == $w)' <<<"$config")
+    wjson=$(jq -c --arg w "$win" 'first(.windows[] | select(.name == $w)) // empty' <<<"$config")
     [[ -n "$wjson" ]] || continue
-    cmd=$(dev_open_window_command "$record" "$wjson" "$env_json") || continue
-    # `dev_backend_respawn_pane` is the sole emitter of pane.respawned (Task 12),
-    # so the container id is handed to it rather than emitted again here. Two
-    # events for one respawn would fold twice and double the `restarts` counter.
-    dev_backend_respawn_pane "$DEV_OPEN_SESSION" "$win" "$cmd" "$cid" || continue
-  done <<<"$dead"
+    if [[ "$(jq -r '.panes != null' <<<"$wjson")" == true ]]; then
+      [[ "$pname" != "-" ]] || continue
+      pjson=$(jq -c --arg p "$pname" 'first(.panes[] | select(.name == $p)) // empty' <<<"$wjson")
+      [[ -n "$pjson" ]] || continue
+      env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$wjson")
+      env=$(jq -c --argjson w "$env" '$w * (.environment // {})' <<<"$pjson")
+      cmd=$(dev_open_window_command "$record" "$pjson" "$env") || continue
+      # `dev_backend_respawn_pane` is the sole emitter of pane.respawned
+      # (Task 12), so the container id is handed to it rather than emitted
+      # again here. Two events for one respawn would fold twice and double
+      # the `restarts` counter.
+      dev_backend_respawn_pane "$DEV_OPEN_SESSION" "$win" "$cmd" "$cid" "$handle" "$pname" || continue
+    else
+      [[ "$total" -eq 1 ]] || continue
+      env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$wjson")
+      cmd=$(dev_open_window_command "$record" "$wjson" "$env") || continue
+      dev_backend_respawn_pane "$DEV_OPEN_SESSION" "$win" "$cmd" "$cid" "$handle" || continue
+    fi
+  done < <(jq -r '.windows[] | .name as $w | (.panes | length) as $n
+    | .panes[] | select(.alive | not)
+    | [$w, (.pane // "-"), .pane_id, ($n | tostring)] | @tsv' <<<"$query")
 }
 
 dev_open_ensure_locked() {
@@ -185,9 +204,7 @@ dev_open_ensure_locked() {
   record=$(jq --arg n "$DEV_OPEN_SESSION" '.session_name = $n' <<<"$record")
   dev_backend_apply_layout "$DEV_OPEN_SESSION" "$config" "$record" || return $?
 
-  if [[ "$repair" -eq 1 && "$created" -eq 0 ]]; then
-    dev_open_respawn_dead "$config" "$record"
-  fi
+  dev_open_respawn_dead "$config" "$record"
 
   if [[ "$created" -eq 1 ]]; then
     dev_open_emit workspace.opened \

--- a/tools/dev/commands/status.sh
+++ b/tools/dev/commands/status.sh
@@ -49,9 +49,30 @@ dev_cmd_status() {
     "$(printf '%s' "$record" | jq -r '.container.status // "none"')"
 
   printf '%s' "$query" | jq -r '.windows[]? |
-    "  window \(.name): " + ([.panes[] | if .alive then "alive" else "dead" end] | join(", "))'
+    "  window \(.name): " + ([.panes[]
+      | (if .pane == null then "" else "\(.pane) " end)
+        + (if .alive then "alive" else "dead" end)] | join(", "))'
   printf '%s' "$record" | jq -r '.agents[]? |
-    "  agent \(.window): \(.state) (\(.command // "?"))"'
+    "  agent \(.window)\(if (.pane // null) != null then "/" + .pane else "" end): \(.state) (\(.command // "?"))"'
+
+  # Drift: running windows/panes the merged configuration does not declare.
+  # Reported, never repaired — open never destroys, and status never repairs.
+  printf '%s' "$query" | jq -r --argjson cfg "$(printf '%s' "$config" | jq -c '.windows // []')" '
+    ([$cfg[].name]) as $wnames
+    | .windows[]?
+    | . as $w
+    | if ($w.name | IN($wnames[])) | not then
+        "  drift:      window \($w.name) is running but not declared"
+      else
+        (first($cfg[] | select(.name == $w.name))) as $decl
+        | (if ($decl.panes // null) != null then
+             [$w.panes[] | select(.pane == null or ((.pane | IN($decl.panes[].name)) | not))]
+           elif ($w.panes | length) > 1 then $w.panes[1:]
+           else [] end) as $extra
+        | if ($extra | length) > 0 then
+            "  drift:      window \($w.name) has \($extra | length) undeclared pane(s) (\([$extra[] | .pane // "unnamed"] | join(", ")))"
+          else empty end
+      end'
 
   local current applied
   current=$(printf '%s' "$record" | jq -r '.config_digest // "none"')

--- a/tools/dev/commands/status.sh
+++ b/tools/dev/commands/status.sh
@@ -67,6 +67,9 @@ dev_cmd_status() {
         (first($cfg[] | select(.name == $w.name))) as $decl
         | (if ($decl.panes // null) != null then
              [$w.panes[] | select(.pane == null or ((.pane | IN($decl.panes[].name)) | not))]
+           # Single-pane window: assumes the declared pane is index 0, which a
+           # manual `split-window -b` or a swap-pane can violate; report-only,
+           # so a false positive here never causes repair action.
            elif ($w.panes | length) > 1 then $w.panes[1:]
            else [] end) as $extra
         | if ($extra | length) > 0 then

--- a/tools/dev/default-workspace.yaml
+++ b/tools/dev/default-workspace.yaml
@@ -4,13 +4,17 @@ devcontainer:
   enabled: auto
   start_timeout: 300
 windows:
-  - name: agent-1
-    agent: claude
+  - name: main
     focus: true
-  - name: agent-2
-    agent: claude
-  - name: shell
-    command: null
-  - name: scratch
-    command: null
-    location: host
+    layout: tiled
+    panes:
+      - name: agent-1
+        agent: claude
+        focus: true
+      - name: agent-2
+        agent: claude
+      - name: shell
+        command: null
+      - name: scratch
+        command: null
+        location: host

--- a/tools/dev/dev-event
+++ b/tools/dev/dev-event
@@ -29,6 +29,14 @@ dev_event_data_from_pairs() {
     # Longest-prefix removal on the key, shortest on the value: `a=b=c` is the
     # key `a` with the value `b=c`, not a truncated `b`.
     value="${pair#*=}"
+    # `pane=` with an empty value is skipped -- and ONLY pane. The pane-died
+    # hook interpolates #{@dev_pane} unconditionally, and single-pane windows
+    # are never stamped, so this is what keeps their pane.died bytes identical
+    # to the pre-panes era (spec §3). Every other key keeps record-everything
+    # behavior: an empty client or exit_status is an observation, not noise.
+    if [[ "$key" == pane && -z "$value" ]]; then
+      continue
+    fi
     out=$(jq -c --arg k "$key" --arg v "$value" '. + {($k): $v}' <<<"$out")
   done
   printf '%s\n' "$out"

--- a/tools/dev/dev.tmux.conf
+++ b/tools/dev/dev.tmux.conf
@@ -36,4 +36,4 @@ set-hook -g client-detached "run-shell -b \"~/.dotfiles/tools/dev/dev-event '#{@
 # pane-died is WINDOW-scoped: registered with -gw, absent from `show-hooks -g`,
 # visible only under `show-hooks -gw`. It fires on process exit under
 # remain-on-exit and does NOT fire for kill-pane.
-set-hook -gw pane-died "run-shell -b \"~/.dotfiles/tools/dev/dev-event '#{@dev_workspace_id}' '#{@dev_slug}' '#{session_name}' '#{@dev_worktree}' pane.died 'window=#{window_name}'\""
+set-hook -gw pane-died "run-shell -b \"~/.dotfiles/tools/dev/dev-event '#{@dev_workspace_id}' '#{@dev_slug}' '#{session_name}' '#{@dev_worktree}' pane.died 'window=#{window_name}' 'pane=#{@dev_pane}'\""

--- a/tools/dev/lib/backend-tmux.sh
+++ b/tools/dev/lib/backend-tmux.sh
@@ -157,10 +157,14 @@ dev_backend_apply_layout() {
 # does not — it silently resolves `=name` to `name-longer` and returns exit 0,
 # which is exactly the cross-workspace misattachment ADR-7 exists to prevent.
 # That asymmetry between tmux's own commands is the whole reason this hid.
+#
+# `pane_id` is an opaque, ephemeral backend handle for targeting a live pane
+# (respawn, select); it is never written to events or records — logical
+# identity is `pane`.
 dev_backend_query() {
   local session_name="$1" panes worktree clients
   if ! panes=$(dev_tmux list-panes -s -t "=$session_name:" \
-    -F '#{pane_dead} #{window_index} #{window_name}' 2>/dev/null); then
+    -F '#{pane_dead} #{window_index} #{pane_id} #{?#{@dev_pane},#{@dev_pane},-} #{window_name}' 2>/dev/null); then
     printf '{"exists":false,"worktree":null,"clients":0,"windows":[]}\n'
     return 0
   fi
@@ -173,9 +177,12 @@ dev_backend_query() {
   printf '%s\n' "$panes" | jq -Rsc --arg wt "$worktree" --argjson clients "$clients" '
     (split("\n")
      | map(select(length > 0))
-     | map(capture("^(?<dead>[01]) (?<idx>[0-9]+) (?<name>.*)$")))
+     | map(capture("^(?<dead>[01]) (?<idx>[0-9]+) (?<pid>%[0-9]+) (?<pn>[^ ]+) (?<name>.*)$")))
     | group_by(.idx | tonumber)
-    | map({name: .[0].name, panes: map({alive: (.dead == "0")})})
+    | map({name: .[0].name,
+           panes: map({alive: (.dead == "0"),
+                       pane: (if .pn == "-" then null else .pn end),
+                       pane_id: .pid})})
     | {exists: true,
        worktree: (if $wt == "" then null else $wt end),
        clients: $clients,

--- a/tools/dev/lib/backend-tmux.sh
+++ b/tools/dev/lib/backend-tmux.sh
@@ -38,6 +38,116 @@ dev_backend_create() {
   dev_tmux set-option -t "=$session_name:" @dev_worktree "$worktree" || return 1
 }
 
+# dev_backend_ensure_pane_window <session_name> <window_json> <record_json> \
+#   <global_env_json> <exists 0|1>
+#
+# Creates a panes-form window (first pane rides new-window) and/or the declared
+# panes it is missing, stamps each with the pane-scoped @dev_pane user option,
+# and applies the window's named layout when anything was created. Undeclared
+# panes — unstamped, or stamped with a name the config no longer declares —
+# are invisible here: never matched, never split into, never killed (§1.2).
+#
+# EVERY stamp is chained into the same tmux invocation as the pane's creation.
+# For the first pane the chain rides new-window (the window target resolves to
+# its active — sole — pane) alongside remain-on-exit, exactly like the
+# single-pane path. For splits the window cannot be destroyed (remain-on-exit
+# is already on, so a fast-exiting command leaves a dead, held pane), but a
+# SECOND race remains: the pane-died hook can fire before a separate second
+# invocation stamps @dev_pane, and an unstamped death event has no pane
+# identity for the fold to route. So split-window runs WITHOUT -d — the new
+# pane becomes the window's active pane — and the chained set-option's window
+# target resolves to it inside one atomic server request. The active-pane
+# side effect is corrected by the focus pass at the end of apply_layout.
+dev_backend_ensure_pane_window() {
+  local session_name="$1" window_json="$2" record_json="$3" global_env="$4" exists="$5"
+  local workspace_id slug worktree wname layout stamped
+  local pane_json pname pane_env location workdir inner pane_cmd created=0
+  local -a prefix
+  local ev_id ev_ts data line
+
+  workspace_id=$(jq -r '.workspace_id' <<<"$record_json")
+  slug=$(jq -r '.slug' <<<"$record_json")
+  worktree=$(jq -r '.worktree' <<<"$record_json")
+  wname=$(jq -r '.name' <<<"$window_json")
+  layout=$(jq -r '.layout // "main-vertical"' <<<"$window_json")
+
+  if [[ "$exists" -eq 1 ]]; then
+    stamped=$(dev_tmux list-panes -t "=$session_name:=$wname" \
+      -F '#{?#{@dev_pane},#{@dev_pane},}' 2>/dev/null || true)
+  else
+    stamped=""
+  fi
+
+  while IFS= read -r pane_json; do
+    [[ -n "$pane_json" ]] || continue
+    pname=$(jq -r '.name' <<<"$pane_json")
+    if [[ -n "$stamped" ]] && printf '%s\n' "$stamped" | grep -Fxq -- "$pname"; then
+      continue
+    fi
+    # global * pane.environment only: the exclusive schema forbids window-level
+    # environment beside panes (validated in config), so there is no window
+    # layer to merge here.
+    pane_env=$(jq -c --argjson g "$global_env" '$g * (.environment // {})' <<<"$pane_json")
+    location=$(dev_window_location "$record_json" "$pane_json") || return 1
+    mapfile -t prefix < <(dev_container_exec_prefix "$record_json" "$pane_json") || return 1
+    [[ ${#prefix[@]} -gt 0 ]] || return 1
+    inner=$(dev_window_inner_command "$record_json" "$pane_json" "$pane_env") || return 1
+    printf -v pane_cmd '%q ' "${prefix[@]}"
+    printf -v pane_cmd '%s%q' "$pane_cmd" "$inner"
+    if [[ "$location" == host ]]; then
+      workdir=$(dev_window_workdir "$record_json" "$pane_json") || return 1
+    else
+      workdir="$worktree"
+    fi
+
+    if [[ "$exists" -eq 0 ]]; then
+      dev_tmux new-window -d -t "=$session_name:" -n "$wname" -c "$workdir" "$pane_cmd" \
+        ';' set-window-option -t "=$session_name:=$wname" remain-on-exit on \
+        ';' set-option -p -t "=$session_name:=$wname" @dev_pane "$pname" || return 1
+      exists=1
+      ev_id=$(dev_event_id_random)
+      ev_ts=$(dev_now)
+      # §4.4 amendment: a panes-form window.created carries the pane roster and
+      # neither location nor command — a mixed host/container window has no
+      # window-level truth for either (absent means "not known").
+      data=$(jq -c '{window: .name, panes: [.panes[].name]}' <<<"$window_json")
+      line=$(dev_event_build "$ev_id" "$ev_ts" "window.created" \
+        "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
+      dev_event_append "$line"
+    else
+      dev_tmux split-window -t "=$session_name:=$wname" -c "$workdir" "$pane_cmd" \
+        ';' set-option -p -t "=$session_name:=$wname" @dev_pane "$pname" || return 1
+    fi
+    created=$((created + 1))
+
+    ev_id=$(dev_event_id_random)
+    ev_ts=$(dev_now)
+    # The DECLARED command, never the rendered one (secrets rule).
+    data=$(jq -c --arg w "$wname" --arg loc "$location" \
+      '{window: $w, pane: .name, location: $loc, command: (.command // .agent // null)}' \
+      <<<"$pane_json")
+    line=$(dev_event_build "$ev_id" "$ev_ts" "pane.created" \
+      "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
+    dev_event_append "$line"
+
+    if [[ "$(jq -r '.agent // ""' <<<"$pane_json")" != "" ]]; then
+      ev_id=$(dev_event_id_random)
+      ev_ts=$(dev_now)
+      data=$(jq -c --arg w "$wname" '{window: $w, pane: .name, command: .agent}' <<<"$pane_json")
+      line=$(dev_event_build "$ev_id" "$ev_ts" "agent.started" \
+        "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
+      dev_event_append "$line"
+    fi
+  done < <(jq -c '.panes[]' <<<"$window_json")
+
+  if [[ "$created" -gt 0 ]]; then
+    # Applied only when a pane was created: re-applying on a no-op open would
+    # stomp the user's manual resizes (spec §4).
+    dev_tmux select-layout -t "=$session_name:=$wname" "$layout" || return 1
+  fi
+  printf '%s\n' "$created"
+}
+
 # dev_backend_apply_layout <session_name> <config_json> <record_json>
 #
 # Creates only the windows that are missing, diffed by name. It never touches,
@@ -46,7 +156,8 @@ dev_backend_create() {
 dev_backend_apply_layout() {
   local session_name="$1" config_json="$2" record_json="$3"
   local workspace_id slug worktree existing created=0 env_json focus_window
-  local window_json name agent location workdir inner pane_cmd
+  local window_json name agent location workdir inner pane_cmd win_created win_env
+  local fw fp pid
   local -a prefix
   local ev_id ev_ts data line
 
@@ -59,6 +170,18 @@ dev_backend_apply_layout() {
   while IFS= read -r window_json; do
     [[ -n "$window_json" ]] || continue
     name=$(printf '%s' "$window_json" | jq -r '.name')
+    win_created=0
+    if [[ "$(jq -r '.panes != null' <<<"$window_json")" == true ]]; then
+      if printf '%s\n' "$existing" | grep -Fxq -- "$name"; then
+        win_created=$(dev_backend_ensure_pane_window "$session_name" "$window_json" \
+          "$record_json" "$env_json" 1) || return 1
+      else
+        win_created=$(dev_backend_ensure_pane_window "$session_name" "$window_json" \
+          "$record_json" "$env_json" 0) || return 1
+      fi
+      created=$((created + win_created))
+      continue
+    fi
     if printf '%s\n' "$existing" | grep -Fxq -- "$name"; then
       continue
     fi
@@ -74,7 +197,8 @@ dev_backend_apply_layout() {
     location=$(dev_window_location "$record_json" "$window_json") || return 1
     mapfile -t prefix < <(dev_container_exec_prefix "$record_json" "$window_json") || return 1
     [[ ${#prefix[@]} -gt 0 ]] || return 1
-    inner=$(dev_window_inner_command "$record_json" "$window_json" "$env_json") || return 1
+    win_env=$(jq -c --argjson g "$env_json" '$g * (.environment // {})' <<<"$window_json")
+    inner=$(dev_window_inner_command "$record_json" "$window_json" "$win_env") || return 1
     printf -v pane_cmd '%q ' "${prefix[@]}"
     printf -v pane_cmd '%s%q' "$pane_cmd" "$inner"
 
@@ -138,6 +262,20 @@ dev_backend_apply_layout() {
   if [[ -n "$focus_window" ]]; then
     dev_tmux select-window -t "=$session_name:=$focus_window" 2>/dev/null || true
   fi
+
+  # `panes[].focus: true` selects the pane the user lands on within its window,
+  # same rationale as focus_window above: re-applied every open (not only on
+  # creation), so drift self-heals. Validation guarantees at most one per window.
+  while IFS=$'\t' read -r fw fp; do
+    [[ -n "$fw" ]] || continue
+    pid=$(dev_tmux list-panes -t "=$session_name:=$fw" \
+      -F '#{pane_id} #{?#{@dev_pane},#{@dev_pane},-}' 2>/dev/null |
+      awk -v p="$fp" '$2 == p {print $1; exit}')
+    [[ -n "$pid" ]] || continue
+    dev_tmux select-pane -t "$pid" 2>/dev/null || true
+  done < <(printf '%s' "$config_json" | jq -r '
+    (.windows // [])[] | select(.panes != null) | .name as $w
+    | .panes[] | select(.focus == true) | [$w, .name] | @tsv')
 }
 
 # dev_backend_query <session_name>

--- a/tools/dev/lib/backend-tmux.sh
+++ b/tools/dev/lib/backend-tmux.sh
@@ -115,7 +115,12 @@ dev_backend_ensure_pane_window() {
         "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
       dev_event_append "$line"
     else
+      # A pre-existing, user-created window that name-collides with a declared
+      # panes-form window never went through the new-window branch above, so it
+      # never got remain-on-exit; set it here too (idempotent for dev-created
+      # windows) or a fast-exiting pane closes the whole window silently.
       dev_tmux split-window -t "=$session_name:=$wname" -c "$workdir" "$pane_cmd" \
+        ';' set-window-option -t "=$session_name:=$wname" remain-on-exit on \
         ';' set-option -p -t "=$session_name:=$wname" @dev_pane "$pname" || return 1
     fi
     created=$((created + 1))

--- a/tools/dev/lib/backend-tmux.sh
+++ b/tools/dev/lib/backend-tmux.sh
@@ -328,7 +328,15 @@ dev_backend_query() {
   '
 }
 
-# dev_backend_respawn_pane <session_name> <window> <command> [container_id]
+# dev_backend_respawn_pane <session_name> <window> <command> [container_id] \
+#   [pane_handle] [pane_name]
+#
+# With a pane_handle (an id from dev_backend_query) the respawn targets exactly
+# that pane; without one it falls back to the window target, which tmux
+# resolves to the window's ACTIVE pane — correct only for single-pane windows,
+# which is the only caller that omits it. pane_name, when non-empty, is the
+# logical @dev_pane identity and is recorded on the event; the stamp itself
+# survives respawn because the pane object does.
 #
 # The envelope identity is read back from the session's user options rather
 # than passed in, which is the same path the tmux hooks take.
@@ -338,15 +346,23 @@ dev_backend_query() {
 # `restarts` counter would report double every recovery.
 dev_backend_respawn_pane() {
   local session_name="$1" window="$2" pane_command="$3" container_id="${4:-}"
-  local workspace_id slug worktree ev_id ev_ts data line
-  dev_tmux respawn-pane -k -t "=$session_name:=$window" "$pane_command" || return 1
+  local pane_handle="${5:-}" pane_name="${6:-}"
+  local target workspace_id slug worktree ev_id ev_ts data line
+  if [[ -n "$pane_handle" ]]; then
+    target="$pane_handle"
+  else
+    target="=$session_name:=$window"
+  fi
+  dev_tmux respawn-pane -k -t "$target" "$pane_command" || return 1
   workspace_id=$(dev_tmux show-options -qv -t "=$session_name:" @dev_workspace_id 2>/dev/null || true)
   slug=$(dev_tmux show-options -qv -t "=$session_name:" @dev_slug 2>/dev/null || true)
   worktree=$(dev_tmux show-options -qv -t "=$session_name:" @dev_worktree 2>/dev/null || true)
   ev_id=$(dev_event_id_random)
   ev_ts=$(dev_now)
-  data=$(jq -nc --arg w "$window" --arg c "$container_id" \
-    '{window: $w} + (if $c == "" then {} else {container_id: $c} end)')
+  data=$(jq -nc --arg w "$window" --arg p "$pane_name" --arg c "$container_id" \
+    '{window: $w}
+     + (if $p == "" then {} else {pane: $p} end)
+     + (if $c == "" then {} else {container_id: $c} end)')
   line=$(dev_event_build "$ev_id" "$ev_ts" "pane.respawned" \
     "$workspace_id" "$slug" "$session_name" "$worktree" "$data")
   dev_event_append "$line"

--- a/tools/dev/lib/backend-tmux.sh
+++ b/tools/dev/lib/backend-tmux.sh
@@ -124,6 +124,12 @@ dev_backend_ensure_pane_window() {
         ';' set-option -p -t "=$session_name:=$wname" @dev_pane "$pname" || return 1
     fi
     created=$((created + 1))
+    # Re-apply the layout after EVERY successful creation, not once at the end:
+    # unbalanced repeated splits halve the active pane each time and can hit
+    # tmux's "pane too small" before the roster is complete; rebalancing as we
+    # go keeps room for the next split. Still conditional on a creation, so a
+    # no-op open never stomps manual resizes (spec §4).
+    dev_tmux select-layout -t "=$session_name:=$wname" "$layout" || return 1
 
     ev_id=$(dev_event_id_random)
     ev_ts=$(dev_now)
@@ -145,11 +151,6 @@ dev_backend_ensure_pane_window() {
     fi
   done < <(jq -c '.panes[]' <<<"$window_json")
 
-  if [[ "$created" -gt 0 ]]; then
-    # Applied only when a pane was created: re-applying on a no-op open would
-    # stomp the user's manual resizes (spec §4).
-    dev_tmux select-layout -t "=$session_name:=$wname" "$layout" || return 1
-  fi
   printf '%s\n' "$created"
 }
 

--- a/tools/dev/lib/config.sh
+++ b/tools/dev/lib/config.sh
@@ -159,7 +159,7 @@ dev_config_validate() {
           | select(.name == null or ((.name | tostring) | test("^[A-Za-z0-9._-]+$") | not))
           | "a pane in window \($w.name) has an invalid name; use [A-Za-z0-9._-]"))
       + ((.windows // []) | map(. as $w | (.panes // [])[]
-          | select(.name != null and ((.name | tostring) | test("^-+$")))
+          | select(.name == "-")
           | "pane \($w.name)/\(.name) has a reserved name"))
       + ((.windows // []) | map(. as $w | (.panes // [])[]
           | select(.location != null and ((.location | IN("container","host")) | not))

--- a/tools/dev/lib/config.sh
+++ b/tools/dev/lib/config.sh
@@ -159,6 +159,9 @@ dev_config_validate() {
           | select(.name == null or ((.name | tostring) | test("^[A-Za-z0-9._-]+$") | not))
           | "a pane in window \($w.name) has an invalid name; use [A-Za-z0-9._-]"))
       + ((.windows // []) | map(. as $w | (.panes // [])[]
+          | select(.name != null and ((.name | tostring) | test("^-+$")))
+          | "pane \($w.name)/\(.name) has a reserved name"))
+      + ((.windows // []) | map(. as $w | (.panes // [])[]
           | select(.location != null and ((.location | IN("container","host")) | not))
           | "pane \($w.name)/\(.name) has invalid location \(.location | tostring)"))
       + ((.windows // []) | map(. as $w | ((.panes // []) | group_by(.name)[] | select(length > 1))

--- a/tools/dev/lib/config.sh
+++ b/tools/dev/lib/config.sh
@@ -3,18 +3,27 @@
 DEV_DOTFILES_ROOT="${DEV_DOTFILES_ROOT:-$HOME/.dotfiles}"
 DEV_OVERLAY_ROOT="${DEV_OVERLAY_ROOT:-$DEV_DOTFILES_ROOT/projects}"
 
-# windows merge by the name key, never by position (spec 4.1). IN(), not
-# inside(): inside() is substring matching on strings and would swallow a new
-# window whose name is a substring of an existing one.
+# windows merge by the name key, never by position (spec 4.1), and panes
+# within a window merge the same way. IN(), not inside(): inside() is
+# substring matching on strings and would swallow a new window whose name is
+# a substring of an existing one.
 DEV_CONFIG_MERGE_JQ='
 def by_name($ws): reduce $ws[] as $w ({}; .[$w.name] = $w);
-def merge_windows($base; $over):
-  (by_name($base)) as $bm
-  | (by_name($over)) as $om
+def merge_named($base; $over):
+  (by_name($over)) as $om
   | ($base | map(.name)) as $bn
   | ($base | map(. * ($om[.name] // {})))
-    + ($over | map(select((.name | IN($bn[])) | not)))
-;
+    + ($over | map(select((.name | IN($bn[])) | not)));
+def merge_window($b; $o):
+  ($b * $o)
+  | if ($b.panes? != null) and ($o.panes? != null)
+    then .panes = merge_named($b.panes; $o.panes)
+    else . end;
+def merge_windows($base; $over):
+  (by_name($over)) as $om
+  | ($base | map(.name)) as $bn
+  | ($base | map(merge_window(.; ($om[.name] // {}))))
+    + ($over | map(select((.name | IN($bn[])) | not)));
 ($a.windows // []) as $bw
 | ($b.windows // []) as $ow
 | ($a * $b)
@@ -22,6 +31,14 @@ def merge_windows($base; $over):
 '
 
 DEV_CONFIG_NORMALIZE_JQ='
+def norm_pane:
+  { name: .name,
+    agent: (.agent // null),
+    command: (.command // null),
+    cwd: (.cwd // null),
+    location: (.location // null),
+    focus: (.focus // false) }
+  + (if .environment != null then {environment: .environment} else {} end);
 { version: (.version // 1),
   autostart: (.autostart // false),
   devcontainer: ((.devcontainer // {}) | {
@@ -29,13 +46,16 @@ DEV_CONFIG_NORMALIZE_JQ='
       config: (.config // null),
       start_timeout: (.start_timeout // 300) }),
   environment: (.environment // {}),
-  windows: ((.windows // []) | map({
-      name: .name,
+  windows: ((.windows // []) | map(
+    { name: .name,
       agent: (.agent // null),
       command: (.command // null),
       cwd: (.cwd // null),
       location: (.location // null),
-      focus: (.focus // false) })) }
+      focus: (.focus // false) }
+    + (if .environment != null then {environment: .environment} else {} end)
+    + (if .layout != null then {layout: .layout} else {} end)
+    + (if .panes != null then {panes: (.panes | map(norm_pane))} else {} end))) }
 '
 # `location` normalizes to null, NOT to "container". Spec §4.1 reads "Default
 # container when one exists" — the default is conditional on the workspace
@@ -59,6 +79,25 @@ dev_config_layer_json() {
   yq -o=json -I=0 '. // {}' "$file"
 }
 
+# By-name merging collapses duplicate names before post-merge validation can
+# see them: a layer that defines an inherited pane twice would silently keep
+# only the last patch. So duplicates are detected per layer, while the layer
+# is still a layer. The post-merge duplicate checks in dev_config_validate
+# stay as defense in depth for hand-fed JSON.
+dev_config_layer_dup_check() {
+  local file="$1" layer="$2" problem
+  problem=$(jq -r '
+    ([(.windows // []) | group_by(.name)[] | select(length > 1)
+       | "window \(.[0].name) is defined more than once"]
+     + [(.windows // [])[] | .name as $w
+        | ((.panes // []) | group_by(.name)[] | select(length > 1))
+        | "pane \($w)/\(.[0].name) is defined more than once"])
+    | first // ""' <<<"$layer") || return 1
+  [[ -z "$problem" ]] && return 0
+  printf 'invalid workspace config in %s: %s\n' "$file" "$problem" >&2
+  return 5
+}
+
 # worktree is accepted for signature stability; no Phase 1 layer is keyed by it
 # (ADR-7 ships no per-worktree configuration layer).
 dev_config_merged() {
@@ -70,6 +109,7 @@ dev_config_merged() {
     "$DEV_OVERLAY_ROOT/$slug/workspace.yaml" \
     "$DEV_OVERLAY_ROOT/$slug/workspace.local.yaml"; do
     layer="$(dev_config_layer_json "$file")" || return 1
+    dev_config_layer_dup_check "$file" "$layer" || return $?
     acc="$(jq -c -n --argjson a "$acc" --argjson b "$layer" "$DEV_CONFIG_MERGE_JQ")" || return 1
   done
   # -S -c: sorted keys, one line, so the digest ignores cosmetic edits.
@@ -100,7 +140,31 @@ dev_config_validate() {
       + (if (((.windows // []) | map(select(.focus == true)) | length) > 1)
          then [((.windows // []) | map(select(.focus == true) | .name) | join(", "))
                | "more than one window sets focus: \(.)"]
-         else [] end);
+         else [] end)
+      + ((.windows // []) | map(select(.panes != null
+          and (.agent != null or .command != null or .cwd != null
+               or .location != null or ((.environment // null) != null)))
+          | "window \(.name) mixes panes with single-pane keys; null them explicitly in the overlay"))
+      + ((.windows // []) | map(select(.panes != null and (.panes | length) == 0)
+          | "window \(.name) declares an empty panes list"))
+      + ((.windows // []) | map(select((.layout // null) != null and .panes == null)
+          | "window \(.name) sets layout without panes"))
+      + ((.windows // []) | map(select((.layout // null) != null
+          and ((.layout | IN("even-horizontal","even-vertical","main-horizontal","main-vertical","tiled")) | not))
+          | "window \(.name) has invalid layout \(.layout | tostring)"))
+      + ((.windows // []) | map(. as $w | (.panes // [])[]
+          | select(.agent != null and .command != null)
+          | "pane \($w.name)/\(.name) sets both agent and command"))
+      + ((.windows // []) | map(. as $w | (.panes // [])[]
+          | select(.name == null or ((.name | tostring) | test("^[A-Za-z0-9._-]+$") | not))
+          | "a pane in window \($w.name) has an invalid name; use [A-Za-z0-9._-]"))
+      + ((.windows // []) | map(. as $w | (.panes // [])[]
+          | select(.location != null and ((.location | IN("container","host")) | not))
+          | "pane \($w.name)/\(.name) has invalid location \(.location | tostring)"))
+      + ((.windows // []) | map(. as $w | ((.panes // []) | group_by(.name)[] | select(length > 1))
+          | "pane \($w.name)/\(.[0].name) is defined more than once"))
+      + ((.windows // []) | map(select(((.panes // []) | map(select(.focus == true)) | length) > 1)
+          | "window \(.name) has more than one focused pane"));
     problems | first // ""')" || return 1
   [[ -z "$problem" ]] && return 0
   printf 'invalid workspace config: %s\n' "$problem" >&2

--- a/tools/dev/lib/fold.sh
+++ b/tools/dev/lib/fold.sh
@@ -7,20 +7,24 @@
 #   * only workspace.attached/detached write .last_seen in the fold
 #   * every transition is an absolute assignment, which is what makes replay idempotent
 #   * unknown event types fall through unchanged — ignored, never rejected
+#   * agent identity is (window, data.pane // null); legacy pane-less events
+#     and records fold identically with pane: null (spec §3)
 #
 # This file is sourced. It defines functions and does no work at source time.
 
 # The shared jq source. Internal to this file; no other task calls it.
 dev_fold_jq_program() {
   cat <<'JQ'
-def agent_has($w): any(.agents[]; .window == $w);
+def agent_matches($d): .window == $d.window and ((.pane // null) == ($d.pane // null));
+def agent_has($d): any(.agents[]; agent_matches($d));
 
-def agent_upsert($w; $patch):
-  if $w == null then .
-  elif agent_has($w) then
-    .agents = [.agents[] | if .window == $w then . + $patch else . end]
+def agent_upsert($d; $patch):
+  if ($d.window // null) == null then .
+  elif agent_has($d) then
+    .agents = [.agents[] | if agent_matches($d) then . + $patch else . end]
   else
-    .agents = (.agents + [{window: $w, command: null, state: null} + $patch])
+    .agents = (.agents
+      + [{window: $d.window, pane: ($d.pane // null), command: null, state: null} + $patch])
   end;
 
 def fold_event($ev):
@@ -47,9 +51,9 @@ def fold_event($ev):
       .status = "stopped" | .stopped_reason = $d.reason
     elif $ev.event == "window.created" then .
     elif $ev.event == "pane.died" then
-      if agent_has($d.window) then agent_upsert($d.window; {state: "exited"}) else . end
+      if agent_has($d) then agent_upsert($d; {state: "exited"}) else . end
     elif $ev.event == "pane.respawned" then
-      if agent_has($d.window) then agent_upsert($d.window; {state: "started"}) else . end
+      if agent_has($d) then agent_upsert($d; {state: "started"}) else . end
     elif $ev.event == "container.starting" then
       .container.status = "starting" | .container.verified = false
     elif $ev.event == "container.ready" then
@@ -74,11 +78,11 @@ def fold_event($ev):
       | .container.observed_at = $ts
     elif $ev.event == "container.replaced" then .
     elif $ev.event == "agent.started" then
-      agent_upsert($d.window; {command: $d.command, state: "started"})
+      agent_upsert($d; {command: $d.command, state: "started"})
     elif $ev.event == "agent.exited" then
-      agent_upsert($d.window; {state: "exited"})
+      agent_upsert($d; {state: "exited"})
     elif $ev.event == "agent.failed" then
-      agent_upsert($d.window; {state: "failed"})
+      agent_upsert($d; {state: "failed"})
     elif $ev.event == "config.changed" then
       .config_digest = $d.config_digest
     else .


### PR DESCRIPTION
## Summary

Adds declarative multi-pane windows to the dev workspace platform: one tmux window can now show several named panes — any of which may run an agent — so all four default units (two agents, shell, scratch) are visible at once as a tiled dashboard.

- **Schema**: a window declares either the existing single-pane form or `panes:` (exclusive; mixing fails validation). Panes carry `name`, `agent`/`command`, `cwd`, `location`, `environment`, `focus`; windows gain `layout:` (tmux's five named layouts, default `main-vertical`). Panes merge by name across config layers; duplicates in any single layer fail loudly *before* merge collapses them; converting an inherited window requires an explicit `agent: null`.
- **Identity**: each pane is stamped with a pane-scoped `@dev_pane` user option, chained atomically into the same tmux invocation that creates the pane (verified on tmux 3.4 including the fast-exit race). Agent state is keyed by `(window, pane // null)` — all events/records are additive, and a panes-less config produces byte-identical digests, events, and `dev list --json` output.
- **Repair**: `dev open` now repairs on every open (previously only after container loss): missing declared panes are split in, dead declared panes respawn by pane handle (also fixing the latent bug where respawn targeted the window's *active* pane), undeclared panes are never touched — `dev status` reports them as drift.
- **Default**: `default-workspace.yaml` becomes one `main` window, `layout: tiled`, panes agent-1/agent-2/shell/scratch. Also fixes window-level `environment` being silently dropped by normalization.

Design spec and implementation plan are included under `docs/superpowers/`.

## Migration note

A workspace already running gains the new `main` window beside its old four windows on its next open (open never destroys); the old windows show as drift until `dev stop <ws>` + `dev <ws>`, which converts cleanly. No project overlays currently patch the old default window names.

## Verification

- Full suite on the final tree: `bats tests` — 735/735 pass; `make lint` clean.
- New coverage: config merge/validation matrix, legacy event-log replay, pane-died hook interpolation under the fast-exit race (real tmux), pane repair end-to-end (one dead agent of two respawns, the other's record untouched), drift reporting, dashboard-default scenario against the real shipped config.
- Every task passed an independent spec+quality review; a final whole-branch review verified the six cross-task invariants and its findings were fixed and re-reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added declarative multi-pane workspaces with named panes, layouts, focus, and pane-specific environments.
  - The default workspace now provides a tiled four-pane dashboard.
  - Status output identifies panes and reports undeclared windows or panes as configuration drift.

- **Bug Fixes**
  - `dev open` now repairs dead declared panes and respawns only affected panes.
  - Improved pane lifecycle tracking, event routing, and environment propagation.

- **Documentation**
  - Added configuration, migration, layout, and pane management guidance.

- **Tests**
  - Expanded coverage for pane creation, repair, validation, events, layouts, and legacy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->