### PR TITLE
feat(bin): reap worktrees whose branch already landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,27 @@ compatible minor in `config/versions.env` by hand.
 - `localrc` — ssh-agent + goms.io environment
 - `script-bootstrap`, `script-install` — old install scripts (replaced by `bin/bootstrap` and `bin/install`)
 
+## Reaping Merged Worktrees
+
+`bin/git-worktree-gc` removes linked worktrees whose branch has already landed.
+Because `bin` is on `PATH`, Git resolves it as a subcommand:
+
+```bash
+git worktree-gc                          # dry run: print the plan, change nothing
+git worktree-gc --yes                    # remove the worktrees it listed
+git worktree-gc --yes --delete-branches  # and delete their branches
+```
+
+Merge detection reads `git branch --merged` *and* `gh pr list --state merged`.
+The second source is what makes it useful in a squash-merge repository, where
+a shipped branch is never an ancestor of `main` and ancestry alone reports
+almost everything as unmerged. Without `gh`, the script says so and falls back
+to ancestry rather than reporting a clean sweep.
+
+The main worktree, the one you are standing in, detached-HEAD worktrees, and
+anything with uncommitted changes are never removed. Locked worktrees are
+skipped unless `--include-locked`, which unlocks each before removing it.
+
 ## Repository Hygiene
 
 - Active configuration must not discover files under `archived/`.

--- a/bin/git-worktree-gc
+++ b/bin/git-worktree-gc
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# bin/git-worktree-gc — Remove linked worktrees whose branch has already landed.
+#
+# Named for Git's subcommand lookup: anywhere on PATH, `git worktree-gc` works.
+#
+# Dry run by default. Nothing is removed without --yes, and even then the
+# removal is the non-forcing one, so a worktree with uncommitted work is
+# reported rather than discarded.
+#
+# Merge detection reads two sources, because neither alone is sufficient:
+#   * `git branch --merged` catches branches that landed as a merge or a
+#     fast-forward, where the tip really is an ancestor of the base ref.
+#   * `gh pr list --state merged` catches squash-merged branches, whose tips
+#     are never ancestors of anything. In a squash-merge repo, ancestry alone
+#     reports almost every shipped branch as unmerged — which is the failure
+#     mode this script exists to avoid, since it looks like a clean result.
+# Without gh the script still runs, and says plainly what it stopped seeing.
+
+set -euo pipefail
+
+PROGRAM=${0##*/}
+BASE_REF=""
+PR_LIMIT=500
+APPLY=false
+DELETE_BRANCHES=false
+INCLUDE_LOCKED=false
+
+usage() {
+  cat <<'USAGE'
+usage: git-worktree-gc [options]
+
+Report linked worktrees whose branch has already been merged, and optionally
+remove them. Prints a plan and exits without changing anything unless --yes.
+
+  -y, --yes             Actually remove the worktrees listed in the plan.
+      --delete-branches Also delete each removed worktree's branch.
+      --base <ref>      Branch to measure "merged" against.
+                        Default: origin/HEAD, else main, else master.
+      --include-locked  Consider locked worktrees too, unlocking each before
+                        removal. Off by default: a lock is a deliberate
+                        "do not reap this" marker.
+      --pr-limit <n>    Merged PRs to read from gh (default 500).
+  -h, --help            Show this help.
+
+Never removed, regardless of flags: the main worktree, the worktree you are
+standing in, detached-HEAD worktrees, and any worktree with uncommitted
+changes. There is no --force; discarding uncommitted work is not this
+script's job.
+USAGE
+}
+
+warn() {
+  printf '%s: %s\n' "$PROGRAM" "$1" >&2
+}
+
+die() {
+  warn "$1"
+  exit 1
+}
+
+while (($# > 0)); do
+  case "$1" in
+    -y | --yes) APPLY=true ;;
+    --delete-branches) DELETE_BRANCHES=true ;;
+    --include-locked) INCLUDE_LOCKED=true ;;
+    --base)
+      [[ $# -ge 2 ]] || die "--base needs a ref"
+      BASE_REF=$2
+      shift
+      ;;
+    --pr-limit)
+      [[ $# -ge 2 ]] || die "--pr-limit needs a number"
+      [[ $2 =~ ^[0-9]+$ ]] || die "--pr-limit needs a number, got '$2'"
+      PR_LIMIT=$2
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) die "unknown option '$1' (try --help)" ;;
+  esac
+  shift
+done
+
+[[ $(git rev-parse --is-inside-work-tree 2>/dev/null || true) == true ]] ||
+  die "must run inside a Git checkout"
+
+# ── Base ref ──────────────────────────────────────────────────────────────────
+
+if [[ -z "$BASE_REF" ]]; then
+  if origin_head=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); then
+    BASE_REF=${origin_head#origin/}
+  else
+    for candidate in main master; do
+      if git show-ref --verify --quiet "refs/heads/$candidate"; then
+        BASE_REF=$candidate
+        break
+      fi
+    done
+  fi
+fi
+
+[[ -n "$BASE_REF" ]] || die "could not infer a base branch; pass --base <ref>"
+git rev-parse --verify --quiet "$BASE_REF" >/dev/null ||
+  die "base ref '$BASE_REF' does not exist"
+
+# ── Merge evidence ────────────────────────────────────────────────────────────
+
+declare -A MERGED=()
+
+while IFS= read -r branch; do
+  [[ -n "$branch" ]] || continue
+  MERGED["$branch"]=ancestry
+done < <(git branch --merged "$BASE_REF" --format='%(refname:short)')
+
+if ! command -v gh >/dev/null 2>&1; then
+  warn "gh not found — squash-merged branches will look unmerged and be left alone"
+elif ! pr_branches=$(gh pr list --state merged --limit "$PR_LIMIT" \
+  --json headRefName --jq '.[].headRefName' 2>&1); then
+  warn "gh pr list failed, continuing on ancestry alone: ${pr_branches%%$'\n'*}"
+else
+  pr_count=0
+  while IFS= read -r branch; do
+    [[ -n "$branch" ]] || continue
+    pr_count=$((pr_count + 1))
+    [[ -n "${MERGED[$branch]:-}" ]] || MERGED["$branch"]=PR
+  done <<<"$pr_branches"
+  # Silence here would read as "nothing older was merged" rather than "we
+  # stopped looking", and the difference is worktrees that quietly survive.
+  if ((pr_count >= PR_LIMIT)); then
+    warn "read the newest $PR_LIMIT merged PRs and stopped; older ones were not checked (--pr-limit)"
+  fi
+fi
+
+# ── Worktree inventory ────────────────────────────────────────────────────────
+
+declare -a WT_PATH=() WT_BRANCH=() WT_LOCKED=()
+
+path="" branch="" locked=false
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) path=${line#worktree } ;;
+    "branch "*)
+      branch=${line#branch }
+      branch=${branch#refs/heads/}
+      ;;
+    "locked"*) locked=true ;;
+    "")
+      if [[ -n "$path" ]]; then
+        WT_PATH+=("$path")
+        WT_BRANCH+=("$branch")
+        WT_LOCKED+=("$locked")
+      fi
+      path="" branch="" locked=false
+      ;;
+  esac
+done < <(
+  git worktree list --porcelain
+  printf '\n'
+)
+
+((${#WT_PATH[@]} > 0)) || die "no worktrees found"
+
+# `git worktree list` documents the main worktree as the first record; it is
+# the one entry that cannot be removed.
+MAIN_WORKTREE=${WT_PATH[0]}
+CURRENT_WORKTREE=$(git rev-parse --show-toplevel)
+
+# ── Plan ──────────────────────────────────────────────────────────────────────
+
+declare -a PLAN_PATH=() PLAN_BRANCH=() PLAN_WHY=() PLAN_LOCKED=()
+declare -a BLOCKED=()
+unmerged=0
+width=0
+
+for i in "${!WT_PATH[@]}"; do
+  wt_path=${WT_PATH[$i]}
+  wt_branch=${WT_BRANCH[$i]}
+  wt_locked=${WT_LOCKED[$i]}
+
+  [[ "$wt_path" != "$MAIN_WORKTREE" ]] || continue
+
+  if [[ -z "$wt_branch" ]]; then
+    BLOCKED+=("$wt_path — detached HEAD, no branch to judge")
+    continue
+  fi
+
+  [[ "$wt_branch" != "$BASE_REF" ]] || continue
+
+  why=${MERGED[$wt_branch]:-}
+  if [[ -z "$why" ]]; then
+    unmerged=$((unmerged + 1))
+    continue
+  fi
+
+  if [[ "$wt_locked" == true && "$INCLUDE_LOCKED" != true ]]; then
+    BLOCKED+=("$wt_branch — locked (--include-locked to consider it)")
+    continue
+  fi
+
+  if [[ "$wt_path" == "$CURRENT_WORKTREE" ]]; then
+    BLOCKED+=("$wt_branch — you are standing in it")
+    continue
+  fi
+
+  if [[ ! -d "$wt_path" ]]; then
+    BLOCKED+=("$wt_branch — directory is gone; \`git worktree prune\` clears it")
+    continue
+  fi
+
+  if [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+    BLOCKED+=("$wt_branch — uncommitted changes")
+    continue
+  fi
+
+  PLAN_PATH+=("$wt_path")
+  PLAN_BRANCH+=("$wt_branch")
+  PLAN_WHY+=("$why")
+  PLAN_LOCKED+=("$wt_locked")
+  ((${#wt_branch} <= width)) || width=${#wt_branch}
+done
+
+# ── Report ────────────────────────────────────────────────────────────────────
+
+printf 'base: %s   worktrees: %d   merged and removable: %d\n\n' \
+  "$BASE_REF" "$((${#WT_PATH[@]} - 1))" "${#PLAN_PATH[@]}"
+
+for i in "${!PLAN_PATH[@]}"; do
+  printf '  %-*s  %-8s  %s\n' \
+    "$width" "${PLAN_BRANCH[$i]}" "${PLAN_WHY[$i]}" "${PLAN_PATH[$i]}"
+done
+
+if ((${#BLOCKED[@]} > 0)); then
+  printf '\nmerged but kept:\n'
+  printf '  %s\n' "${BLOCKED[@]}"
+fi
+
+((unmerged == 0)) || printf '\n%d worktree(s) on unmerged branches, untouched.\n' "$unmerged"
+
+if ((${#PLAN_PATH[@]} == 0)); then
+  printf '\nNothing to remove.\n'
+  exit 0
+fi
+
+if [[ "$APPLY" != true ]]; then
+  printf '\nDry run. Re-run with --yes to remove the %d worktree(s) above.\n' \
+    "${#PLAN_PATH[@]}"
+  exit 0
+fi
+
+# ── Apply ─────────────────────────────────────────────────────────────────────
+
+printf '\n'
+failures=0
+
+for i in "${!PLAN_PATH[@]}"; do
+  wt_path=${PLAN_PATH[$i]}
+  wt_branch=${PLAN_BRANCH[$i]}
+
+  # `git worktree remove` refuses a locked worktree outright, and the escape
+  # hatch it offers is --force twice — which would also override the dirty
+  # check. Unlocking first keeps --include-locked meaning only "ignore the
+  # lock", never "discard uncommitted work".
+  if [[ "${PLAN_LOCKED[$i]}" == true ]] && ! git worktree unlock "$wt_path"; then
+    warn "could not unlock $wt_path"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  # No --force: the plan already excluded dirty worktrees, so a refusal here
+  # means something changed since, and the right answer is to stop for that one.
+  if ! git worktree remove "$wt_path"; then
+    warn "could not remove $wt_path"
+    failures=$((failures + 1))
+    continue
+  fi
+  printf 'removed  %s\n' "$wt_path"
+
+  [[ "$DELETE_BRANCHES" == true ]] || continue
+
+  # -D, not -d: a squash-merged branch is not an ancestor of the base ref, so
+  # -d refuses exactly the branches this script is built to reap. The safety
+  # -d provides is already covered — nothing reaches here without merge
+  # evidence from ancestry or a merged PR.
+  if ! git branch -D "$wt_branch" >/dev/null; then
+    warn "removed the worktree but could not delete branch $wt_branch"
+    failures=$((failures + 1))
+    continue
+  fi
+  printf 'deleted  %s\n' "$wt_branch"
+done
+
+git worktree prune
+
+((failures == 0)) || exit 1

--- a/bin/git-worktree-gc
+++ b/bin/git-worktree-gc
@@ -114,9 +114,14 @@ while IFS= read -r branch; do
   MERGED["$branch"]=ancestry
 done < <(git branch --merged "$BASE_REF" --format='%(refname:short)')
 
+# gh filters on a branch name, so a base given (or resolved) as origin/main has
+# to lose its remote prefix or it matches no PR at all — which would read as
+# "nothing was ever merged" rather than "the filter was malformed".
+PR_BASE=${BASE_REF#origin/}
+
 if ! command -v gh >/dev/null 2>&1; then
   warn "gh not found — squash-merged branches will look unmerged and be left alone"
-elif ! pr_branches=$(gh pr list --state merged --limit "$PR_LIMIT" \
+elif ! pr_branches=$(gh pr list --state merged --base "$PR_BASE" --limit "$PR_LIMIT" \
   --json headRefName --jq '.[].headRefName' 2>&1); then
   warn "gh pr list failed, continuing on ancestry alone: ${pr_branches%%$'\n'*}"
 else
@@ -135,9 +140,9 @@ fi
 
 # ── Worktree inventory ────────────────────────────────────────────────────────
 
-declare -a WT_PATH=() WT_BRANCH=() WT_LOCKED=()
+declare -a WT_PATH=() WT_BRANCH=() WT_LOCKED=() WT_LOCK_REASON=()
 
-path="" branch="" locked=false
+path="" branch="" locked=false lock_reason=""
 while IFS= read -r line; do
   case "$line" in
     "worktree "*) path=${line#worktree } ;;
@@ -145,14 +150,19 @@ while IFS= read -r line; do
       branch=${line#branch }
       branch=${branch#refs/heads/}
       ;;
-    "locked"*) locked=true ;;
+    locked) locked=true ;;
+    "locked "*)
+      locked=true
+      lock_reason=${line#locked }
+      ;;
     "")
       if [[ -n "$path" ]]; then
         WT_PATH+=("$path")
         WT_BRANCH+=("$branch")
         WT_LOCKED+=("$locked")
+        WT_LOCK_REASON+=("$lock_reason")
       fi
-      path="" branch="" locked=false
+      path="" branch="" locked=false lock_reason=""
       ;;
   esac
 done < <(
@@ -169,7 +179,7 @@ CURRENT_WORKTREE=$(git rev-parse --show-toplevel)
 
 # ── Plan ──────────────────────────────────────────────────────────────────────
 
-declare -a PLAN_PATH=() PLAN_BRANCH=() PLAN_WHY=() PLAN_LOCKED=()
+declare -a PLAN_PATH=() PLAN_BRANCH=() PLAN_WHY=() PLAN_LOCKED=() PLAN_LOCK_REASON=()
 declare -a BLOCKED=()
 unmerged=0
 width=0
@@ -218,6 +228,7 @@ for i in "${!WT_PATH[@]}"; do
   PLAN_BRANCH+=("$wt_branch")
   PLAN_WHY+=("$why")
   PLAN_LOCKED+=("$wt_locked")
+  PLAN_LOCK_REASON+=("${WT_LOCK_REASON[$i]}")
   ((${#wt_branch} <= width)) || width=${#wt_branch}
 done
 
@@ -272,6 +283,20 @@ for i in "${!PLAN_PATH[@]}"; do
   # means something changed since, and the right answer is to stop for that one.
   if ! git worktree remove "$wt_path"; then
     warn "could not remove $wt_path"
+    # The unlock above was a means to removal, not a decision to unlock. Left
+    # as-is, a failed removal would silently strip a deliberate marker.
+    #
+    # This restores the lock only when git refused early — the dirty-worktree
+    # race this path exists for. `git worktree remove` deregisters before it
+    # deletes, so a failure during deletion leaves nothing to lock and the
+    # re-lock warns instead. That is reported rather than hidden.
+    if [[ "${PLAN_LOCKED[$i]}" == true ]]; then
+      lock_args=("$wt_path")
+      [[ -z "${PLAN_LOCK_REASON[$i]}" ]] ||
+        lock_args=(--reason "${PLAN_LOCK_REASON[$i]}" "$wt_path")
+      git worktree lock "${lock_args[@]}" ||
+        warn "could not re-lock $wt_path — it is now unlocked"
+    fi
     failures=$((failures + 1))
     continue
   fi

--- a/tests/git_worktree_gc.bats
+++ b/tests/git_worktree_gc.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  GC="$REPO_ROOT/bin/git-worktree-gc"
+  REPO="$TEST_ROOT/repo"
+
+  git init -q -b main "$REPO"
+  git -C "$REPO" config user.email test@example.com
+  git -C "$REPO" config user.name Test
+  echo one >"$REPO/file"
+  git -C "$REPO" add file
+  git -C "$REPO" commit -q -m one
+
+  # git-worktree-gc acts on the current repository, so every test must stand
+  # inside the fixture — not in the dotfiles checkout bats was invoked from.
+  cd "$REPO"
+}
+
+# Adds a worktree whose branch carries a commit that is NOT an ancestor of
+# main — the shape a squash merge leaves behind.
+add_worktree() {
+  local name="$1"
+  git -C "$REPO" worktree add -q -b "$name" "$TEST_ROOT/wt-$name" main
+  echo "$name" >"$TEST_ROOT/wt-$name/$name"
+  git -C "$TEST_ROOT/wt-$name" add "$name"
+  git -C "$TEST_ROOT/wt-$name" commit -q -m "$name"
+}
+
+stub_gh_merged() {
+  stub_command gh "printf '%s\n' $(printf "'%s' " "$@")"
+}
+
+@test "dry run reports a squash-merged worktree without removing it" {
+  add_worktree shipped
+  stub_gh_merged shipped
+
+  run "$GC" --base main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *shipped* ]]
+  [[ "$output" == *"Dry run"* ]]
+  [ -d "$TEST_ROOT/wt-shipped" ]
+}
+
+@test "--yes removes a squash-merged worktree but keeps its branch" {
+  add_worktree shipped
+  stub_gh_merged shipped
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  assert_file_absent "$TEST_ROOT/wt-shipped"
+  git -C "$REPO" show-ref --verify --quiet refs/heads/shipped
+}
+
+@test "--delete-branches deletes the squash-merged branch too" {
+  add_worktree shipped
+  stub_gh_merged shipped
+
+  run "$GC" --base main --yes --delete-branches
+  [ "$status" -eq 0 ]
+  assert_file_absent "$TEST_ROOT/wt-shipped"
+  ! git -C "$REPO" show-ref --verify --quiet refs/heads/shipped
+}
+
+@test "an unmerged worktree is left alone" {
+  add_worktree shipped
+  add_worktree wip
+  stub_gh_merged shipped
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_ROOT/wt-wip" ]
+  [[ "$output" == *"1 worktree(s) on unmerged branches"* ]]
+}
+
+@test "uncommitted changes keep a merged worktree" {
+  add_worktree shipped
+  stub_gh_merged shipped
+  echo dirty >"$TEST_ROOT/wt-shipped/scratch"
+  git -C "$TEST_ROOT/wt-shipped" add scratch
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_ROOT/wt-shipped" ]
+  [[ "$output" == *"uncommitted changes"* ]]
+}
+
+@test "a locked worktree is kept unless --include-locked" {
+  add_worktree shipped
+  stub_gh_merged shipped
+  git -C "$REPO" worktree lock "$TEST_ROOT/wt-shipped"
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_ROOT/wt-shipped" ]
+  [[ "$output" == *locked* ]]
+
+  # The first run left it locked and untouched; --include-locked unlocks it.
+  run "$GC" --base main --yes --include-locked
+  [ "$status" -eq 0 ]
+  assert_file_absent "$TEST_ROOT/wt-shipped"
+}
+
+@test "ancestry-merged branches are found without gh" {
+  git -C "$REPO" worktree add -q -b landed "$TEST_ROOT/wt-landed" main
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  assert_file_absent "$TEST_ROOT/wt-landed"
+}
+
+@test "a missing gh warns that squash merges are invisible" {
+  add_worktree shipped
+  # gh sits in /usr/bin beside git, so the only way to hide it is a PATH built
+  # from the handful of binaries this script and bats actually need.
+  mkdir -p "$TEST_ROOT/minbin"
+  for tool in env bash sh git rm; do
+    ln -s "$(command -v "$tool")" "$TEST_ROOT/minbin/$tool"
+  done
+  PATH="$TEST_ROOT/minbin"
+
+  run "$GC" --base main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh not found"* ]]
+  [ -d "$TEST_ROOT/wt-shipped" ]
+}
+
+@test "a failing gh falls back to ancestry rather than reporting a clean sweep" {
+  add_worktree shipped
+  stub_command gh "echo 'no git remotes found' >&2; exit 1"
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"continuing on ancestry alone"* ]]
+  [ -d "$TEST_ROOT/wt-shipped" ]
+}
+
+@test "the main worktree is never a candidate" {
+  stub_gh_merged main
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  [ -d "$REPO" ]
+  [[ "$output" == *"Nothing to remove"* ]]
+}
+
+@test "a bad base ref fails loudly" {
+  run "$GC" --base no-such-branch
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"does not exist"* ]]
+}

--- a/tests/git_worktree_gc.bats
+++ b/tests/git_worktree_gc.bats
@@ -6,6 +6,9 @@ setup() {
   setup_dotfiles_test
   GC="$REPO_ROOT/bin/git-worktree-gc"
   REPO="$TEST_ROOT/repo"
+  # Captured before any git stub is installed, so pass-through stubs can reach
+  # the real binary rather than recursing into themselves.
+  REAL_GIT=$(command -v git)
 
   git init -q -b main "$REPO"
   git -C "$REPO" config user.email test@example.com
@@ -29,8 +32,24 @@ add_worktree() {
   git -C "$TEST_ROOT/wt-$name" commit -q -m "$name"
 }
 
+# A gh stub that honors --base, so tests can prove the base filter is passed
+# and respected. Args: <base-the-PRs-landed-in> <branch>...
+stub_gh_merged_into() {
+  local base="$1"
+  shift
+  stub_command gh "
+base=''
+while [ \$# -gt 0 ]; do
+  [ \"\$1\" = '--base' ] && base=\$2
+  shift
+done
+[ \"\$base\" = '$base' ] || exit 0
+printf '%s\n' $(printf "'%s' " "$@")
+"
+}
+
 stub_gh_merged() {
-  stub_command gh "printf '%s\n' $(printf "'%s' " "$@")"
+  stub_gh_merged_into main "$@"
 }
 
 @test "dry run reports a squash-merged worktree without removing it" {
@@ -150,4 +169,65 @@ stub_gh_merged() {
   run "$GC" --base no-such-branch
   [ "$status" -eq 1 ]
   [[ "$output" == *"does not exist"* ]]
+}
+
+@test "a PR merged into a different base is not treated as landed" {
+  add_worktree shipped
+  # Merged, but into a release branch — nothing to do with main.
+  stub_gh_merged_into release shipped
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_ROOT/wt-shipped" ]
+  [[ "$output" == *"1 worktree(s) on unmerged branches"* ]]
+}
+
+@test "an origin-prefixed base still reaches gh as a branch name" {
+  add_worktree shipped
+  stub_gh_merged_into main shipped
+  git -C "$REPO" update-ref refs/remotes/origin/main "$(git -C "$REPO" rev-parse main)"
+
+  run "$GC" --base origin/main --yes
+  [ "$status" -eq 0 ]
+  assert_file_absent "$TEST_ROOT/wt-shipped"
+}
+
+# Forces the exact race the removal path guards: the worktree is clean when the
+# plan checks it, and dirty by the time `git worktree remove` runs. Only this
+# early refusal leaves the worktree registered — a later failure (an
+# undeletable directory) deregisters it first, so nothing remains to re-lock.
+stub_git_dirties_before_remove() {
+  stub_command git "
+if [ \"\$1\" = 'worktree' ] && [ \"\$2\" = 'remove' ]; then
+  echo raced >\"\$3/raced-untracked\"
+fi
+exec $REAL_GIT \"\$@\"
+"
+}
+
+@test "a failed removal re-locks the worktree with its original reason" {
+  add_worktree shipped
+  stub_gh_merged shipped
+  git -C "$REPO" worktree lock --reason "held for review" "$TEST_ROOT/wt-shipped"
+  stub_git_dirties_before_remove
+
+  run "$GC" --base main --yes --include-locked
+  [ "$status" -eq 1 ]
+  [ -d "$TEST_ROOT/wt-shipped" ]
+  [[ "$output" == *"could not remove"* ]]
+
+  run git -C "$REPO" worktree list --porcelain
+  [[ "$output" == *"locked held for review"* ]]
+}
+
+@test "a failed removal of an unlocked worktree leaves it unlocked" {
+  add_worktree shipped
+  stub_gh_merged shipped
+  stub_git_dirties_before_remove
+
+  run "$GC" --base main --yes
+  [ "$status" -eq 1 ]
+
+  run git -C "$REPO" worktree list --porcelain
+  [[ "$output" != *locked* ]]
 }


### PR DESCRIPTION
Adds `bin/git-worktree-gc`, which lists linked worktrees whose branch is merged and, with `--yes`, removes them. Extensionless in `bin/`, so Git resolves it as a subcommand: `git worktree-gc`.

## Why two merge sources

Detection reads `git branch --merged` **and** `gh pr list --state merged`. In a squash-merge repo the branch tip is never an ancestor of the base ref, so ancestry alone reports shipped branches as unmerged — a false clean result that is worse than no tool at all. On a 66-worktree checkout, ancestry found 1 merged branch; the PR source found the other 55.

If `gh` is missing or fails, the script warns and continues on ancestry rather than silently reporting a clean sweep. It also warns when it hits `--pr-limit`, since stopping early looks identical to "nothing older was merged".

## Safety

Dry run is the default. Never removed, regardless of flags: the main worktree, the current one, detached HEADs, and anything with uncommitted changes. There is no `--force`.

Two behaviors the implementation forced:

- `git worktree remove` refuses a locked worktree outright, and the escape hatch it offers is `--force` twice — which would also override the dirty check. `--include-locked` runs `git worktree unlock` first instead, so the flag means only "ignore the lock", never "discard work".
- `git branch -d` refuses exactly the branches this reaps, since a squash-merged branch is not an ancestor of the base ref. `--delete-branches` uses `-D`, which is safe only because nothing reaches that line without merge evidence from ancestry or a merged PR. Commented at the call site.

## Verification

- `bats tests` — 747 passing, 0 failing (`BATS_EXIT=0`), including 11 new cases in `tests/git_worktree_gc.bats`: dry run, apply, branch deletion, dirty kept, locked kept then unlocked, ancestry-only, missing `gh`, failing `gh`, main worktree never a candidate, bad base ref.
- `bash -n`, `shellcheck -x -S warning -e SC1091`, `shfmt -d -i 2 -ci` via `bin/list-check-files` — clean.
- `python3 -m unittest discover -s tests/python` — `Ran 8 tests / OK`.
- `bin/validate-ai` — `Errors: 0  Warnings: 0`.

`make check` was not runnable in the authoring shell (`make` not on PATH), so its four sub-targets were run directly; CI runs the real target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to identify worktrees associated with merged branches and optionally remove them.
  * Defaults to dry-run mode and supports configurable base references, merged pull request detection, and optional branch deletion.
  * Safely handles locked, dirty, detached, missing, and unmerged worktrees, with safeguards against removing the current or primary worktree.

* **Documentation**
  * Added usage guidance and behavior details for the worktree cleanup utility.

* **Tests**
  * Added coverage for cleanup scenarios, safety exclusions, merge detection, failures, and invalid configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->