### PR TITLE
feat(git): route git and gh by remote owner for multiple GitHub identities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ docs/superpowers/*
 !docs/superpowers/specs/*.md
 platforms/macos/brewfile.lock.json
 core/git/gitconfig.local.symlink
+# Machine-local secondary GitHub identity (name, email, signing key). The
+# tracked template is core/git/gitconfig.guarzo.symlink.example.
+core/git/gitconfig.guarzo.symlink
 .dotfiles-profile
 .opencode/
 ai/codex/projects.local.toml

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ from scripts, editors, and AI tool shells, not just interactive zsh. It
 refuses to run rather than guess when a repository has remotes under two
 different mapped owners.
 
+`GH_CONFIG_DIR` also partitions **non-repo** `gh` state, not just
+credentials: inside a secondary-identity repository, `gh extension list` and
+similar commands see that identity's config dir. `gh` extensions installed
+under the default identity are not visible there and must be installed again
+per identity.
+
 `bin/git-identity` is the diagnostic: run it inside a repository to see which
 owner/identity applies and whether it's usable (provisioned, token valid,
 transport supported). It's the fastest way to check "why is this behaving
@@ -117,9 +123,18 @@ bypassed or the repo's local config drifted.
 - **Mixed-owner repositories** (remotes under two different mapped owners,
   e.g. a fork with `origin` under one owner and `upstream` under another).
   `hasconfig` matches any configured remote, not the push target, so this
-  can't be routed unambiguously. `bin/gh` refuses to run and the pre-push
-  guard blocks the push; use an explicit `GH_CONFIG_DIR` (and `GH_REPO` if
-  needed) instead.
+  can't be routed unambiguously. `bin/gh` refuses to run in either direction.
+  The pre-push guard is narrower: it only blocks pushing to the *default*
+  owner from a repo whose effective identity resolves to the secondary (the
+  fork case) -- pushing to the secondary owner is allowed, since routing
+  correctly resolved to that identity. Use an explicit `GH_CONFIG_DIR` (and
+  `GH_REPO` if needed) instead.
+- **Owner casing.** GitHub owner names are case-insensitive, but git's own
+  `includeIf hasconfig:` matching is not, so a differently-cased clone (e.g.
+  `Guarzo/repo`) won't pick up the include -- the repo's effective identity
+  stays the default. `bin/gh` and the pre-push guard still fold case when
+  resolving the destination owner, so they recognise the mismatch and refuse
+  rather than silently pushing under the wrong account.
 
 **Manual provisioning steps** (also driven interactively by `bin/bootstrap`'s
 secondary-identity prompt, which fills in the template but does not run

--- a/README.md
+++ b/README.md
@@ -64,32 +64,82 @@ self-guard with `[[ -z "$WORK_PROFILE" ]] && return` to prevent accidental loadi
 
 ## Multiple GitHub Accounts
 
-If this repo needs to use a different GitHub account than your default, use an SSH host alias.
+Repositories are routed to a GitHub identity by **remote owner**, not by
+per-repo configuration you have to remember to set. `core/git/identity-owners`
+is a tracked, non-secret map of `owner slug`:
 
-**1. Generate a key for the second account**
-```bash
-ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519_work
 ```
-Add `~/.ssh/id_ed25519_work.pub` to that GitHub account under Settings → SSH keys.
-
-**2. Add a host alias to `~/.ssh/config`**
-```
-Host github-work
-    HostName github.com
-    User git
-    IdentityFile ~/.ssh/id_ed25519_work
+gambtho default
+guarzo  guarzo
 ```
 
-**3. Update the repo remote to use the alias**
-```bash
-git remote set-url origin git@github-work:gambtho/dotfiles.git
-```
+The `default` slug means "use the stock `~/.config/gh` and `~/.gitconfig.local`
+— nothing extra to provision." Any other slug (`guarzo`) requires two
+machine-local files that this map alone does not create:
+`~/.gitconfig.<slug>` and a `~/.gh-<slug>` config directory. That split is
+deliberate: the map says which owners this machine *knows about*, independent
+of whether they are actually set up, so tooling can tell "unmapped and
+unrelated" apart from "known identity but not provisioned."
 
-**Verify:**
-```bash
-ssh -T git@github-work
-# Hi gambtho! You've successfully authenticated...
-```
+**How routing works.** `core/git/gitconfig.symlink` carries an
+`includeIf "hasconfig:remote.*.url:..."` block per non-default owner, pulling
+in `~/.gitconfig.guarzo` only for repositories with a matching remote. That
+include path is gitignored and machine-local — the tracked template lives at
+`core/git/gitconfig.guarzo.symlink.example`. Copy it to
+`core/git/gitconfig.guarzo.symlink` (relinked to `~/.gitconfig.guarzo`) and
+fill in the real name, email, and signing key.
+
+`bin/gh` is a PATH shim (installed ahead of the real `gh`, see the symlink
+table below) that resolves the current repository's remote owner and exports
+`GH_CONFIG_DIR` before exec'ing the real binary — so `gh` behaves correctly
+from scripts, editors, and AI tool shells, not just interactive zsh. It
+refuses to run rather than guess when a repository has remotes under two
+different mapped owners.
+
+`bin/git-identity` is the diagnostic: run it inside a repository to see which
+owner/identity applies and whether it's usable (provisioned, token valid,
+transport supported). It's the fastest way to check "why is this behaving
+oddly" and is what both `bin/gh` and the pre-push guard point you at on
+failure.
+
+A global `pre-push` hook (`core/git/git-hooks.symlink/pre-push`) double-checks
+before every push: if the destination owner resolves to a provisioned
+identity, it blocks the push when the effective `user.email` or
+`user.signingKey` doesn't match what that identity expects. This is the last
+line of defense against pushing under the wrong account even if `bin/gh` was
+bypassed or the repo's local config drifted.
+
+**Unsupported and detected, not silently mishandled:**
+- **SSH remotes** for a routed identity. Git never invokes a credential
+  helper over SSH, and `user.signingKey` doesn't select an SSH auth key, so
+  SSH remotes bypass this whole mechanism. `bin/git-identity` reports
+  `UNSUPPORTED` and tells you to re-point the remote at its `https://` URL.
+- **Mixed-owner repositories** (remotes under two different mapped owners,
+  e.g. a fork with `origin` under one owner and `upstream` under another).
+  `hasconfig` matches any configured remote, not the push target, so this
+  can't be routed unambiguously. `bin/gh` refuses to run and the pre-push
+  guard blocks the push; use an explicit `GH_CONFIG_DIR` (and `GH_REPO` if
+  needed) instead.
+
+**Manual provisioning steps** (also driven interactively by `bin/bootstrap`'s
+secondary-identity prompt, which fills in the template but does not run
+either of these for you):
+
+1. Authenticate `gh` into the identity's own config directory, with the
+   scopes this design's credential helper needs:
+   ```bash
+   GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth login --scopes repo,workflow
+   ```
+2. Generate an SSH key registered on the second GitHub account **as a signing
+   key** (Settings → SSH and GPG keys → New SSH key → key type "Signing Key"),
+   then add it to `~/.ssh/allowed_signers` so local `git log --show-signature`
+   and `git verify-commit` can verify it:
+   ```bash
+   ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519_guarzo
+   echo "you@example.com $(cat ~/.ssh/id_ed25519_guarzo.pub)" >> ~/.ssh/allowed_signers
+   ```
+   Point `signingKey` in `~/.gitconfig.guarzo` at the **absolute path** to the
+   `.pub` file — git does not expand `~` for this setting on every platform.
 
 ## Routine Updates
 
@@ -161,6 +211,8 @@ compatible minor in `config/versions.env` by hand.
 | `~/.zshrc` | `core/shell/zshrc.symlink` |
 | `~/.gitconfig` | `core/git/gitconfig.symlink` |
 | `~/.gitconfig.local` | `core/git/gitconfig.local.symlink` (machine-local, gitignored) |
+| `~/.gitconfig.guarzo` | `core/git/gitconfig.guarzo.symlink` (machine-local, gitignored — see [Multiple GitHub Accounts](#multiple-github-accounts)) |
+| `~/.bash_profile` | `core/shell/bash_profile.symlink` |
 | `~/.config/mise/config.toml` | `config/mise/config.toml` |
 | `~/.config/nvim` | `config/nvim/` |
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -134,9 +134,27 @@ setup_secondary_identity() {
     return 0
   fi
 
-  sed -e "s|YOUR_ACCOUNT_NAME|$name|" \
-    -e "s|you@example.com|$email|" \
-    -e "s|/home/YOUR_USER/.ssh/id_ed25519_guarzo.pub|$keypath|" \
+  # git does not expand ~ for user.signingKey on every platform, so a relative
+  # or tilde path silently yields an unusable signing configuration. Reject it
+  # before writing anything rather than producing a file that looks provisioned.
+  case "$keypath" in
+    /*) : ;;
+    *)
+      log_warning "Signing key path must be absolute; leaving the secondary identity unconfigured."
+      return 0
+      ;;
+  esac
+
+  # Escape the sed replacement metacharacters (\ & and the | delimiter) so an
+  # answer containing them substitutes literally instead of corrupting the file.
+  local esc_name esc_email esc_keypath
+  esc_name=$(printf '%s' "$name" | sed -e 's/[\\&|]/\\&/g')
+  esc_email=$(printf '%s' "$email" | sed -e 's/[\\&|]/\\&/g')
+  esc_keypath=$(printf '%s' "$keypath" | sed -e 's/[\\&|]/\\&/g')
+
+  sed -e "s|YOUR_ACCOUNT_NAME|$esc_name|" \
+    -e "s|you@example.com|$esc_email|" \
+    -e "s|/home/YOUR_USER/.ssh/id_ed25519_guarzo.pub|$esc_keypath|" \
     "$template" >"$target"
 
   log_success "Secondary identity written to $target"

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -152,10 +152,32 @@ setup_secondary_identity() {
   esc_email=$(printf '%s' "$email" | sed -e 's/[\\&|]/\\&/g')
   esc_keypath=$(printf '%s' "$keypath" | sed -e 's/[\\&|]/\\&/g')
 
-  sed -e "s|YOUR_ACCOUNT_NAME|$esc_name|" \
+  # Render to a temporary file beside the target and rename only on success. A
+  # plain redirect truncates $target before sed runs, so a failed write would
+  # leave a partial file -- and a partial file is worse than none here: this
+  # function early-returns when the target exists, and the pre-push guard treats
+  # mere existence as "provisioned", so the breakage would surface at push time.
+  # Every failure path here warns and returns 0, like the incomplete-answer and
+  # relative-path paths above. bootstrap runs under `set -e` and calls this
+  # bare, so a non-zero return would abort the run before ensure_stable_link_root
+  # and install_dotfiles -- failing an OPTIONAL secondary identity would leave
+  # the machine with no dotfiles symlinks at all. Leaving the identity absent is
+  # already the safe outcome: the pre-push guard then treats it as unprovisioned
+  # and blocks loudly.
+  local temp
+  if ! temp="$(mktemp "$DOTFILES_ROOT/core/git/.gitconfig.guarzo.XXXXXX")"; then
+    log_warning "Could not create a temporary file; leaving the secondary identity unconfigured."
+    return 0
+  fi
+
+  if ! sed -e "s|YOUR_ACCOUNT_NAME|$esc_name|" \
     -e "s|you@example.com|$esc_email|" \
     -e "s|/home/YOUR_USER/.ssh/id_ed25519_guarzo.pub|$esc_keypath|" \
-    "$template" >"$target"
+    "$template" >"$temp" || ! mv "$temp" "$target"; then
+    rm -f "$temp"
+    log_warning "Failed to render the secondary identity; leaving it unconfigured."
+    return 0
+  fi
 
   log_success "Secondary identity written to $target"
   log_info "Next: GH_CONFIG_DIR=\$HOME/.gh-guarzo gh auth login"

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -92,6 +92,57 @@ setup_gitconfig() {
   fi
 }
 
+# Optional secondary GitHub identity (see core/git/identity-owners).
+#
+# --non-interactive NEVER prompts and NEVER partially creates this file, the
+# same contract bootstrap already enforces for the primary identity. A
+# half-populated identity file is worse than none: it looks provisioned to the
+# pre-push guard and then fails at push time.
+setup_secondary_identity() {
+  local template="$DOTFILES_ROOT/core/git/gitconfig.guarzo.symlink.example"
+  local target="$DOTFILES_ROOT/core/git/gitconfig.guarzo.symlink"
+  local name email keypath reply
+
+  [ -f "$template" ] || return 0
+
+  if [ -f "$target" ]; then
+    log_info "Secondary GitHub identity already configured."
+    return 0
+  fi
+
+  if [ "${NON_INTERACTIVE:-false}" = true ]; then
+    log_info "Skipping optional secondary GitHub identity (non-interactive)."
+    return 0
+  fi
+
+  printf 'Configure a secondary GitHub identity? [y/N] '
+  read -r reply
+  case "$reply" in
+    [Yy]*) : ;;
+    *) return 0 ;;
+  esac
+
+  printf 'Account name: '
+  read -r name
+  printf 'Account email: '
+  read -r email
+  printf 'Absolute path to its SSH signing public key: '
+  read -r keypath
+
+  if [ -z "$name" ] || [ -z "$email" ] || [ -z "$keypath" ]; then
+    log_warning "Incomplete answers; leaving the secondary identity unconfigured."
+    return 0
+  fi
+
+  sed -e "s|YOUR_ACCOUNT_NAME|$name|" \
+    -e "s|you@example.com|$email|" \
+    -e "s|/home/YOUR_USER/.ssh/id_ed25519_guarzo.pub|$keypath|" \
+    "$template" >"$target"
+
+  log_success "Secondary identity written to $target"
+  log_info "Next: GH_CONFIG_DIR=\$HOME/.gh-guarzo gh auth login"
+}
+
 setup_profile() {
   if [[ -n "$BOOTSTRAP_PROFILE" ]]; then
     printf '%s\n' "$BOOTSTRAP_PROFILE" >"$HOME/.dotfiles-profile"
@@ -317,6 +368,7 @@ main() {
   esac
 
   setup_gitconfig
+  setup_secondary_identity
   setup_profile
   # $HOME/.dotfiles, not $DOTFILES_ROOT: the latter is wherever this script was
   # run from, which may be a disposable linked worktree. The stable root must

--- a/bin/gh
+++ b/bin/gh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# PATH shim routing `gh` to the identity owning the current repository's
+# remote. A shell function would reach only interactive zsh; scripts, editors,
+# Codex, and Claude Code's bash tool would all silently use the default
+# account -- the exact disagreement this design exists to prevent.
+#
+# BASH 3.2 ONLY: macOS ships bash 3.2, and tests/portability.bats rejects
+# Bash-4-only array builtins anywhere under bin/ -- including in comments,
+# since it matches the bare word. Keep that word out of this file.
+set -uo pipefail
+
+IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
+# shellcheck source=/dev/null
+. "$IDENTITY_DOTFILES_ROOT/core/git/identity-lib.sh"
+
+# Resolve through symlinks. Comparing raw paths fails to recognise this script
+# when invoked through a link, and the exec below then re-enters this file
+# forever.
+identity_realpath() {
+  local target="$1" dir base
+  if readlink -f / >/dev/null 2>&1; then
+    readlink -f "$target"
+    return
+  fi
+  dir="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || return 1
+  base="$(basename "$target")"
+  while [ -L "$dir/$base" ]; do
+    target="$(readlink "$dir/$base")"
+    case "$target" in
+      /*) : ;;
+      *) target="$dir/$target" ;;
+    esac
+    dir="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || return 1
+    base="$(basename "$target")"
+  done
+  printf '%s/%s\n' "$dir" "$base"
+}
+
+find_real_gh() {
+  local self entry candidate rest="$PATH"
+  self="$(identity_realpath "${BASH_SOURCE[0]}")"
+  while [ -n "$rest" ]; do
+    entry="${rest%%:*}"
+    if [ "$entry" = "$rest" ]; then
+      rest=""
+    else
+      rest="${rest#*:}"
+    fi
+    [ -n "$entry" ] || continue
+    candidate="$entry/gh"
+    [ -x "$candidate" ] || continue
+    [ "$(identity_realpath "$candidate")" = "$self" ] && continue
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  return 1
+}
+
+real_gh="$(find_real_gh)" || {
+  printf 'gh: no real gh found on PATH\n' >&2
+  exit 127
+}
+
+# An explicit GH_CONFIG_DIR means the caller has already chosen. Never
+# second-guess it -- it is the documented escape hatch for mixed-owner repos.
+if [ -n "${GH_CONFIG_DIR:-}" ]; then
+  exec "$real_gh" "$@"
+fi
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exec "$real_gh" "$@"
+
+# Inside a git repository, an unusable map is a hard error. Falling through
+# would silently use the default account for a repo that may not be its.
+if ! identity_validate_map; then
+  printf 'gh: refusing to run -- the owner map is unusable (see above).\n' >&2
+  exit 5
+fi
+
+owners=""
+owner_count=0
+while IFS= read -r owner; do
+  [ -n "$owner" ] || continue
+  owners="$owners $owner"
+  owner_count=$((owner_count + 1))
+done < <(identity_repo_owners)
+
+if [ "$owner_count" -eq 0 ]; then
+  exec "$real_gh" "$@"
+fi
+
+if [ "$owner_count" -gt 1 ]; then
+  printf 'gh: refusing to run -- remotes under mixed mapped identities:%s\n' "$owners" >&2
+  printf 'gh: re-run with an explicit GH_CONFIG_DIR (and GH_REPO if needed).\n' >&2
+  exit 3
+fi
+
+owner="${owners# }"
+slug="$(identity_owner_slug "$owner")"
+
+if [ "$slug" = default ]; then
+  exec "$real_gh" "$@"
+fi
+
+if ! identity_slug_provisioned "$slug"; then
+  printf 'gh: identity "%s" is mapped but not provisioned.\n' "$slug" >&2
+  printf 'gh: expected %s and %s.\n' \
+    "$(identity_slug_configfile "$slug")" "$(identity_slug_configdir "$slug")" >&2
+  printf 'gh: run bin/git-identity for the remaining steps.\n' >&2
+  exit 4
+fi
+
+GH_CONFIG_DIR="$(identity_slug_configdir "$slug")"
+export GH_CONFIG_DIR
+exec "$real_gh" "$@"

--- a/bin/gh
+++ b/bin/gh
@@ -10,8 +10,20 @@
 set -uo pipefail
 
 IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
+IDENTITY_LIB="$IDENTITY_DOTFILES_ROOT/core/git/identity-lib.sh"
+
+# Fail closed but readably. Without the library we cannot resolve an owner to
+# an identity, and guessing is exactly what this design forbids -- but a moved
+# or broken $DOTFILES checkout must not turn every `gh` invocation on the
+# machine, including in unrelated repositories, into raw bash "no such file"
+# errors.
+if [ ! -r "$IDENTITY_LIB" ]; then
+  printf 'gh: refusing to run -- identity library not found: %s\n' "$IDENTITY_LIB" >&2
+  printf 'gh: cannot route identities without it.\n' >&2
+  exit 5
+fi
 # shellcheck source=/dev/null
-. "$IDENTITY_DOTFILES_ROOT/core/git/identity-lib.sh"
+. "$IDENTITY_LIB"
 
 # Resolve through symlinks. Comparing raw paths fails to recognise this script
 # when invoked through a link, and the exec below then re-enters this file

--- a/bin/git-identity
+++ b/bin/git-identity
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Report which GitHub identity applies to the current repository and whether it
+# is usable. Every failure mode in this design is silent -- a missing include,
+# an unmapped remote, an expired token all present as "you are quietly the
+# default identity" -- so this turns that into one line.
+#
+# BASH 3.2 ONLY (see core/git/identity-lib.sh).
+set -uo pipefail
+
+IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
+# shellcheck source=/dev/null
+. "$IDENTITY_DOTFILES_ROOT/core/git/identity-lib.sh"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  printf 'not inside a git repository\n'
+  exit 0
+fi
+
+identity_validate_map || exit 1
+
+owners=""
+owner_count=0
+while IFS= read -r o; do
+  [ -n "$o" ] || continue
+  owners="$owners $o"
+  owner_count=$((owner_count + 1))
+done < <(identity_repo_owners)
+
+if [ "$owner_count" -eq 0 ]; then
+  printf 'owner:    <unmapped>\nidentity: default (stock gh config)\n'
+  exit 0
+fi
+
+if [ "$owner_count" -gt 1 ]; then
+  printf 'owner:   %s\n' "$owners"
+  printf 'identity: MIXED -- this repository is not routed.\n'
+  printf 'Use an explicit GH_CONFIG_DIR, or remove one remote.\n'
+  exit 2
+fi
+
+owner="${owners# }"
+slug="$(identity_owner_slug "$owner")"
+printf 'owner:    %s\nidentity: %s\n' "$owner" "$slug"
+
+if [ "$slug" = default ]; then
+  printf 'email:    %s\n' "$(git config user.email 2>/dev/null || echo '<unset>')"
+  exit 0
+fi
+
+if ! identity_slug_provisioned "$slug"; then
+  printf 'status:   NOT PROVISIONED\n'
+  [ -e "$(identity_slug_configfile "$slug")" ] ||
+    printf '  missing: %s\n' "$(identity_slug_configfile "$slug")"
+  [ -d "$(identity_slug_configdir "$slug")" ] ||
+    printf '  missing: %s\n' "$(identity_slug_configdir "$slug")"
+  exit 3
+fi
+
+configdir="$(identity_slug_configdir "$slug")"
+printf 'email:    %s\n' "$(git config user.email 2>/dev/null || echo '<unset>')"
+printf 'key:      %s\n' "$(git config user.signingKey 2>/dev/null || echo '<unset>')"
+printf 'ghconfig: %s\n' "$configdir"
+
+# SSH transport is deliberately unsupported: git never invokes a credential
+# helper for it, and user.signingKey does not select an authentication key.
+while IFS= read -r url; do
+  case "$url" in
+    https://*) continue ;;
+  esac
+  if [ "$(identity_url_owner "$url" 2>/dev/null || true)" = "$owner" ]; then
+    printf 'status:   UNSUPPORTED -- SSH remote for a routed identity (%s)\n' "$url"
+    printf 'Re-point the remote at its https:// URL.\n'
+    exit 5
+  fi
+done < <(git config --get-regexp '^remote\..*\.url$' 2>/dev/null | cut -d' ' -f2-)
+
+if ! GH_CONFIG_DIR="$configdir" gh auth status >/dev/null 2>&1; then
+  printf 'status:   TOKEN INVALID OR MISSING\n'
+  printf 'Run: GH_CONFIG_DIR=%s gh auth login\n' "$configdir"
+  exit 4
+fi
+
+printf 'status:   OK\n'

--- a/core/git/git-hooks.symlink/pre-push
+++ b/core/git/git-hooks.symlink/pre-push
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Global pre-push hook: identity guard, then the stock git-lfs hook.
 #
 # ORDER IS LOAD-BEARING. `git lfs pre-push` runs LAST because its exit status

--- a/core/git/git-hooks.symlink/pre-push
+++ b/core/git/git-hooks.symlink/pre-push
@@ -1,13 +1,102 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# Global pre-push hook: identity guard, then the stock git-lfs hook.
+#
+# ORDER IS LOAD-BEARING. `git lfs pre-push` runs LAST because its exit status
+# is the hook's exit status; running it first and appending the guard would let
+# a passing guard mask a failed LFS upload and push refs whose objects never
+# uploaded.
+#
+# This hook must never read stdin: git feeds ref updates there and
+# `git lfs pre-push` consumes them. The guard uses only $1 and $2.
+#
+# FAIL-OPEN BOUNDARY. core.hooksPath is global, so this runs for every repo on
+# the machine. It exits 0 silently for anything outside its remit -- non-github
+# hosts and unmapped owners. Once the destination is a mapped owner, every
+# uncertainty blocks instead.
+
+remote_url="${2:-}"
+
+identity_guard() {
+  local url="$1"
+  local root owner dest eff exp_email exp_key eff_email eff_key
+
+  [ -n "$url" ] || return 0
+
+  root="${DOTFILES:-$HOME/.dotfiles}"
+  [ -r "$root/core/git/identity-lib.sh" ] || return 0
+  # shellcheck source=/dev/null
+  . "$root/core/git/identity-lib.sh"
+
+  owner="$(identity_url_owner "$url")" || return 0
+
+  # Past this point the destination is on github.com. An unusable map can no
+  # longer be shrugged off: a dropped entry would demote a known owner to
+  # "unmapped" and convert a blocked push into a wrong-identity push.
+  if ! identity_validate_map; then
+    printf 'pre-push: BLOCKED -- the owner map is unusable (see above).\n' >&2
+    return 1
+  fi
+
+  dest="$(identity_owner_slug "$owner")" || return 0
+
+  if [ "$dest" != default ]; then
+    if ! identity_slug_provisioned "$dest"; then
+      printf 'pre-push: BLOCKED -- pushing to %s but identity "%s" is not provisioned.\n' "$owner" "$dest" >&2
+      printf 'pre-push: expected %s and %s. Run bin/git-identity.\n' \
+        "$(identity_slug_configfile "$dest")" "$(identity_slug_configdir "$dest")" >&2
+      return 1
+    fi
+
+    exp_email="$(identity_slug_email "$dest" 2>/dev/null || true)"
+    exp_key="$(identity_slug_key "$dest" 2>/dev/null || true)"
+    eff_email="$(git config user.email 2>/dev/null || true)"
+    eff_key="$(git config user.signingKey 2>/dev/null || true)"
+
+    if [ -z "$exp_email" ] || [ -z "$eff_email" ]; then
+      printf 'pre-push: BLOCKED -- cannot determine the identity for %s.\n' "$owner" >&2
+      return 1
+    fi
+    if [ "$exp_email" != "$eff_email" ]; then
+      printf 'pre-push: BLOCKED -- pushing to %s as %s, but identity "%s" is %s.\n' \
+        "$owner" "$eff_email" "$dest" "$exp_email" >&2
+      return 1
+    fi
+    if [ -n "$exp_key" ] && [ "$exp_key" != "$eff_key" ]; then
+      printf 'pre-push: BLOCKED -- signing key %s does not match identity "%s" (%s).\n' \
+        "${eff_key:-<unset>}" "$dest" "$exp_key" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  # Default destination. Block only when the effective identity positively
+  # matches ANOTHER provisioned identity -- that is the fork case (origin=
+  # default owner, upstream=secondary, routing resolved to the secondary).
+  # A merely unusual per-repo email matches nothing and is left alone.
+  eff="$(identity_effective_slug)"
+  if [ -n "$eff" ] && [ "$eff" != default ]; then
+    if identity_slug_provisioned "$eff"; then
+      printf 'pre-push: BLOCKED -- pushing to %s, but this repository resolves to identity "%s".\n' \
+        "$owner" "$eff" >&2
+      printf 'pre-push: a repository with remotes under two mapped owners is not routed; see bin/git-identity.\n' >&2
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+identity_guard "$remote_url" || exit 1
+
 # Stock git-lfs hook, adapted for a GLOBAL core.hooksPath. git-lfs writes these
 # per-repo, where a missing binary really is an error worth `exit 2`. The
 # dotfiles point core.hooksPath here for EVERY repo, so that exit code turns any
-# machine without git-lfs into one where clone and checkout fail outright —
+# machine without git-lfs into one where clone and checkout fail outright --
 # including the repos that never touched LFS. Devcontainer images are the common
 # case: it breaks lazy.nvim's plugin clones with an error naming LFS, not the
 # container. Warn and step aside instead. A genuine LFS repo still checks out,
 # just with pointer files, which is the best available outcome without the
-# binary — and far better than no checkout at all.
+# binary -- and far better than no checkout at all.
 command -v git-lfs >/dev/null 2>&1 || {
   printf >&2 '%s\n' "git-lfs not found - skipping 'git lfs pre-push'; any LFS files are left as pointers."
   exit 0

--- a/core/git/gitconfig.guarzo.symlink.example
+++ b/core/git/gitconfig.guarzo.symlink.example
@@ -1,0 +1,12 @@
+# Copy to core/git/gitconfig.guarzo.symlink and fill in. That file is
+# gitignored; this template is tracked and must never hold real values.
+#
+# signingKey must be an ABSOLUTE path -- git does not expand ~ for this key on
+# every platform.
+[user]
+	name = YOUR_ACCOUNT_NAME
+	email = you@example.com
+	signingKey = /home/YOUR_USER/.ssh/id_ed25519_guarzo.pub
+[credential "https://github.com"]
+	helper =
+	helper = !GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth git-credential

--- a/core/git/gitconfig.local.symlink.example
+++ b/core/git/gitconfig.local.symlink.example
@@ -1,6 +1,9 @@
 [user]
-	name = YOUR_NAME
-	email = you@example.com
+	# AUTHORNAME and AUTHOREMAIL are substituted by setup_gitconfig in
+	# bin/bootstrap. They must stay exactly these tokens: any other placeholder
+	# is copied through literally and every commit is authored as it.
+	name = AUTHORNAME
+	email = AUTHOREMAIL
 	# signingkey = YOUR_GPG_KEY_ID
 # [commit]
 #	gpgsign = true

--- a/core/git/gitconfig.local.symlink.example
+++ b/core/git/gitconfig.local.symlink.example
@@ -1,6 +1,6 @@
 [user]
-	name = Tom
-	email = Guaro.Eve@gmail.com
+	name = YOUR_NAME
+	email = you@example.com
 	# signingkey = YOUR_GPG_KEY_ID
 # [commit]
 #	gpgsign = true

--- a/core/git/gitconfig.symlink
+++ b/core/git/gitconfig.symlink
@@ -39,8 +39,19 @@
 [coderabbit]
 	machineId = cli/5bd04c69e8d44ee38277024221b4b453
 [credential "https://github.com"]
-	helper = 
-	helper = !/usr/bin/gh auth git-credential
+	helper =
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
-	helper = 
-	helper = !/usr/bin/gh auth git-credential
+	helper =
+	helper = !gh auth git-credential
+
+# Secondary GitHub identity, routed by remote owner per
+# core/git/identity-owners. The include path is gitignored and machine-local,
+# so this block is inert where it has not been provisioned -- git silently
+# ignores a missing include file.
+#
+# hasconfig matches ANY configured remote, not the push target, so a repo with
+# remotes under two mapped owners resolves ambiguously. That case is not
+# routed: the pre-push guard blocks it and bin/gh refuses to run.
+[includeIf "hasconfig:remote.*.url:https://github.com/guarzo/**"]
+	path = ~/.gitconfig.guarzo

--- a/core/git/identity-lib.sh
+++ b/core/git/identity-lib.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Shared owner -> identity resolution for bin/gh, bin/git-identity, and the
+# pre-push guard. Sourced, never executed.
+#
+# BASH 3.2 ONLY: macOS ships bash 3.2. No associative arrays, and none of the
+# Bash-4-only array-reading builtins.
+#
+# Three states, and conflating any two reintroduces a silent wrong-identity
+# path:
+#   unmapped   owner absent from the map   -> out of remit
+#   default    owner maps to the default   -> stock gh config
+#   secondary  maps to another slug        -> may be UNPROVISIONED
+
+IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
+IDENTITY_MAP_FILE="${IDENTITY_MAP_FILE:-$IDENTITY_DOTFILES_ROOT/core/git/identity-owners}"
+
+# Print the owner for a github.com URL. Exit 1 for any other host or
+# unparseable input; callers treat that as "out of remit".
+identity_url_owner() {
+  local url="$1" rest host path
+
+  case "$url" in
+    https://* | http://*)
+      rest="${url#*://}"
+      rest="${rest#*@}"
+      host="${rest%%/*}"
+      path="${rest#*/}"
+      ;;
+    ssh://*)
+      rest="${url#ssh://}"
+      rest="${rest#*@}"
+      host="${rest%%/*}"
+      path="${rest#*/}"
+      ;;
+    *@*:*)
+      rest="${url#*@}"
+      host="${rest%%:*}"
+      path="${rest#*:}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  host="${host%%:*}"
+  [ "$host" = "github.com" ] || return 1
+
+  path="${path#/}"
+  case "$path" in
+    */*) : ;;
+    *) return 1 ;;
+  esac
+
+  printf '%s\n' "${path%%/*}"
+}
+
+# Validate the map. A malformed or duplicated entry is a hard error, never a
+# skipped line: a dropped entry demotes a known owner to "unmapped" and turns a
+# blocked push into a silent wrong-identity push.
+identity_validate_map() {
+  local file="${1:-$IDENTITY_MAP_FILE}"
+  local line owner slug extra rest lineno=0 seen=""
+
+  if [ ! -r "$file" ]; then
+    printf 'identity: owner map not readable: %s\n' "$file" >&2
+    return 1
+  fi
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    line="${line%%#*}"
+    # Split explicitly rather than relying on unquoted expansion, so the
+    # behaviour is identical under `sh`-like IFS settings.
+    IFS=$' \t' read -r owner slug extra rest <<<"$line"
+    [ -n "$owner" ] || continue
+
+    if [ -z "$slug" ] || [ -n "$extra" ]; then
+      printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+      return 1
+    fi
+    case "$owner" in
+      [A-Za-z0-9]*) : ;;
+      *)
+        printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+        return 1
+        ;;
+    esac
+    case "$slug" in
+      [a-z0-9]*) : ;;
+      *)
+        printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+        return 1
+        ;;
+    esac
+    case " $seen " in
+      *" $owner "*)
+        printf 'identity: duplicate owner %s at %s:%d\n' "$owner" "$file" "$lineno" >&2
+        return 1
+        ;;
+    esac
+    seen="$seen $owner"
+  done <"$file"
+
+  return 0
+}
+
+identity_owner_slug() {
+  local owner="$1" file="${2:-$IDENTITY_MAP_FILE}"
+  local line o s extra rest
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"
+    IFS=$' \t' read -r o s extra rest <<<"$line"
+    [ -n "$o" ] || continue
+    if [ "$o" = "$owner" ]; then
+      printf '%s\n' "$s"
+      return 0
+    fi
+  done <"$file"
+
+  return 1
+}
+
+# shellcheck disable=SC2120  # callers may pass a map path; the default is used internally
+identity_slugs() {
+  local file="${1:-$IDENTITY_MAP_FILE}"
+  local line o s extra rest
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"
+    IFS=$' \t' read -r o s extra rest <<<"$line"
+    [ -n "$s" ] || continue
+    printf '%s\n' "$s"
+  done <"$file" | sort -u
+}
+
+identity_slug_configdir() {
+  local slug="$1"
+  if [ "$slug" = default ]; then
+    printf '%s\n' "${GH_DEFAULT_CONFIG_DIR:-$HOME/.config/gh}"
+  else
+    printf '%s\n' "$HOME/.gh-$slug"
+  fi
+}
+
+identity_slug_configfile() {
+  local slug="$1"
+  if [ "$slug" = default ]; then
+    printf '%s\n' "$HOME/.gitconfig.local"
+  else
+    printf '%s\n' "$HOME/.gitconfig.$slug"
+  fi
+}
+
+# A secondary slug is provisioned only when BOTH its git include and its gh
+# config dir exist. Either alone is a half-configured identity, which looks
+# usable to a naive check and then fails at push time.
+identity_slug_provisioned() {
+  local slug="$1" dir
+  [ "$slug" = default ] && return 0
+  [ -e "$(identity_slug_configfile "$slug")" ] || return 1
+  dir="$(identity_slug_configdir "$slug")"
+  [ -d "$dir" ] || return 1
+  return 0
+}
+
+identity_slug_email() {
+  local file
+  file="$(identity_slug_configfile "$1")"
+  [ -r "$file" ] || return 1
+  git config --file "$file" user.email 2>/dev/null
+}
+
+identity_slug_key() {
+  local file
+  file="$(identity_slug_configfile "$1")"
+  [ -r "$file" ] || return 1
+  git config --file "$file" user.signingKey 2>/dev/null
+}
+
+# Distinct MAPPED owners across every remote. Unmapped owners are omitted, so
+# "guarzo + an unmapped work org" is not mixed-owner.
+identity_repo_owners() {
+  local url owner
+  git config --get-regexp '^remote\..*\.url$' 2>/dev/null |
+    cut -d' ' -f2- |
+    while IFS= read -r url; do
+      [ -n "$url" ] || continue
+      owner="$(identity_url_owner "$url")" || continue
+      identity_owner_slug "$owner" >/dev/null 2>&1 || continue
+      printf '%s\n' "$owner"
+    done | sort -u
+}
+
+# Which mapped slug does this repository's EFFECTIVE config actually match?
+# Compares author email and signing key -- the original incident had correct
+# emails and the wrong signing key in all three repositories, so email alone
+# does not identify an identity. Prints nothing when no slug matches.
+identity_effective_slug() {
+  local eff_email eff_key slug exp_email exp_key
+  eff_email="$(git config user.email 2>/dev/null || true)"
+  eff_key="$(git config user.signingKey 2>/dev/null || true)"
+  [ -n "$eff_email" ] || return 0
+
+  while IFS= read -r slug; do
+    [ -n "$slug" ] || continue
+    exp_email="$(identity_slug_email "$slug" 2>/dev/null || true)"
+    [ -n "$exp_email" ] || continue
+    [ "$exp_email" = "$eff_email" ] || continue
+    exp_key="$(identity_slug_key "$slug" 2>/dev/null || true)"
+    if [ -n "$exp_key" ] && [ -n "$eff_key" ] && [ "$exp_key" != "$eff_key" ]; then
+      continue
+    fi
+    printf '%s\n' "$slug"
+    return 0
+  done < <(identity_slugs)
+
+  return 0
+}

--- a/core/git/identity-lib.sh
+++ b/core/git/identity-lib.sh
@@ -108,6 +108,16 @@ identity_owner_slug() {
   local owner="$1" file="${2:-$IDENTITY_MAP_FILE}"
   local line o s extra rest
 
+  # GitHub owner names are case-insensitive (Guarzo/guarzo/GUARZO all resolve
+  # to the same account), but git's own `includeIf hasconfig:` matching is
+  # case-sensitive and cannot be fixed from here. Fold here, once, so every
+  # consumer -- bin/gh, bin/git-identity, the pre-push guard -- treats a
+  # differently-cased owner as the same mapped identity instead of silently
+  # falling through to "unmapped" and the default account. `tr` is used
+  # instead of `${owner,,}` because that expansion is bash-4-only and this
+  # file must run under bash 3.2 (macOS).
+  owner="$(printf '%s' "$owner" | tr '[:upper:]' '[:lower:]')"
+
   while IFS= read -r line || [ -n "$line" ]; do
     line="${line%%#*}"
     IFS=$' \t' read -r o s extra rest <<<"$line"

--- a/core/git/identity-lib.sh
+++ b/core/git/identity-lib.sh
@@ -78,17 +78,21 @@ identity_validate_map() {
       printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
       return 1
     fi
+    # Validate the WHOLE token, not just its first character. Owners must be
+    # canonical lowercase because identity_owner_slug folds the lookup key: an
+    # uppercase entry here would parse fine and then never match anything, which
+    # is a silent misconfiguration rather than a visible error.
     case "$owner" in
-      [A-Za-z0-9]*) : ;;
-      *)
-        printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+      -* | *[!a-z0-9-]*)
+        printf 'identity: owner must be lowercase [a-z0-9-] at %s:%d\n' "$file" "$lineno" >&2
         return 1
         ;;
     esac
+    # Slugs become path components in ~/.gitconfig.<slug> and ~/.gh-<slug>, so a
+    # separator or dot segment would escape the intended location.
     case "$slug" in
-      [a-z0-9]*) : ;;
-      *)
-        printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+      -* | *[!a-z0-9-]*)
+        printf 'identity: slug must be lowercase [a-z0-9-] at %s:%d\n' "$file" "$lineno" >&2
         return 1
         ;;
     esac

--- a/core/git/identity-owners
+++ b/core/git/identity-owners
@@ -1,0 +1,14 @@
+# GitHub owner -> identity slug.
+#
+# Tracked and non-secret on purpose: this file states which owners this machine
+# knows about INDEPENDENTLY of whether their identity files exist. That is what
+# lets consumers tell "unmapped and unrelated" (fail open) apart from "known
+# identity but not provisioned" (fail closed).
+#
+# The default slug uses the stock ~/.config/gh and ~/.gitconfig.local. Any other
+# slug requires ~/.gitconfig.<slug> and ~/.gh-<slug>.
+#
+# Adding an owner here also requires an includeIf block in gitconfig.symlink;
+# tests/git_identity.bats asserts the two agree as owner+slug pairs.
+gambtho default
+guarzo  guarzo

--- a/core/shell/bash_profile.symlink
+++ b/core/shell/bash_profile.symlink
@@ -1,0 +1,20 @@
+# ~/.bash_profile -- managed by dotfiles.
+#
+# Bash reads this INSTEAD of ~/.profile when it exists, so source ~/.profile
+# first to preserve whatever is already there (on a stock Debian/Ubuntu box
+# that means sourcing ~/.bashrc, adding ~/bin and ~/.local/bin, and loading the
+# Cargo environment).
+#
+# Then put the dotfiles bin directory ahead of /usr/local/bin so the bin/gh
+# identity shim wins over the real gh for bash login shells too -- without
+# this, only zsh and its descendants route gh by owner.
+
+if [ -f "$HOME/.profile" ]; then
+  . "$HOME/.profile"
+fi
+
+case ":$PATH:" in
+  *":$HOME/.dotfiles/bin:"*) ;;
+  *) PATH="$HOME/.dotfiles/bin:$PATH" ;;
+esac
+export PATH

--- a/docs/superpowers/plans/2026-08-05-multi-github-identity.md
+++ b/docs/superpowers/plans/2026-08-05-multi-github-identity.md
@@ -4,26 +4,29 @@
 
 **Goal:** Route git and `gh` to the correct GitHub account automatically, based on who owns the repository's remote, so one machine holds two identities with no global switching.
 
-**Architecture:** A tracked owner map (`core/git/identity-owners`) is the single source of truth for which GitHub owners this machine knows. A shared bash library resolves URL → owner → identity slug. Three consumers read it: a `git` conditional include routes config declaratively, a `bin/gh` PATH shim routes the CLI, and a `pre-push` guard blocks any push whose destination disagrees with the resolved identity. Machine-local identity values live in a gitignored file, so nothing personal is committed to this public repository.
+**Architecture:** A tracked owner map (`core/git/identity-owners`) is the single source of truth for which GitHub owners this machine knows. A shared bash library resolves URL → owner → identity slug, and derives an *identity fingerprint* (author email, signing key, credential routing) for each slug. Three consumers use it: a `git` conditional include routes config declaratively, a `bin/gh` PATH shim routes the CLI, and a `pre-push` guard blocks any push whose destination disagrees with the fingerprint actually in effect. Machine-local identity values live in a gitignored file, so nothing personal is committed to this public repository.
 
-**Tech Stack:** bash, git 2.36+ conditional includes (`includeIf hasconfig:`), GitHub CLI (`gh`), bats for tests, shellcheck + shfmt for lint.
+**Tech Stack:** bash 3.2-compatible shell, git 2.36+ conditional includes (`includeIf hasconfig:`), GitHub CLI (`gh`), bats, shellcheck + shfmt.
 
 **Spec:** `docs/superpowers/specs/2026-08-05-multi-github-identity-design.md` (approved at commit `e22a66a`).
 
 ## Global Constraints
 
-- **This repository is public.** No email addresses, key paths, or account-identifying values in tracked files. Placeholders only. `tests/repository_hygiene.bats` enforces this.
+- **This repository is public.** No email addresses, key paths, or account-identifying values in tracked files. Placeholders only.
+- **Bash 3.2 compatibility is mandatory for `bin/` and `core/`.** macOS ships bash 3.2, and `tests/portability.bats` **already fails any `mapfile` under `$REPO_ROOT/bin`**. Therefore: no `mapfile`, no `readarray`, no associative arrays (`declare -A` / `declare -gA`), no `${var^^}`. Indexed arrays and `arr+=()` are fine.
 - **Formatting:** all shell must pass `shfmt -d -i 2 -ci` and `shellcheck -x -S warning -e SC1091`. Run `make lint` before every commit.
-- **Global hooks must fail open outside their remit.** `core.hooksPath` is global; a hook that errors breaks every repository on the machine. See the existing comment in `core/git/git-hooks.symlink/pre-push`.
-- **The pre-push hook must preserve stdin.** Git feeds ref updates to `pre-push` on stdin, and `git lfs pre-push` consumes them. A guard that reads stdin starves LFS.
-- **The pre-push hook must preserve the exact `git lfs pre-push` exit status.** It runs last and its status is authoritative.
+- **Global hooks must fail open *outside their remit*.** `core.hooksPath` is global; a hook that errors breaks every repository on the machine. Fail-open applies only before the destination is known to be a mapped GitHub owner.
+- **Once the destination is a mapped GitHub owner, every uncertainty is fail-CLOSED.** This includes a malformed owner map. A dropped map entry silently demotes a known owner to "unmapped", converting a blocked operation into a wrong-identity operation — so map validation failure must be a hard error in every consumer, never a fallthrough.
+- **The pre-push hook must preserve stdin.** Git feeds ref updates there and `git lfs pre-push` consumes them. The guard reads only `$1` (remote name) and `$2` (remote URL).
+- **The pre-push hook must preserve the exact `git lfs pre-push` exit status.** It runs last; its status is authoritative.
+- **The guard verifies EVERY mapped destination, including `default`.** Checking only non-default destinations leaves the fork case — `origin`=gambtho, `upstream`=guarzo, routing resolved to guarzo — pushing to gambtho under the guarzo identity.
+- **Identity comparison covers more than email.** The original incident had correct local emails and the wrong signing key in all three repositories. The fingerprint is author email + signing key + credential routing.
 - **The `gh` shim must resolve symlinks when excluding itself** from the `PATH` scan, or it recurses when invoked through a link.
-- **The owner map must be validated, not silently accepted.** Malformed lines and duplicate owners are errors.
-- **The owner-map/include consistency test compares owner-and-slug PAIRS**, not slugs alone.
-- **Owner map semantics — three states, never two:** absent from map = *unmapped* (fail open); maps to `default` = default identity; maps to a secondary slug = requires `~/.gitconfig.<slug>` and `~/.gh-<slug>`, and if either is absent the state is *known but unprovisioned* (fail closed), never "unmapped".
+- **Owner map semantics — three states, never two:** absent = *unmapped* (fail open); `default` = default identity; any other slug requires `~/.gitconfig.<slug>` and `~/.gh-<slug>`, and if either is absent the state is *known but unprovisioned* (fail closed), never "unmapped".
+- **Repository work and machine migration are separate.** Tasks 1–9 change only tracked files and are verified with `DOTFILES` pointed at the worktree. Task 10 runs **after the branch is integrated into `~/.dotfiles`** and is the only task that mutates machine state. Never run `bin/relink` from the worktree — it would point `$HOME` symlinks at a disposable directory.
 - **Known-bad test baseline** (pre-existing on `main`, never attribute to this work): `tests/dev_commands.bats`, `tests/dev_config_merge.bats`, `tests/dev_install.bats`, `tests/dev_lifecycle.bats`, `tests/claude_compose_override.bats`. Every other suite must stay green.
-- **Test harness:** `load test_helper` then `setup_dotfiles_test`, which sets `HOME="$TEST_ROOT/home"`, `STUB_BIN`, and `PATH="$STUB_BIN:/usr/bin:/bin"`. `git` is `/usr/bin/git` so it remains available. Use `stub_command <name> <body>` for stubs.
-- **Root resolution:** all new scripts resolve the repo as `DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"`. Tests override `DOTFILES`.
+- **Test harness:** `load test_helper` then `setup_dotfiles_test`, which sets `HOME="$TEST_ROOT/home"`, `STUB_BIN`, and `PATH="$STUB_BIN:/usr/bin:/bin"`. `git` is `/usr/bin/git`. Use `stub_command <name> <body>`.
+- **Sourcing `bin/bootstrap` in tests requires `BOOTSTRAP_SOURCE_ONLY=1`** (`bin/bootstrap:331`), or the footer runs `main "$@"` — real OS prep, `sudo apt`, symlink installation. Follow `tests/install_orchestration.bats:136`.
 
 ---
 
@@ -32,18 +35,16 @@
 | File | Responsibility |
 | --- | --- |
 | `core/git/identity-owners` | Tracked owner→slug map. Data only. |
-| `core/git/identity-lib.sh` | Shared resolution: URL parsing, map load/validate, provisioning checks. Sourced, never executed. |
-| `core/git/gitconfig.symlink` | Conditional include + collapsed credential block. |
-| `core/git/gitconfig.guarzo.symlink.example` | Tracked template with placeholders. |
-| `core/git/gitconfig.guarzo.symlink` | Gitignored, machine-local identity values. Never tracked. |
-| `bin/gh` | PATH shim. Routes `GH_CONFIG_DIR`, refuses mixed-owner. |
+| `core/git/identity-lib.sh` | Shared resolution: URL parsing, map validation, fingerprints. Sourced, never executed. |
+| `core/git/gitconfig.symlink` | Conditional include + single credential block. |
+| `core/git/gitconfig.guarzo.symlink.example` | Tracked template, placeholders only. |
+| `core/git/gitconfig.guarzo.symlink` | Gitignored machine-local identity values. |
+| `bin/gh` | PATH shim. Routes `GH_CONFIG_DIR`, refuses mixed-owner and invalid maps. |
 | `bin/git-identity` | Doctor. Reports resolved identity and provisioning state. |
 | `core/git/git-hooks.symlink/pre-push` | Guard, composed before the existing LFS call. |
 | `core/shell/bash_profile.symlink` | Bash login `PATH` coverage, chained to `~/.profile`. |
-| `tests/git_identity.bats` | Library, routing, shim, guard, doctor tests. |
+| `tests/git_identity.bats` | Library, routing, shim, guard, doctor, bootstrap tests. |
 | `tests/repository_hygiene.bats` | Extended: no real addresses in tracked `.example` files. |
-
-Tasks 1–8 are ordered by dependency. Task 9 (adjacent fixes) and Task 10 (migration) are independent of each other but both depend on 1–8.
 
 ---
 
@@ -54,15 +55,17 @@ Tasks 1–8 are ordered by dependency. Task 9 (adjacent fixes) and Task 10 (migr
 - Create: `core/git/identity-lib.sh`
 - Test: `tests/git_identity.bats`
 
-**Interfaces:**
-- Consumes: nothing.
-- Produces, all sourced from `core/git/identity-lib.sh`:
-  - `identity_url_owner <url>` → prints `<owner>` on stdout for a github.com URL; exit 1 for any non-github.com URL or unparseable input.
-  - `identity_load_map [path]` → validates and loads the map into the associative array `IDENTITY_MAP`; exit 1 with a message on stderr for malformed or duplicate entries.
-  - `identity_owner_slug <owner>` → prints the slug; exit 1 if unmapped.
-  - `identity_slug_configdir <slug>` → prints the `gh` config dir (`$HOME/.config/gh` for `default`, `$HOME/.gh-<slug>` otherwise).
-  - `identity_slug_provisioned <slug>` → exit 0 if usable; exit 1 if a secondary slug is missing `~/.gitconfig.<slug>` or its `gh` config dir. `default` is always provisioned.
-  - `identity_repo_owners` → prints distinct **mapped** owners across all remotes of the current repo, one per line, sorted.
+**Interfaces produced** (all sourced from `core/git/identity-lib.sh`):
+- `identity_url_owner <url>` → prints owner for a github.com URL; exit 1 otherwise.
+- `identity_validate_map [file]` → exit 0 if well-formed; exit 1 with a message on stderr for malformed or duplicate entries.
+- `identity_owner_slug <owner> [file]` → prints slug; exit 1 if unmapped.
+- `identity_slugs [file]` → prints every distinct slug, one per line.
+- `identity_slug_configdir <slug>` → `$HOME/.config/gh` for `default`, else `$HOME/.gh-<slug>`.
+- `identity_slug_configfile <slug>` → `$HOME/.gitconfig.local` for `default`, else `$HOME/.gitconfig.<slug>`.
+- `identity_slug_provisioned <slug>` → exit 0 if usable; `default` always is.
+- `identity_slug_email <slug>` / `identity_slug_key <slug>` → expected values from that slug's config file.
+- `identity_repo_owners` → distinct **mapped** owners across all remotes, sorted.
+- `identity_effective_slug` → the slug whose fingerprint matches the repo's effective config, or empty.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -82,6 +85,7 @@ setup() {
 gambtho default
 guarzo  guarzo
 EOF
+  export IDENTITY_MAP_FILE="$MAP"
 }
 
 @test "identity_url_owner parses https, ssh, and scp-style github URLs" {
@@ -106,39 +110,37 @@ EOF
   [ "$status" -eq 1 ]
 }
 
-@test "identity_load_map rejects a duplicate owner" {
-  cat >"$MAP" <<'EOF'
-guarzo guarzo
-guarzo default
-EOF
-  run bash -c "source '$LIB'; identity_load_map '$MAP'"
+@test "identity_validate_map rejects duplicates and malformed lines" {
+  printf 'guarzo guarzo\nguarzo default\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
   [ "$status" -eq 1 ]
   [[ "$output" == *"duplicate owner"* ]]
-}
 
-@test "identity_load_map rejects a malformed line" {
-  cat >"$MAP" <<'EOF'
-guarzo
-EOF
-  run bash -c "source '$LIB'; identity_load_map '$MAP'"
+  printf 'guarzo\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"malformed"* ]]
+
+  printf 'a b c\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
   [ "$status" -eq 1 ]
   [[ "$output" == *"malformed"* ]]
 }
 
 @test "identity_owner_slug maps known owners and rejects unmapped ones" {
-  run bash -c "source '$LIB'; identity_load_map '$MAP'; identity_owner_slug guarzo"
+  run bash -c "source '$LIB'; identity_owner_slug guarzo '$MAP'"
   [ "$status" -eq 0 ]
   [ "$output" = "guarzo" ]
 
-  run bash -c "source '$LIB'; identity_load_map '$MAP'; identity_owner_slug gambtho"
+  run bash -c "source '$LIB'; identity_owner_slug gambtho '$MAP'"
   [ "$status" -eq 0 ]
   [ "$output" = "default" ]
 
-  run bash -c "source '$LIB'; identity_load_map '$MAP'; identity_owner_slug kubernetes-sigs"
+  run bash -c "source '$LIB'; identity_owner_slug kubernetes-sigs '$MAP'"
   [ "$status" -eq 1 ]
 }
 
-@test "identity_slug_provisioned distinguishes default, provisioned, and unprovisioned" {
+@test "identity_slug_provisioned distinguishes default, provisioned, unprovisioned" {
   run bash -c "source '$LIB'; identity_slug_provisioned default"
   [ "$status" -eq 0 ]
 
@@ -149,6 +151,11 @@ EOF
   mkdir -p "$HOME/.gh-guarzo"
   run bash -c "source '$LIB'; identity_slug_provisioned guarzo"
   [ "$status" -eq 0 ]
+}
+
+@test "library uses no bash-4-only constructs" {
+  run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$LIB"
+  [ "$status" -ne 0 ]
 }
 ```
 
@@ -164,13 +171,13 @@ Create `core/git/identity-owners`:
 ```
 # GitHub owner -> identity slug.
 #
-# Tracked and non-secret on purpose: this file must state which owners this
-# machine knows about INDEPENDENTLY of whether their identity files exist.
-# That is what lets consumers tell "unmapped and unrelated" (fail open) apart
-# from "known identity but not provisioned" (fail closed).
+# Tracked and non-secret on purpose: this file states which owners this machine
+# knows about INDEPENDENTLY of whether their identity files exist. That is what
+# lets consumers tell "unmapped and unrelated" (fail open) apart from "known
+# identity but not provisioned" (fail closed).
 #
-# The default slug uses the standard ~/.config/gh and ~/.gitconfig.local.
-# Any other slug requires ~/.gitconfig.<slug> and ~/.gh-<slug>.
+# The default slug uses the stock ~/.config/gh and ~/.gitconfig.local. Any other
+# slug requires ~/.gitconfig.<slug> and ~/.gh-<slug>.
 #
 # Adding an owner here also requires an includeIf block in gitconfig.symlink;
 # tests/git_identity.bats asserts the two agree as owner+slug pairs.
@@ -187,20 +194,20 @@ Create `core/git/identity-lib.sh`:
 # Shared owner -> identity resolution for bin/gh, bin/git-identity, and the
 # pre-push guard. Sourced, never executed.
 #
-# Every consumer shares these three states, and conflating any two of them
-# reintroduces a silent wrong-identity path:
-#   unmapped            owner absent from the map      -> out of remit
-#   default             owner maps to the default      -> stock gh config
-#   secondary           owner maps to another slug     -> may be UNPROVISIONED
+# BASH 3.2 ONLY: macOS ships bash 3.2. No associative arrays, and none of the
+# Bash-4-only array-reading builtins.
+#
+# Three states, and conflating any two reintroduces a silent wrong-identity
+# path:
+#   unmapped   owner absent from the map   -> out of remit
+#   default    owner maps to the default   -> stock gh config
+#   secondary  maps to another slug        -> may be UNPROVISIONED
 
 IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
 IDENTITY_MAP_FILE="${IDENTITY_MAP_FILE:-$IDENTITY_DOTFILES_ROOT/core/git/identity-owners}"
 
-declare -gA IDENTITY_MAP
-
-# Print the owner for a github.com URL. Exit 1 for any other host or for input
-# that does not parse -- callers treat that as "out of remit", so being strict
-# here is what keeps unrelated remotes on the fail-open path.
+# Print the owner for a github.com URL. Exit 1 for any other host or
+# unparseable input; callers treat that as "out of remit".
 identity_url_owner() {
   local url="$1" rest host path
 
@@ -239,14 +246,12 @@ identity_url_owner() {
   printf '%s\n' "${path%%/*}"
 }
 
-# Load and VALIDATE the owner map. A malformed or duplicated entry is an error,
-# never a silently skipped line: a dropped entry would demote a known owner to
-# "unmapped" and turn a blocked push into a silent wrong-identity push.
-identity_load_map() {
+# Validate the map. A malformed or duplicated entry is a hard error, never a
+# skipped line: a dropped entry demotes a known owner to "unmapped" and turns a
+# blocked push into a silent wrong-identity push.
+identity_validate_map() {
   local file="${1:-$IDENTITY_MAP_FILE}"
-  local line owner slug extra lineno=0
-
-  IDENTITY_MAP=()
+  local line owner slug extra rest lineno=0 seen=""
 
   if [ ! -r "$file" ]; then
     printf 'identity: owner map not readable: %s\n' "$file" >&2
@@ -256,14 +261,12 @@ identity_load_map() {
   while IFS= read -r line || [ -n "$line" ]; do
     lineno=$((lineno + 1))
     line="${line%%#*}"
-    # shellcheck disable=SC2086
-    set -- $line
-    [ "$#" -gt 0 ] || continue
-    owner="$1"
-    slug="${2:-}"
-    extra="${3:-}"
+    # Split explicitly rather than relying on unquoted expansion, so the
+    # behaviour is identical under `sh`-like IFS settings.
+    IFS=$' \t' read -r owner slug extra rest <<<"$line"
+    [ -n "$owner" ] || continue
 
-    if [ "$#" -ne 2 ] || [ -n "$extra" ]; then
+    if [ -z "$slug" ] || [ -n "$extra" ]; then
       printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
       return 1
     fi
@@ -281,21 +284,46 @@ identity_load_map() {
         return 1
         ;;
     esac
-    if [ -n "${IDENTITY_MAP[$owner]:-}" ]; then
-      printf 'identity: duplicate owner %s at %s:%d\n' "$owner" "$file" "$lineno" >&2
-      return 1
-    fi
-    IDENTITY_MAP["$owner"]="$slug"
+    case " $seen " in
+      *" $owner "*)
+        printf 'identity: duplicate owner %s at %s:%d\n' "$owner" "$file" "$lineno" >&2
+        return 1
+        ;;
+    esac
+    seen="$seen $owner"
   done <"$file"
 
   return 0
 }
 
 identity_owner_slug() {
-  local owner="$1"
-  local slug="${IDENTITY_MAP[$owner]:-}"
-  [ -n "$slug" ] || return 1
-  printf '%s\n' "$slug"
+  local owner="$1" file="${2:-$IDENTITY_MAP_FILE}"
+  local line o s extra rest
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"
+    IFS=$' \t' read -r o s extra rest <<<"$line"
+    [ -n "$o" ] || continue
+    if [ "$o" = "$owner" ]; then
+      printf '%s\n' "$s"
+      return 0
+    fi
+  done <"$file"
+
+  return 1
+}
+
+# shellcheck disable=SC2120  # callers may pass a map path; the default is used internally
+identity_slugs() {
+  local file="${1:-$IDENTITY_MAP_FILE}"
+  local line o s extra rest
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"
+    IFS=$' \t' read -r o s extra rest <<<"$line"
+    [ -n "$s" ] || continue
+    printf '%s\n' "$s"
+  done <"$file" | sort -u
 }
 
 identity_slug_configdir() {
@@ -307,61 +335,102 @@ identity_slug_configdir() {
   fi
 }
 
+identity_slug_configfile() {
+  local slug="$1"
+  if [ "$slug" = default ]; then
+    printf '%s\n' "$HOME/.gitconfig.local"
+  else
+    printf '%s\n' "$HOME/.gitconfig.$slug"
+  fi
+}
+
 # A secondary slug is provisioned only when BOTH its git include and its gh
 # config dir exist. Either alone is a half-configured identity, which looks
 # usable to a naive check and then fails at push time.
 identity_slug_provisioned() {
   local slug="$1" dir
   [ "$slug" = default ] && return 0
-  [ -e "$HOME/.gitconfig.$slug" ] || return 1
+  [ -e "$(identity_slug_configfile "$slug")" ] || return 1
   dir="$(identity_slug_configdir "$slug")"
   [ -d "$dir" ] || return 1
   return 0
 }
 
-# Distinct MAPPED owners across every remote of the current repo. Unmapped
-# owners are omitted, so "guarzo + an unmapped work org" is not mixed-owner.
+identity_slug_email() {
+  local file
+  file="$(identity_slug_configfile "$1")"
+  [ -r "$file" ] || return 1
+  git config --file "$file" user.email 2>/dev/null
+}
+
+identity_slug_key() {
+  local file
+  file="$(identity_slug_configfile "$1")"
+  [ -r "$file" ] || return 1
+  git config --file "$file" user.signingKey 2>/dev/null
+}
+
+# Distinct MAPPED owners across every remote. Unmapped owners are omitted, so
+# "guarzo + an unmapped work org" is not mixed-owner.
 identity_repo_owners() {
-  local url owner slug
-  while IFS= read -r url; do
-    [ -n "$url" ] || continue
-    owner="$(identity_url_owner "$url")" || continue
-    slug="$(identity_owner_slug "$owner")" || continue
-    printf '%s\n' "$owner"
-  done < <(git config --get-regexp '^remote\..*\.url$' 2>/dev/null | cut -d' ' -f2-) | sort -u
+  local url owner
+  git config --get-regexp '^remote\..*\.url$' 2>/dev/null |
+    cut -d' ' -f2- |
+    while IFS= read -r url; do
+      [ -n "$url" ] || continue
+      owner="$(identity_url_owner "$url")" || continue
+      identity_owner_slug "$owner" >/dev/null 2>&1 || continue
+      printf '%s\n' "$owner"
+    done | sort -u
+}
+
+# Which mapped slug does this repository's EFFECTIVE config actually match?
+# Compares author email and signing key -- the original incident had correct
+# emails and the wrong signing key in all three repositories, so email alone
+# does not identify an identity. Prints nothing when no slug matches.
+identity_effective_slug() {
+  local eff_email eff_key slug exp_email exp_key
+  eff_email="$(git config user.email 2>/dev/null || true)"
+  eff_key="$(git config user.signingKey 2>/dev/null || true)"
+  [ -n "$eff_email" ] || return 0
+
+  while IFS= read -r slug; do
+    [ -n "$slug" ] || continue
+    exp_email="$(identity_slug_email "$slug" 2>/dev/null || true)"
+    [ -n "$exp_email" ] || continue
+    [ "$exp_email" = "$eff_email" ] || continue
+    exp_key="$(identity_slug_key "$slug" 2>/dev/null || true)"
+    if [ -n "$exp_key" ] && [ -n "$eff_key" ] && [ "$exp_key" != "$eff_key" ]; then
+      continue
+    fi
+    printf '%s\n' "$slug"
+    return 0
+  done < <(identity_slugs)
+
+  return 0
 }
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
-
-Run: `bats tests/git_identity.bats`
-Expected: PASS, 6 tests.
-
-- [ ] **Step 6: Lint**
-
-Run: `make lint`
-Expected: clean.
-
-- [ ] **Step 7: Commit**
+- [ ] **Step 5: Run tests, lint, commit**
 
 ```bash
+bats tests/git_identity.bats
+make lint
 git add core/git/identity-owners core/git/identity-lib.sh tests/git_identity.bats
 git commit -m "feat(git): add tracked owner map and identity resolution library"
 ```
 
+Expected: 6 tests PASS, lint clean.
+
 ---
 
-### Task 2: Conditional include and collapsed credential block
+### Task 2: Conditional include and single credential block
 
 **Files:**
 - Modify: `core/git/gitconfig.symlink`
 - Test: `tests/git_identity.bats`
 
-**Interfaces:**
-- Consumes: `identity_load_map` from Task 1 (for the pair-consistency test).
-- Produces: `~/.gitconfig.guarzo` as the include path for slug `guarzo`.
-
-**Why this is riskiest:** collapsing the credential block changes credential resolution for *every* repository including work. Do it in its own commit and verify before anything else layers on top.
+**Scope note:** this task changes only the **tracked** file. The machine-local `~/.gitconfig.local` carries its own GitHub and Gist helper blocks; those are stripped in Task 10, which is the only task permitted to mutate machine state. Verification here is therefore about the tracked file, not the machine's effective config — the end-to-end assertion lives in Task 10 Step 4.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -374,9 +443,14 @@ Append to `tests/git_identity.bats`:
   [ "$output" -eq 1 ]
 }
 
+@test "tracked gitconfig pins no absolute gh path" {
+  run grep -n 'helper = !/.*gh auth git-credential' "$REPO_ROOT/core/git/gitconfig.symlink"
+  [ "$status" -ne 0 ]
+}
+
 @test "owner map and conditional includes agree as owner+slug pairs" {
-  # Compare PAIRS, not slugs: a test that only checked slugs would pass while
-  # an owner was wired to the wrong include.
+  # Compare PAIRS, not slugs: a slug-only check passes while an owner is wired
+  # to the wrong include.
   local config="$REPO_ROOT/core/git/gitconfig.symlink"
   local owner slug expected
   while read -r owner slug; do
@@ -403,11 +477,11 @@ Append to `tests/git_identity.bats`:
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `bats tests/git_identity.bats`
-Expected: FAIL — two credential blocks exist and no `includeIf` is present.
+Expected: FAIL — the file pins `/usr/bin/gh` and has no `includeIf`.
 
-- [ ] **Step 3: Collapse the duplicate credential block**
+- [ ] **Step 3: Replace the credential blocks**
 
-In `core/git/gitconfig.symlink`, delete this block entirely:
+In `core/git/gitconfig.symlink`, replace:
 
 ```
 [credential "https://github.com"]
@@ -418,8 +492,7 @@ In `core/git/gitconfig.symlink`, delete this block entirely:
 	helper = !/usr/bin/gh auth git-credential
 ```
 
-and replace it with one referencing `gh` by name so it resolves through `PATH`
-rather than pinning the older apt binary at `/usr/bin/gh`:
+with (referencing `gh` by name so it resolves through `PATH` instead of pinning the older apt binary):
 
 ```
 [credential "https://github.com"]
@@ -435,37 +508,28 @@ rather than pinning the older apt binary at `/usr/bin/gh`:
 Append to `core/git/gitconfig.symlink`:
 
 ```
-# Secondary GitHub identity. Routed by remote owner, per
+# Secondary GitHub identity, routed by remote owner per
 # core/git/identity-owners. The include path is gitignored and machine-local,
-# so this block is inert on a machine that has not provisioned it -- git
-# silently ignores a missing include file.
+# so this block is inert where it has not been provisioned -- git silently
+# ignores a missing include file.
 #
 # hasconfig matches ANY configured remote, not the push target, so a repo with
-# remotes owned by two mapped owners resolves ambiguously. That case is not
+# remotes under two mapped owners resolves ambiguously. That case is not
 # routed: the pre-push guard blocks it and bin/gh refuses to run.
 [includeIf "hasconfig:remote.*.url:https://github.com/guarzo/**"]
 	path = ~/.gitconfig.guarzo
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
-
-Run: `bats tests/git_identity.bats`
-Expected: PASS.
-
-- [ ] **Step 6: Verify credential resolution did not break**
-
-Run: `git config --get-all credential.https://github.com.helper`
-Expected: exactly one non-empty helper, `!gh auth git-credential`, preceded by the empty reset.
-
-Run: `git -C ~/workspace/headlamp ls-remote --exit-code origin HEAD >/dev/null && echo OK`
-Expected: `OK` — an unrelated repository still authenticates.
-
-- [ ] **Step 7: Commit**
+- [ ] **Step 5: Run tests, lint, commit**
 
 ```bash
+bats tests/git_identity.bats
+make lint
 git add core/git/gitconfig.symlink tests/git_identity.bats
-git commit -m "fix(git): collapse duplicate github credential block and route guarzo by owner"
+git commit -m "fix(git): unpin the gh credential helper and route guarzo by owner"
 ```
+
+Expected: PASS, lint clean.
 
 ---
 
@@ -475,10 +539,6 @@ git commit -m "fix(git): collapse duplicate github credential block and route gu
 - Create: `core/git/gitconfig.guarzo.symlink.example`
 - Modify: `.gitignore`
 - Test: `tests/git_identity.bats`
-
-**Interfaces:**
-- Consumes: nothing.
-- Produces: `core/git/gitconfig.guarzo.symlink` (gitignored, created at provisioning time by Task 8), linking to `~/.gitconfig.guarzo`.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -500,7 +560,7 @@ Append to `tests/git_identity.bats`:
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run to verify it fails**
 
 Run: `bats tests/git_identity.bats`
 Expected: FAIL — neither the ignore rule nor the template exists.
@@ -521,7 +581,7 @@ Create `core/git/gitconfig.guarzo.symlink.example`:
 
 ```
 # Copy to core/git/gitconfig.guarzo.symlink and fill in. That file is
-# gitignored; this template is tracked and must never contain real values.
+# gitignored; this template is tracked and must never hold real values.
 #
 # signingKey must be an ABSOLUTE path -- git does not expand ~ for this key on
 # every platform.
@@ -534,14 +594,10 @@ Create `core/git/gitconfig.guarzo.symlink.example`:
 	helper = !GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth git-credential
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
-
-Run: `bats tests/git_identity.bats`
-Expected: PASS.
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Run tests and commit**
 
 ```bash
+bats tests/git_identity.bats
 git add .gitignore core/git/gitconfig.guarzo.symlink.example tests/git_identity.bats
 git commit -m "feat(git): add gitignored secondary identity file and tracked template"
 ```
@@ -554,11 +610,9 @@ git commit -m "feat(git): add gitignored secondary identity file and tracked tem
 - Create: `bin/gh`
 - Test: `tests/git_identity.bats`
 
-**Interfaces:**
-- Consumes: `identity_load_map`, `identity_repo_owners`, `identity_owner_slug`, `identity_slug_configdir`, `identity_slug_provisioned` from Task 1.
-- Produces: nothing consumed by later tasks.
+**Interfaces consumed:** all Task 1 functions.
 
-**Recursion hazard:** the shim must exclude *itself* from the `PATH` scan by comparing fully resolved paths. Comparing raw paths fails when the shim is reached through a symlink, and it then execs itself forever.
+**Two hazards:** the shim must exclude *itself* from the `PATH` scan by comparing **resolved** paths, or it execs itself forever. And a map that fails validation must be a hard error once we know we are in a GitHub repository — falling through to the real `gh` would silently use the wrong account.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -573,16 +627,26 @@ setup_shim_repo() {
   mkdir -p "$DOTFILES/core/git"
   cp "$REPO_ROOT/core/git/identity-lib.sh" "$DOTFILES/core/git/"
   cp "$MAP" "$DOTFILES/core/git/identity-owners"
-  stub_command gh-real 'echo "real gh: GH_CONFIG_DIR=[${GH_CONFIG_DIR:-unset}] args=$*"'
+  unset IDENTITY_MAP_FILE
   mkdir -p "$STUB_BIN/real"
-  mv "$STUB_BIN/gh-real" "$STUB_BIN/real/gh"
+  printf '#!/usr/bin/env bash\necho "real gh: GH_CONFIG_DIR=[${GH_CONFIG_DIR:-unset}] args=$*"\n' \
+    >"$STUB_BIN/real/gh"
+  chmod +x "$STUB_BIN/real/gh"
   export PATH="$STUB_BIN:$STUB_BIN/real:/usr/bin:/bin"
+}
+
+provision_guarzo_files() {
+  cat >"$HOME/.gitconfig.guarzo" <<'EOF'
+[user]
+	email = guarzo@example.invalid
+	signingKey = /keys/guarzo.pub
+EOF
+  mkdir -p "$HOME/.gh-guarzo"
 }
 
 @test "shim routes a guarzo repo to the guarzo gh config dir" {
   setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
-  touch "$HOME/.gitconfig.guarzo"
-  mkdir -p "$HOME/.gh-guarzo"
+  provision_guarzo_files
   cd "$TEST_ROOT/r"
   run "$REPO_ROOT/bin/gh" pr list
   [ "$status" -eq 0 ]
@@ -612,14 +676,12 @@ setup_shim_repo() {
   run "$REPO_ROOT/bin/gh" pr merge
   [ "$status" -ne 0 ]
   [[ "$output" == *"mixed"* ]]
-  [[ "$output" == *"GH_CONFIG_DIR"* ]]
 }
 
 @test "shim does not treat a mapped owner plus an unmapped org as mixed" {
   setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
   git -C "$TEST_ROOT/r" remote add fork https://github.com/kubernetes-sigs/repo.git
-  touch "$HOME/.gitconfig.guarzo"
-  mkdir -p "$HOME/.gh-guarzo"
+  provision_guarzo_files
   cd "$TEST_ROOT/r"
   run "$REPO_ROOT/bin/gh" pr list
   [ "$status" -eq 0 ]
@@ -632,6 +694,15 @@ setup_shim_repo() {
   run "$REPO_ROOT/bin/gh" pr list
   [ "$status" -ne 0 ]
   [[ "$output" == *"not provisioned"* ]]
+}
+
+@test "shim refuses when the owner map is invalid" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  printf 'guarzo guarzo\nguarzo default\n' >"$DOTFILES/core/git/identity-owners"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"duplicate owner"* ]]
 }
 
 @test "shim passes through untouched when the caller set GH_CONFIG_DIR" {
@@ -651,9 +722,14 @@ setup_shim_repo() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"real gh"* ]]
 }
+
+@test "shim uses no bash-4-only constructs" {
+  run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$REPO_ROOT/bin/gh"
+  [ "$status" -ne 0 ]
+}
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run to verify it fails**
 
 Run: `bats tests/git_identity.bats`
 Expected: FAIL — `bin/gh` does not exist.
@@ -664,26 +740,29 @@ Create `bin/gh` (mode 0755):
 
 ```bash
 #!/usr/bin/env bash
-# PATH shim that routes `gh` to the identity owning the current repository's
+# PATH shim routing `gh` to the identity owning the current repository's
 # remote. A shell function would reach only interactive zsh; scripts, editors,
 # Codex, and Claude Code's bash tool would all silently use the default
-# account, which is the exact disagreement this design exists to prevent.
-set -euo pipefail
+# account -- the exact disagreement this design exists to prevent.
+#
+# BASH 3.2 ONLY: macOS ships bash 3.2, and tests/portability.bats rejects
+# Bash-4-only array builtins anywhere under bin/ -- including in comments,
+# since it matches the bare word. Keep that word out of this file.
+set -uo pipefail
 
 IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
 # shellcheck source=/dev/null
 . "$IDENTITY_DOTFILES_ROOT/core/git/identity-lib.sh"
 
-# Resolve a path through symlinks. Comparing raw paths would fail to recognise
-# this script when it is invoked through a link, and the exec below would then
-# re-enter this same file forever.
+# Resolve through symlinks. Comparing raw paths fails to recognise this script
+# when invoked through a link, and the exec below then re-enters this file
+# forever.
 identity_realpath() {
-  local target="$1"
-  if command -v readlink >/dev/null 2>&1 && readlink -f / >/dev/null 2>&1; then
+  local target="$1" dir base
+  if readlink -f / >/dev/null 2>&1; then
     readlink -f "$target"
     return
   fi
-  local dir base
   dir="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || return 1
   base="$(basename "$target")"
   while [ -L "$dir/$base" ]; do
@@ -699,11 +778,15 @@ identity_realpath() {
 }
 
 find_real_gh() {
-  local self entry candidate
-  local -a entries
+  local self entry candidate rest="$PATH"
   self="$(identity_realpath "${BASH_SOURCE[0]}")"
-  IFS=: read -r -a entries <<<"$PATH"
-  for entry in "${entries[@]}"; do
+  while [ -n "$rest" ]; do
+    entry="${rest%%:*}"
+    if [ "$entry" = "$rest" ]; then
+      rest=""
+    else
+      rest="${rest#*:}"
+    fi
     [ -n "$entry" ] || continue
     candidate="$entry/gh"
     [ -x "$candidate" ] || continue
@@ -720,29 +803,40 @@ real_gh="$(find_real_gh)" || {
 }
 
 # An explicit GH_CONFIG_DIR means the caller has already chosen. Never
-# second-guess it -- it is also the documented escape hatch for mixed-owner
-# repositories.
+# second-guess it -- it is the documented escape hatch for mixed-owner repos.
 if [ -n "${GH_CONFIG_DIR:-}" ]; then
   exec "$real_gh" "$@"
 fi
 
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exec "$real_gh" "$@"
 
-identity_load_map || exec "$real_gh" "$@"
+# Inside a git repository, an unusable map is a hard error. Falling through
+# would silently use the default account for a repo that may not be its.
+if ! identity_validate_map; then
+  printf 'gh: refusing to run -- the owner map is unusable (see above).\n' >&2
+  exit 5
+fi
 
-mapfile -t owners < <(identity_repo_owners)
+owners=""
+owner_count=0
+while IFS= read -r owner; do
+  [ -n "$owner" ] || continue
+  owners="$owners $owner"
+  owner_count=$((owner_count + 1))
+done < <(identity_repo_owners)
 
-if [ "${#owners[@]}" -eq 0 ]; then
+if [ "$owner_count" -eq 0 ]; then
   exec "$real_gh" "$@"
 fi
 
-if [ "${#owners[@]}" -gt 1 ]; then
-  printf 'gh: refusing to run -- this repository has remotes owned by mixed mapped identities: %s\n' "${owners[*]}" >&2
-  printf 'gh: re-run with an explicit GH_CONFIG_DIR (and GH_REPO if needed) to choose.\n' >&2
+if [ "$owner_count" -gt 1 ]; then
+  printf 'gh: refusing to run -- remotes under mixed mapped identities:%s\n' "$owners" >&2
+  printf 'gh: re-run with an explicit GH_CONFIG_DIR (and GH_REPO if needed).\n' >&2
   exit 3
 fi
 
-slug="$(identity_owner_slug "${owners[0]}")"
+owner="${owners# }"
+slug="$(identity_owner_slug "$owner")"
 
 if [ "$slug" = default ]; then
   exec "$real_gh" "$@"
@@ -750,7 +844,8 @@ fi
 
 if ! identity_slug_provisioned "$slug"; then
   printf 'gh: identity "%s" is mapped but not provisioned.\n' "$slug" >&2
-  printf 'gh: expected %s and %s.\n' "$HOME/.gitconfig.$slug" "$(identity_slug_configdir "$slug")" >&2
+  printf 'gh: expected %s and %s.\n' \
+    "$(identity_slug_configfile "$slug")" "$(identity_slug_configdir "$slug")" >&2
   printf 'gh: run bin/git-identity for the remaining steps.\n' >&2
   exit 4
 fi
@@ -760,26 +855,18 @@ export GH_CONFIG_DIR
 exec "$real_gh" "$@"
 ```
 
-- [ ] **Step 4: Make it executable and run the tests**
+- [ ] **Step 4: Make executable, test, lint, commit**
 
 ```bash
 chmod 755 bin/gh
 bats tests/git_identity.bats
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Lint**
-
-Run: `make lint`
-Expected: clean.
-
-- [ ] **Step 6: Commit**
-
-```bash
+bats tests/portability.bats
+make lint
 git add bin/gh tests/git_identity.bats
 git commit -m "feat(gh): route gh by remote owner with a recursion-safe PATH shim"
 ```
+
+Expected: PASS including `portability.bats` (no `mapfile` under `bin/`).
 
 ---
 
@@ -788,10 +875,6 @@ git commit -m "feat(gh): route gh by remote owner with a recursion-safe PATH shi
 **Files:**
 - Create: `core/shell/bash_profile.symlink`
 - Test: `tests/git_identity.bats`
-
-**Interfaces:**
-- Consumes: nothing.
-- Produces: `~/.bash_profile`, placing `~/.dotfiles/bin` ahead of `/usr/local/bin` for bash login shells.
 
 **Why not `profile.symlink`:** `link_file` in `bin/relink` uses `policy=skip` for any destination that is not already a symlink, and `bin/relink` then calls `log_error`, which exits. A `profile.symlink` would collide with the real `~/.profile` and abort relink for *every* managed dotfile. `~/.bash_profile` does not exist on this machine, so it links cleanly. Bash reads `.bash_profile` instead of `.profile` when present, so chaining preserves the existing file.
 
@@ -834,10 +917,10 @@ EOF
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run to verify it fails**
 
 Run: `bats tests/git_identity.bats`
-Expected: FAIL — `core/shell/bash_profile.symlink` does not exist.
+Expected: FAIL — the file does not exist.
 
 - [ ] **Step 3: Write the file**
 
@@ -848,8 +931,8 @@ Create `core/shell/bash_profile.symlink`:
 #
 # Bash reads this INSTEAD of ~/.profile when it exists, so source ~/.profile
 # first to preserve whatever is already there (on a stock Debian/Ubuntu box
-# that includes sourcing ~/.bashrc, adding ~/bin and ~/.local/bin, and loading
-# the Cargo environment).
+# that means sourcing ~/.bashrc, adding ~/bin and ~/.local/bin, and loading the
+# Cargo environment).
 #
 # Then put the dotfiles bin directory ahead of /usr/local/bin so the bin/gh
 # identity shim wins over the real gh for bash login shells too -- without
@@ -866,14 +949,10 @@ esac
 export PATH
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `bats tests/git_identity.bats`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Test and commit**
 
 ```bash
+bats tests/git_identity.bats
 git add core/shell/bash_profile.symlink tests/git_identity.bats
 git commit -m "feat(shell): add bash login profile chaining to ~/.profile for shim PATH"
 ```
@@ -886,98 +965,157 @@ git commit -m "feat(shell): add bash login profile chaining to ~/.profile for sh
 - Modify: `core/git/git-hooks.symlink/pre-push`
 - Test: `tests/git_identity.bats`
 
-**Interfaces:**
-- Consumes: Task 1 library.
-- Produces: nothing consumed by later tasks.
+**The rule, stated exactly.** For a push to a mapped owner, let `dest` be that owner's slug and `eff` be `identity_effective_slug` (the slug whose author email *and* signing key match the repository's effective config).
 
-**Three constraints that are easy to get wrong:**
-1. **stdin** — git feeds ref updates on stdin and `git lfs pre-push` consumes them. The guard must not read stdin at all; it uses only `$1` (remote name) and `$2` (remote URL).
-2. **exit status** — `git lfs pre-push "$@"` runs last so its status is the hook's status.
-3. **fail-open boundary** — open before the destination is known in remit, closed after.
+| `dest` | Condition | Result |
+| --- | --- | --- |
+| unmapped / non-github | any | allow, silent |
+| any | map invalid | **block** |
+| non-`default` | unprovisioned | **block** |
+| non-`default` | `eff` empty (indeterminate) | **block** |
+| non-`default` | `eff` != `dest` | **block** |
+| `default` | `eff` is another mapped, provisioned slug | **block** — the fork case |
+| `default` | `eff` empty or `default` | allow |
+| otherwise | | allow |
 
-"Resolved identity matches" is defined explicitly: the repository's effective `user.email` equals the `user.email` that the destination slug's include file sets. If either side is empty or unreadable, the identity is *indeterminate*, which is a fail-closed condition — not a pass.
+The `default` row is why the guard verifies *every* mapped destination. Checking only non-default destinations leaves `origin`=gambtho + `upstream`=guarzo pushing to gambtho under the guarzo identity — the exact case that motivated the guard. It blocks only when the effective identity *positively matches another identity*, so a legitimate per-repo email override on a gambtho repo is not a false positive.
 
 - [ ] **Step 1: Write the failing tests**
 
 Append to `tests/git_identity.bats`:
 
 ```bash
-setup_guard_repo() {
+setup_guard() {
   export DOTFILES="$TEST_ROOT/dotfiles"
   mkdir -p "$DOTFILES/core/git"
   cp "$REPO_ROOT/core/git/identity-lib.sh" "$DOTFILES/core/git/"
   cp "$MAP" "$DOTFILES/core/git/identity-owners"
+  unset IDENTITY_MAP_FILE
   HOOK="$REPO_ROOT/core/git/git-hooks.symlink/pre-push"
   GUARD_REPO="$TEST_ROOT/g"
   git init -q "$GUARD_REPO"
   stub_command git-lfs 'exit 0'
-  stub_command jq 'exit 0'
+  cat >"$HOME/.gitconfig.local" <<'EOF'
+[user]
+	email = default@example.invalid
+	signingKey = /keys/default.pub
+EOF
 }
 
 provision_guarzo() {
   cat >"$HOME/.gitconfig.guarzo" <<'EOF'
 [user]
 	email = guarzo@example.invalid
+	signingKey = /keys/guarzo.pub
 EOF
   mkdir -p "$HOME/.gh-guarzo"
 }
 
+be_guarzo() {
+  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  git -C "$GUARD_REPO" config user.signingKey /keys/guarzo.pub
+}
+
+be_default() {
+  git -C "$GUARD_REPO" config user.email default@example.invalid
+  git -C "$GUARD_REPO" config user.signingKey /keys/default.pub
+}
+
 @test "guard fails open for a non-github destination" {
-  setup_guard_repo
+  setup_guard
   cd "$GUARD_REPO"
   run "$HOOK" origin https://gitlab.com/guarzo/repo.git </dev/null
   [ "$status" -eq 0 ]
-  [ -z "$output" ]
 }
 
 @test "guard fails open for an unmapped owner" {
-  setup_guard_repo
+  setup_guard
   cd "$GUARD_REPO"
   run "$HOOK" origin https://github.com/kubernetes-sigs/repo.git </dev/null
   [ "$status" -eq 0 ]
-  [ -z "$output" ]
 }
 
 @test "guard blocks a guarzo push when the identity is unprovisioned" {
-  setup_guard_repo
+  setup_guard
   cd "$GUARD_REPO"
   run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
   [ "$status" -ne 0 ]
   [[ "$output" == *"not provisioned"* ]]
 }
 
-@test "guard blocks a guarzo push whose resolved identity disagrees" {
-  setup_guard_repo
+@test "guard blocks a guarzo push made under the default identity" {
+  setup_guard
   provision_guarzo
-  git -C "$GUARD_REPO" config user.email someone-else@example.invalid
+  be_default
   cd "$GUARD_REPO"
   run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
   [ "$status" -ne 0 ]
-  [[ "$output" == *"identity"* ]]
 }
 
-@test "guard allows a guarzo push whose resolved identity matches" {
-  setup_guard_repo
+@test "guard allows a guarzo push made under the guarzo identity" {
+  setup_guard
   provision_guarzo
-  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  be_guarzo
   cd "$GUARD_REPO"
   run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
   [ "$status" -eq 0 ]
 }
 
-@test "guard blocks a mapped destination when the identity is indeterminate" {
-  setup_guard_repo
+@test "guard blocks the fork case: pushing to gambtho as guarzo" {
+  # origin=gambtho, upstream=guarzo -- hasconfig resolves the repo to guarzo,
+  # and the push targets gambtho. This is the case the guard exists for.
+  setup_guard
   provision_guarzo
-  git -C "$GUARD_REPO" config --unset user.email || true
+  be_guarzo
+  git -C "$GUARD_REPO" remote add upstream https://github.com/guarzo/repo.git
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/gambtho/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"gambtho"* ]]
+}
+
+@test "guard allows a gambtho push made under the default identity" {
+  setup_guard
+  provision_guarzo
+  be_default
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/gambtho/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard allows a gambtho push with an unrelated per-repo email" {
+  # A legitimate override must not be a false positive: it matches no identity.
+  setup_guard
+  provision_guarzo
+  git -C "$GUARD_REPO" config user.email project-specific@example.invalid
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/gambtho/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard blocks a mapped destination when the identity is indeterminate" {
+  setup_guard
+  provision_guarzo
+  cd "$GUARD_REPO"
+  git config --unset user.email || true
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+}
+
+@test "guard blocks a github push when the owner map is invalid" {
+  setup_guard
+  provision_guarzo
+  be_guarzo
+  printf 'guarzo guarzo\nguarzo default\n' >"$DOTFILES/core/git/identity-owners"
   cd "$GUARD_REPO"
   run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
   [ "$status" -ne 0 ]
 }
 
 @test "composed hook preserves a non-zero git-lfs exit status" {
-  setup_guard_repo
+  setup_guard
   provision_guarzo
-  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  be_guarzo
   stub_command git-lfs 'exit 7'
   cd "$GUARD_REPO"
   run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
@@ -985,8 +1123,8 @@ EOF
 }
 
 @test "a rejecting guard never reaches git lfs pre-push" {
-  setup_guard_repo
-  stub_command git-lfs "echo LFS_RAN >>'$TEST_ROOT/lfs.log'; exit 0"
+  setup_guard
+  stub_command git-lfs "echo ran >>'$TEST_ROOT/lfs.log'; exit 0"
   cd "$GUARD_REPO"
   run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
   [ "$status" -ne 0 ]
@@ -994,22 +1132,22 @@ EOF
 }
 
 @test "guard leaves stdin intact for git lfs pre-push" {
-  setup_guard_repo
+  setup_guard
   provision_guarzo
-  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  be_guarzo
   stub_command git-lfs "cat >'$TEST_ROOT/lfs-stdin.txt'; exit 0"
   cd "$GUARD_REPO"
   printf 'refs/heads/main aaa refs/heads/main bbb\n' |
-    run "$HOOK" origin https://github.com/guarzo/repo.git
+    "$HOOK" origin https://github.com/guarzo/repo.git
   run cat "$TEST_ROOT/lfs-stdin.txt"
   [[ "$output" == *"refs/heads/main"* ]]
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run to verify it fails**
 
 Run: `bats tests/git_identity.bats`
-Expected: FAIL — the guard is not present.
+Expected: FAIL — no guard present.
 
 - [ ] **Step 3: Rewrite the hook**
 
@@ -1019,26 +1157,24 @@ Replace `core/git/git-hooks.symlink/pre-push` with:
 #!/usr/bin/env bash
 # Global pre-push hook: identity guard, then the stock git-lfs hook.
 #
-# ORDER IS LOAD-BEARING. `git lfs pre-push` must run LAST because its exit
-# status is the hook's exit status; running it first and appending the guard
-# would let a passing guard mask a failed LFS upload and push refs whose
-# objects never uploaded.
+# ORDER IS LOAD-BEARING. `git lfs pre-push` runs LAST because its exit status
+# is the hook's exit status; running it first and appending the guard would let
+# a passing guard mask a failed LFS upload and push refs whose objects never
+# uploaded.
 #
-# This hook must also never read stdin: git feeds ref updates there and
-# `git lfs pre-push` consumes them. The guard uses only $1 (remote name) and
-# $2 (remote URL).
+# This hook must never read stdin: git feeds ref updates there and
+# `git lfs pre-push` consumes them. The guard uses only $1 and $2.
 #
-# FAIL-OPEN BOUNDARY. core.hooksPath is global, so this hook runs for every
-# repository on the machine. It exits 0 silently for anything outside its
-# remit -- non-github.com hosts and unmapped owners. Once the destination is
-# known to belong to a mapped identity, "cannot verify" becomes a blocking
-# condition rather than a silent pass.
+# FAIL-OPEN BOUNDARY. core.hooksPath is global, so this runs for every repo on
+# the machine. It exits 0 silently for anything outside its remit -- non-github
+# hosts and unmapped owners. Once the destination is a mapped owner, every
+# uncertainty blocks instead.
 
 remote_url="${2:-}"
 
 identity_guard() {
   local url="$1"
-  local root owner slug expected actual
+  local root owner dest eff exp_email exp_key eff_email eff_key
 
   [ -n "$url" ] || return 0
 
@@ -1048,34 +1184,59 @@ identity_guard() {
   . "$root/core/git/identity-lib.sh"
 
   owner="$(identity_url_owner "$url")" || return 0
-  identity_load_map || return 0
-  slug="$(identity_owner_slug "$owner")" || return 0
 
-  # Past this point the destination is in remit: fail closed.
-  if [ "$slug" = default ]; then
+  # Past this point the destination is on github.com. An unusable map can no
+  # longer be shrugged off: a dropped entry would demote a known owner to
+  # "unmapped" and convert a blocked push into a wrong-identity push.
+  if ! identity_validate_map; then
+    printf 'pre-push: BLOCKED -- the owner map is unusable (see above).\n' >&2
+    return 1
+  fi
+
+  dest="$(identity_owner_slug "$owner")" || return 0
+
+  if [ "$dest" != default ]; then
+    if ! identity_slug_provisioned "$dest"; then
+      printf 'pre-push: BLOCKED -- pushing to %s but identity "%s" is not provisioned.\n' "$owner" "$dest" >&2
+      printf 'pre-push: expected %s and %s. Run bin/git-identity.\n' \
+        "$(identity_slug_configfile "$dest")" "$(identity_slug_configdir "$dest")" >&2
+      return 1
+    fi
+
+    exp_email="$(identity_slug_email "$dest" 2>/dev/null || true)"
+    exp_key="$(identity_slug_key "$dest" 2>/dev/null || true)"
+    eff_email="$(git config user.email 2>/dev/null || true)"
+    eff_key="$(git config user.signingKey 2>/dev/null || true)"
+
+    if [ -z "$exp_email" ] || [ -z "$eff_email" ]; then
+      printf 'pre-push: BLOCKED -- cannot determine the identity for %s.\n' "$owner" >&2
+      return 1
+    fi
+    if [ "$exp_email" != "$eff_email" ]; then
+      printf 'pre-push: BLOCKED -- pushing to %s as %s, but identity "%s" is %s.\n' \
+        "$owner" "$eff_email" "$dest" "$exp_email" >&2
+      return 1
+    fi
+    if [ -n "$exp_key" ] && [ "$exp_key" != "$eff_key" ]; then
+      printf 'pre-push: BLOCKED -- signing key %s does not match identity "%s" (%s).\n' \
+        "${eff_key:-<unset>}" "$dest" "$exp_key" >&2
+      return 1
+    fi
     return 0
   fi
 
-  if ! identity_slug_provisioned "$slug"; then
-    printf 'pre-push: BLOCKED -- pushing to %s but identity "%s" is not provisioned.\n' "$owner" "$slug" >&2
-    printf 'pre-push: expected %s and %s. Run bin/git-identity.\n' "$HOME/.gitconfig.$slug" "$(identity_slug_configdir "$slug")" >&2
-    return 1
-  fi
-
-  expected="$(git config --file "$HOME/.gitconfig.$slug" user.email 2>/dev/null || true)"
-  actual="$(git config user.email 2>/dev/null || true)"
-
-  if [ -z "$expected" ] || [ -z "$actual" ]; then
-    printf 'pre-push: BLOCKED -- cannot determine the identity for %s (expected=%s actual=%s).\n' \
-      "$owner" "${expected:-<empty>}" "${actual:-<empty>}" >&2
-    return 1
-  fi
-
-  if [ "$expected" != "$actual" ]; then
-    printf 'pre-push: BLOCKED -- pushing to %s as %s, but identity "%s" is %s.\n' \
-      "$owner" "$actual" "$slug" "$expected" >&2
-    printf 'pre-push: a repository with remotes under two mapped owners is not routed; see bin/git-identity.\n' >&2
-    return 1
+  # Default destination. Block only when the effective identity positively
+  # matches ANOTHER provisioned identity -- that is the fork case (origin=
+  # default owner, upstream=secondary, routing resolved to the secondary).
+  # A merely unusual per-repo email matches nothing and is left alone.
+  eff="$(identity_effective_slug)"
+  if [ -n "$eff" ] && [ "$eff" != default ]; then
+    if identity_slug_provisioned "$eff"; then
+      printf 'pre-push: BLOCKED -- pushing to %s, but this repository resolves to identity "%s".\n' \
+        "$owner" "$eff" >&2
+      printf 'pre-push: a repository with remotes under two mapped owners is not routed; see bin/git-identity.\n' >&2
+      return 1
+    fi
   fi
 
   return 0
@@ -1099,19 +1260,10 @@ command -v git-lfs >/dev/null 2>&1 || {
 git lfs pre-push "$@"
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `bats tests/git_identity.bats`
-Expected: PASS.
-
-- [ ] **Step 5: Verify the hook did not break unrelated repositories**
-
-Run: `git -C ~/workspace/headlamp push --dry-run origin HEAD 2>&1 | tail -3`
-Expected: normal dry-run output, no `pre-push: BLOCKED`.
-
-- [ ] **Step 6: Lint and commit**
+- [ ] **Step 4: Test, lint, commit**
 
 ```bash
+bats tests/git_identity.bats
 make lint
 git add core/git/git-hooks.symlink/pre-push tests/git_identity.bats
 git commit -m "feat(git): guard pushes against identity mismatch before the LFS hook"
@@ -1125,11 +1277,7 @@ git commit -m "feat(git): guard pushes against identity mismatch before the LFS 
 - Create: `bin/git-identity`
 - Test: `tests/git_identity.bats`
 
-**Interfaces:**
-- Consumes: Task 1 library.
-- Produces: nothing consumed by later tasks.
-
-Exit codes: `0` usable; `2` mixed-owner; `3` mapped but unprovisioned; `4` mapped and provisioned but the token is invalid; `5` guarzo SSH remote (unsupported transport). An unmapped owner is `0` — the default identity working as intended.
+Exit codes: `0` usable; `1` unusable owner map; `2` mixed-owner; `3` mapped but unprovisioned; `4` token invalid; `5` guarzo SSH remote.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1144,12 +1292,20 @@ Append to `tests/git_identity.bats`:
   [[ "$output" == *"default"* ]]
 }
 
+@test "doctor exits 1 on an invalid owner map" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  printf 'guarzo guarzo\nguarzo default\n' >"$DOTFILES/core/git/identity-owners"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 1 ]
+}
+
 @test "doctor exits 3 for a mapped but unprovisioned identity" {
   setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
   cd "$TEST_ROOT/r"
   run "$REPO_ROOT/bin/git-identity"
   [ "$status" -eq 3 ]
-  [[ "$output" == *"not provisioned"* ]]
+  [[ "$output" == *"NOT PROVISIONED"* ]]
 }
 
 @test "doctor exits 2 for a mixed-owner repository" {
@@ -1158,13 +1314,12 @@ Append to `tests/git_identity.bats`:
   cd "$TEST_ROOT/r"
   run "$REPO_ROOT/bin/git-identity"
   [ "$status" -eq 2 ]
-  [[ "$output" == *"mixed"* ]]
+  [[ "$output" == *"MIXED"* ]]
 }
 
 @test "doctor exits 5 for a guarzo ssh remote" {
   setup_shim_repo "$TEST_ROOT/r" git@github.com:guarzo/repo.git
-  touch "$HOME/.gitconfig.guarzo"
-  mkdir -p "$HOME/.gh-guarzo"
+  provision_guarzo_files
   cd "$TEST_ROOT/r"
   run "$REPO_ROOT/bin/git-identity"
   [ "$status" -eq 5 ]
@@ -1173,18 +1328,22 @@ Append to `tests/git_identity.bats`:
 
 @test "doctor exits 4 when the token is invalid" {
   setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
-  touch "$HOME/.gitconfig.guarzo"
-  mkdir -p "$HOME/.gh-guarzo"
+  provision_guarzo_files
   rm -f "$STUB_BIN/real/gh"
   stub_command gh 'echo "token invalid" >&2; exit 1'
   cd "$TEST_ROOT/r"
   run "$REPO_ROOT/bin/git-identity"
   [ "$status" -eq 4 ]
-  [[ "$output" == *"token"* ]]
+  [[ "$output" == *"TOKEN"* ]]
+}
+
+@test "doctor uses no bash-4-only constructs" {
+  run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$REPO_ROOT/bin/git-identity"
+  [ "$status" -ne 0 ]
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run to verify it fails**
 
 Run: `bats tests/git_identity.bats`
 Expected: FAIL — `bin/git-identity` does not exist.
@@ -1195,10 +1354,12 @@ Create `bin/git-identity` (mode 0755):
 
 ```bash
 #!/usr/bin/env bash
-# Report which GitHub identity applies to the current repository, and whether
-# it is actually usable. Every failure mode in this design is silent -- a
-# missing include, an unmapped remote, an expired token all present as "you are
-# quietly the default identity" -- so this turns that into one line.
+# Report which GitHub identity applies to the current repository and whether it
+# is usable. Every failure mode in this design is silent -- a missing include,
+# an unmapped remote, an expired token all present as "you are quietly the
+# default identity" -- so this turns that into one line.
+#
+# BASH 3.2 ONLY (see core/git/identity-lib.sh).
 set -uo pipefail
 
 IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
@@ -1210,25 +1371,29 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 0
 fi
 
-if ! identity_load_map; then
-  exit 1
-fi
+identity_validate_map || exit 1
 
-mapfile -t owners < <(identity_repo_owners)
+owners=""
+owner_count=0
+while IFS= read -r o; do
+  [ -n "$o" ] || continue
+  owners="$owners $o"
+  owner_count=$((owner_count + 1))
+done < <(identity_repo_owners)
 
-if [ "${#owners[@]}" -eq 0 ]; then
+if [ "$owner_count" -eq 0 ]; then
   printf 'owner:    <unmapped>\nidentity: default (stock gh config)\n'
   exit 0
 fi
 
-if [ "${#owners[@]}" -gt 1 ]; then
-  printf 'owner:    %s\n' "${owners[*]}"
+if [ "$owner_count" -gt 1 ]; then
+  printf 'owner:   %s\n' "$owners"
   printf 'identity: MIXED -- this repository is not routed.\n'
   printf 'Use an explicit GH_CONFIG_DIR, or remove one remote.\n'
   exit 2
 fi
 
-owner="${owners[0]}"
+owner="${owners# }"
 slug="$(identity_owner_slug "$owner")"
 printf 'owner:    %s\nidentity: %s\n' "$owner" "$slug"
 
@@ -1239,8 +1404,10 @@ fi
 
 if ! identity_slug_provisioned "$slug"; then
   printf 'status:   NOT PROVISIONED\n'
-  [ -e "$HOME/.gitconfig.$slug" ] || printf '  missing: %s\n' "$HOME/.gitconfig.$slug"
-  [ -d "$(identity_slug_configdir "$slug")" ] || printf '  missing: %s\n' "$(identity_slug_configdir "$slug")"
+  [ -e "$(identity_slug_configfile "$slug")" ] ||
+    printf '  missing: %s\n' "$(identity_slug_configfile "$slug")"
+  [ -d "$(identity_slug_configdir "$slug")" ] ||
+    printf '  missing: %s\n' "$(identity_slug_configdir "$slug")"
   exit 3
 fi
 
@@ -1271,38 +1438,28 @@ fi
 printf 'status:   OK\n'
 ```
 
-- [ ] **Step 4: Make executable, run tests, lint**
+- [ ] **Step 4: Make executable, test, lint, commit**
 
 ```bash
 chmod 755 bin/git-identity
 bats tests/git_identity.bats
+bats tests/portability.bats
 make lint
-```
-
-Expected: PASS, lint clean.
-
-- [ ] **Step 5: Commit**
-
-```bash
 git add bin/git-identity tests/git_identity.bats
 git commit -m "feat(git): add bin/git-identity to report the resolved identity"
 ```
 
 ---
 
-### Task 8: Provisioning through bootstrap and relink
+### Task 8: Provisioning through bootstrap
 
 **Files:**
 - Modify: `bin/bootstrap`
 - Test: `tests/git_identity.bats`
 
-**Interfaces:**
-- Consumes: `core/git/gitconfig.guarzo.symlink.example` from Task 3.
-- Produces: `core/git/gitconfig.guarzo.symlink`, linked to `~/.gitconfig.guarzo` by the existing `managed_link_pairs` machinery — no change to `bin/relink` is needed, since `*.symlink` discovery is automatic.
+`*.symlink` discovery is automatic, so `bin/relink` needs no change: `managed_link_pairs` maps the new file to `~/.gitconfig.guarzo` once it exists.
 
-**Non-interactive contract:** `bin/bootstrap --non-interactive` already requires `user.name`/`user.email` to be set beforehand and errors rather than reading stdin (`bin/bootstrap:65`). The secondary identity follows the same rule: **never prompt, never partially create.** Skip unless the file already exists. No new flags.
-
-A half-populated identity file is worse than none — it looks provisioned to the guard and then fails at push time.
+**Non-interactive contract:** `--non-interactive` already requires `user.name`/`user.email` beforehand and errors rather than reading stdin (`bin/bootstrap:65`). The secondary identity follows the same rule: **never prompt, never partially create.** Skip unless the file already exists. No new flags. A half-populated identity file is worse than none — it looks provisioned to the guard and then fails at push time.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1310,41 +1467,47 @@ Append to `tests/git_identity.bats`:
 
 ```bash
 @test "non-interactive bootstrap skips secondary provisioning and reads no stdin" {
-  local fake="$TEST_ROOT/dotfiles-boot"
+  local fake="$TEST_ROOT/boot1"
   mkdir -p "$fake/core/git"
   cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
-  run bash -c "
-    set -e
-    source '$REPO_ROOT/bin/bootstrap' >/dev/null 2>&1 || true
-    NON_INTERACTIVE=true DOTFILES_ROOT='$fake' setup_secondary_identity
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=true
+    DOTFILES_ROOT='$fake'
+    setup_secondary_identity
   " </dev/null
   [ "$status" -eq 0 ]
   assert_file_absent "$fake/core/git/gitconfig.guarzo.symlink"
 }
 
-@test "non-interactive bootstrap links an already-provisioned identity" {
-  local fake="$TEST_ROOT/dotfiles-boot2"
+@test "non-interactive bootstrap leaves an already-provisioned identity for relink" {
+  local fake="$TEST_ROOT/boot2"
   mkdir -p "$fake/core/git"
   cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
   printf '[user]\n\temail = x@example.invalid\n' >"$fake/core/git/gitconfig.guarzo.symlink"
-  run bash -c "
-    set -e
-    source '$REPO_ROOT/bin/bootstrap' >/dev/null 2>&1 || true
-    NON_INTERACTIVE=true DOTFILES_ROOT='$fake' setup_secondary_identity
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=true
+    DOTFILES_ROOT='$fake'
+    setup_secondary_identity
   " </dev/null
   [ "$status" -eq 0 ]
-  [ -f "$fake/core/git/gitconfig.guarzo.symlink" ]
+  [[ "$output" == *"already configured"* ]]
+  run grep -c 'x@example.invalid' "$fake/core/git/gitconfig.guarzo.symlink"
+  [ "$output" -eq 1 ]
+  run bash -c "source '$REPO_ROOT/bin/common.sh' >/dev/null 2>&1; managed_link_pairs '$fake' '$HOME' | tr '\0' '\n'"
+  [[ "$output" == *"$HOME/.gitconfig.guarzo"* ]]
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run to verify it fails**
 
 Run: `bats tests/git_identity.bats`
 Expected: FAIL — `setup_secondary_identity` is not defined.
 
 - [ ] **Step 3: Add the function to `bin/bootstrap`**
 
-Add near the existing gitconfig setup, and call it from the same place that sets up `gitconfig.local`:
+Define it beside the existing gitconfig setup, and call it from the same place:
 
 ```bash
 # Optional secondary GitHub identity (see core/git/identity-owners).
@@ -1365,7 +1528,7 @@ setup_secondary_identity() {
     return 0
   fi
 
-  if [ "$NON_INTERACTIVE" = true ]; then
+  if [ "${NON_INTERACTIVE:-false}" = true ]; then
     log_info "Skipping optional secondary GitHub identity (non-interactive)."
     return 0
   fi
@@ -1399,59 +1562,56 @@ setup_secondary_identity() {
 }
 ```
 
-- [ ] **Step 4: Run tests, lint, and verify relink maps the new files**
+- [ ] **Step 4: Test, lint, commit**
 
 ```bash
 bats tests/git_identity.bats
 make lint
-bash bin/relink 2>&1 | tail -5
-```
-
-Expected: tests PASS, lint clean, relink completes without reporting skipped destinations.
-
-- [ ] **Step 5: Commit**
-
-```bash
 git add bin/bootstrap tests/git_identity.bats
 git commit -m "feat(bootstrap): provision the optional secondary identity without prompting non-interactively"
 ```
 
+**Do not run `bin/relink` from the worktree.** It would repoint `$HOME` symlinks at a disposable directory. Linking is verified in Task 10 from the canonical checkout.
+
 ---
 
-### Task 9: Adjacent fixes
+### Task 9: Documentation and hygiene
 
 **Files:**
 - Modify: `core/git/gitconfig.local.symlink.example`
 - Modify: `README.md`
 - Modify: `tests/repository_hygiene.bats`
-- Delete: `git/gitconfig.local.symlink` (and repoint `~/.gitconfig.local`)
 
-- [ ] **Step 1: Write the failing hygiene test**
+Note: the stale `git/gitconfig.local.symlink` is an **untracked** file that exists only in the primary checkout, not in this worktree. It cannot be asserted on from here, and removing it is machine state — so it moves to Task 10. What *can* be asserted here is that nothing under `git/` is tracked.
+
+- [ ] **Step 1: Write the failing tests**
 
 Append to `tests/repository_hygiene.bats`:
 
 ```bash
 @test "tracked git example files carry no real email addresses" {
-  # Templates keep illustrative placeholders, so allow only the reserved
-  # example domains. Anything else is a personal address in a public repo.
+  # Templates keep illustrative placeholders, so allow only reserved example
+  # domains. Anything else is a personal address in a public repo.
   run bash -c "
     grep -hoE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
       '$REPO_ROOT'/core/git/*.example 2>/dev/null |
-      grep -vE '@example\.(com|invalid|org)$' || true
+      grep -vE '@example\.(com|invalid|org)\$' || true
   "
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
-@test "the stale git/ gitconfig.local copy is gone" {
-  assert_file_absent "$REPO_ROOT/git/gitconfig.local.symlink"
+@test "the public repository tracks nothing under git/" {
+  run git -C "$REPO_ROOT" ls-files git/
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `bats tests/repository_hygiene.bats`
-Expected: FAIL — the example file contains a real gmail address, and the stale copy exists.
+Expected: FAIL on the first test — the example file contains a real gmail address.
 
 - [ ] **Step 3: Scrub the example**
 
@@ -1464,24 +1624,13 @@ In `core/git/gitconfig.local.symlink.example`, replace the `[user]` block with:
 	# signingkey = YOUR_GPG_KEY_ID
 ```
 
-Note: this changes `HEAD` only. The address remains in git history and is already public; rewriting history is out of scope.
+This changes `HEAD` only; the address remains in history and is already public. Rewriting history is out of scope.
 
-- [ ] **Step 4: Repoint the machine-local symlink and remove the stale copy**
+- [ ] **Step 4: Replace the README section**
 
-```bash
-cp -a ~/.dotfiles/git/gitconfig.local.symlink ~/.dotfiles/core/git/gitconfig.local.symlink
-ln -sfn "$HOME/.dotfiles/core/git/gitconfig.local.symlink" "$HOME/.gitconfig.local"
-rm -f ~/.dotfiles/git/gitconfig.local.symlink
-git -C ~/.dotfiles rm -r --cached --ignore-unmatch git/ 2>/dev/null || true
-```
+Replace `## Multiple GitHub Accounts` (the SSH host-alias recipe) with owner-based routing: the `core/git/identity-owners` map, the gitignored `gitconfig.guarzo.symlink` and its template, `bin/gh`, `bin/git-identity`, the pre-push guard, and the two manual provisioning steps. Add `~/.gitconfig.guarzo` and `~/.bash_profile` to the symlink table. State that SSH transport and mixed-owner repositories are unsupported and detected.
 
-Verify: `readlink ~/.gitconfig.local` prints the `core/git/` path, and `git config user.email` is unchanged.
-
-- [ ] **Step 5: Replace the README section**
-
-Replace the `## Multiple GitHub Accounts` section (the SSH host-alias recipe) with a description of owner-based routing: the `core/git/identity-owners` map, the gitignored `gitconfig.guarzo.symlink` and its template, `bin/gh`, `bin/git-identity`, the pre-push guard, and the two manual provisioning steps. Add `~/.gitconfig.guarzo` and `~/.bash_profile` to the symlink table. State that SSH transport and mixed-owner repositories are unsupported and detected.
-
-- [ ] **Step 6: Run tests and commit**
+- [ ] **Step 5: Test and commit**
 
 ```bash
 bats tests/repository_hygiene.bats
@@ -1490,28 +1639,48 @@ git add -A
 git commit -m "docs(git): document owner-based identity routing and scrub the example address"
 ```
 
----
-
-### Task 10: Migrate the three repositories and verify end to end
-
-**Files:** none in this repository. Operates on `~/workspace/{binderplan,slabledger,yetishopify}`.
-
-**Why this is required, not cleanup:** repo-local config outranks `~/.gitconfig` includes, so these three repositories shadow the new mechanism entirely. Until they are migrated, none of the routing above takes effect for them.
-
-- [ ] **Step 1: Record the current values (reversibility)**
+- [ ] **Step 6: Full suite before integration**
 
 ```bash
-for repo in binderplan slabledger yetishopify; do
-  printf '=== %s ===\n' "$repo"
-  git -C "$HOME/workspace/$repo" config --local --get-regexp 'user\.|credential' || true
-done | tee /tmp/identity-migration-backup.txt
+make check 2>&1 | tail -20
 ```
 
-Expected: each repo shows `user.name`, `user.email`, and a credential helper. Keep this file until Step 5 passes.
+Expected: no failures outside the known-bad baseline. Compare the count against the 60 recorded on `main`; any increase is a regression.
 
-- [ ] **Step 2: Complete the two manual provisioning steps**
+---
 
-These require the account holder and cannot be scripted:
+### Task 10: Integrate, then migrate the machine
+
+**This is the only task that mutates machine state, and it runs from `~/.dotfiles` after the branch is integrated.** Everything above changed tracked files only. Running these steps from the worktree would point `$HOME` symlinks at a disposable directory and invoke a `bin/git-identity` that the canonical checkout does not yet have.
+
+- [ ] **Step 1: Integrate the branch**
+
+```bash
+cd ~/.dotfiles
+git merge --no-ff worktree-multi-github-identity
+git log --oneline -1
+```
+
+Verify `~/.dotfiles/bin/git-identity` and `~/.dotfiles/core/git/identity-lib.sh` now exist.
+
+- [ ] **Step 2: Record current machine state (reversibility)**
+
+```bash
+{
+  for repo in binderplan slabledger yetishopify; do
+    printf '=== %s ===\n' "$repo"
+    git -C "$HOME/workspace/$repo" config --local --get-regexp 'user\.|credential' || true
+  done
+  printf '=== gitconfig.local ===\n'
+  cat "$HOME/.gitconfig.local"
+  printf '=== effective helper ===\n'
+  git config --includes --show-origin --get-all credential.https://github.com.helper
+} | tee /tmp/identity-migration-backup.txt
+```
+
+Keep this file until Step 8 passes.
+
+- [ ] **Step 3: Complete the two manual provisioning steps**
 
 ```bash
 GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth login # scopes: repo, workflow
@@ -1520,11 +1689,41 @@ ssh-keygen -t ed25519 -f "$HOME/.ssh/id_ed25519_guarzo" -C "guarzo signing key"
 
 Register `~/.ssh/id_ed25519_guarzo.pub` on the guarzo account **as a signing key** (GitHub keeps authentication and signing keys in separate lists), then append a line for the guarzo email to `~/.ssh/allowed_signers`.
 
-Then create `core/git/gitconfig.guarzo.symlink` from the template with the real values and run `bin/relink`.
+Create `~/.dotfiles/core/git/gitconfig.guarzo.symlink` from the template with the real values.
 
 Verify: `GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth status` reports a valid token.
 
-- [ ] **Step 3: Strip the repo-local config**
+- [ ] **Step 4: Finish the credential collapse in the machine-local file**
+
+Task 2 fixed the tracked file; `~/.gitconfig.local` still declares its own GitHub and Gist helper blocks, whose trailing reset discards the tracked one.
+
+```bash
+cp -a "$HOME/.dotfiles/git/gitconfig.local.symlink" "$HOME/.dotfiles/core/git/gitconfig.local.symlink"
+ln -sfn "$HOME/.dotfiles/core/git/gitconfig.local.symlink" "$HOME/.gitconfig.local"
+rm -f "$HOME/.dotfiles/git/gitconfig.local.symlink"
+```
+
+Then delete the `[credential "https://github.com"]` and `[credential "https://gist.github.com"]` sections from `~/.dotfiles/core/git/gitconfig.local.symlink`, leaving the tracked block as the only source.
+
+Verify the complete ordered result, not a block count:
+
+```bash
+git config --includes --show-origin --get-all credential.https://github.com.helper
+```
+
+Expected: exactly two entries from `core/git/gitconfig.symlink` — one empty reset, then `!gh auth git-credential`. No entry originating from `.gitconfig.local`, and no absolute `/usr/bin/gh` or `/usr/local/bin/gh` path.
+
+- [ ] **Step 5: Link the new files**
+
+```bash
+cd ~/.dotfiles && bash bin/relink 2>&1 | tail -5
+readlink "$HOME/.gitconfig.guarzo"
+readlink "$HOME/.bash_profile"
+```
+
+Expected: relink completes with no skipped destinations; both symlinks resolve into `~/.dotfiles`.
+
+- [ ] **Step 6: Strip the repo-local overrides**
 
 ```bash
 for repo in binderplan slabledger yetishopify; do
@@ -1536,50 +1735,36 @@ for repo in binderplan slabledger yetishopify; do
 done
 ```
 
-- [ ] **Step 4: Verify each repository resolves correctly from the remote alone**
+- [ ] **Step 7: Verify routing, the guard, and the untouched default**
 
 ```bash
 for repo in binderplan slabledger yetishopify; do
   printf '=== %s ===\n' "$repo"
-  (cd "$HOME/workspace/$repo" && "$HOME/.dotfiles/bin/git-identity")
+  (cd "$HOME/workspace/$repo" && git-identity)
 done
-```
-
-Expected: each prints `owner: guarzo`, `identity: guarzo`, `status: OK`, and an email matching the recorded backup.
-
-- [ ] **Step 5: Verify a real push path and the untouched default identity**
-
-```bash
 cd "$HOME/workspace/slabledger" && git push --dry-run origin HEAD
-cd "$HOME/workspace/headlamp" && "$HOME/.dotfiles/bin/git-identity"
+cd "$HOME/workspace/headlamp" && git-identity && git push --dry-run origin HEAD
 gh auth status
 ```
 
-Expected: the guarzo dry-run authenticates and is not blocked; `headlamp` reports `<unmapped>` / `default`; `gh auth status` still shows the default account active.
+Expected: each guarzo repo reports `owner: guarzo`, `identity: guarzo`, `status: OK`, with the email from the Step 2 backup; the guarzo dry-run authenticates and is not blocked; `headlamp` reports `<unmapped>` / `default` and its dry-run is unaffected; `gh auth status` still shows the default account active.
 
-- [ ] **Step 6: Full verification**
-
-```bash
-make check 2>&1 | tail -20
-```
-
-Expected: no failures outside the known-bad baseline (`dev_commands`, `dev_config_merge`, `dev_install`, `dev_lifecycle`, `claude_compose_override`). Compare the failure count against the 60 recorded on `main`; any increase is a regression from this work.
-
-- [ ] **Step 7: Clean up and commit**
+- [ ] **Step 8: Full verification and cleanup**
 
 ```bash
+cd ~/.dotfiles && make check 2>&1 | tail -20
+git status --short
 rm -f /tmp/identity-migration-backup.txt
-git -C ~/.dotfiles status --short
 ```
 
-Expected: clean tree — this task changes no tracked files.
+Expected: no failures outside the known-bad baseline; clean tree.
 
 ---
 
 ## Self-Review
 
-**Spec coverage:** owner map → Task 1; routing + credential collapse → Task 2; machine-local identity + template + gitignore → Task 3; `gh` shim incl. mixed-owner refusal and recursion safety → Task 4; bash login coverage → Task 5; guard incl. LFS composition, stdin, and the fail-open boundary → Task 6; doctor incl. all five exit codes → Task 7; provisioning and the non-interactive contract → Task 8; adjacent fixes and hygiene → Task 9; migration and manual steps → Task 10. No spec section is unimplemented.
+**Spec coverage:** owner map → Task 1; routing + credential unpinning → Task 2 (tracked) and Task 10 Step 4 (machine-local); identity file + template + gitignore → Task 3; shim incl. mixed-owner and invalid-map refusal → Task 4; bash login coverage → Task 5; guard incl. LFS composition, stdin, and both fail directions → Task 6; doctor with six exit codes → Task 7; provisioning contract → Task 8; docs and hygiene → Task 9; integration and migration → Task 10.
 
-**Reviewer constraints:** (1) validation → Task 1 Step 4, tested Step 1; (2) pair comparison → Task 2 Step 1, second test; (3) explicit match definition → Task 6 preamble and implementation, with the indeterminate case tested; (4) stdin and LFS status → Task 6, three dedicated tests; (5) symlink-resolving self-exclusion → Task 4 `identity_realpath`, tested via the symlink test.
+**Review findings addressed:** default-destination guard hole → Task 6 rule table plus the fork-case and false-positive tests; identity comparison beyond email → `identity_effective_slug` compares email *and* signing key, with an explicit signing-key check for secondary destinations; invalid map failing open → hard error in shim, guard, and doctor, each with a test; bootstrap side effects → `env BOOTSTRAP_SOURCE_ONLY=1` per `tests/install_orchestration.bats:136`, and the second test now asserts linking; incomplete credential collapse → Task 10 Step 4 strips the machine-local blocks and verifies with `git config --includes --show-origin --get-all`; bash 3.2 → no `mapfile`/`readarray`/associative arrays, with a grep test per script and `tests/portability.bats` run in Tasks 4 and 7; worktree/checkout mixing → Tasks 1–9 are repo-only, Task 10 runs post-integration from `~/.dotfiles`, and the unassertable stale-file test is replaced by a tracked-files assertion.
 
-**Type consistency:** all five library functions are named identically across Tasks 1, 4, 6, and 7 (`identity_url_owner`, `identity_load_map`, `identity_owner_slug`, `identity_slug_configdir`, `identity_slug_provisioned`, `identity_repo_owners`). The slug `guarzo` and path `~/.gh-guarzo` are consistent throughout.
+**Type consistency:** every library function name is identical across Tasks 1, 4, 6, and 7 (`identity_url_owner`, `identity_validate_map`, `identity_owner_slug`, `identity_slugs`, `identity_slug_configdir`, `identity_slug_configfile`, `identity_slug_provisioned`, `identity_slug_email`, `identity_slug_key`, `identity_repo_owners`, `identity_effective_slug`). `identity_load_map` from the previous revision is gone entirely, replaced by `identity_validate_map`.

--- a/docs/superpowers/plans/2026-08-05-multi-github-identity.md
+++ b/docs/superpowers/plans/2026-08-05-multi-github-identity.md
@@ -1,0 +1,1585 @@
+# Multi-GitHub-Identity Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route git and `gh` to the correct GitHub account automatically, based on who owns the repository's remote, so one machine holds two identities with no global switching.
+
+**Architecture:** A tracked owner map (`core/git/identity-owners`) is the single source of truth for which GitHub owners this machine knows. A shared bash library resolves URL → owner → identity slug. Three consumers read it: a `git` conditional include routes config declaratively, a `bin/gh` PATH shim routes the CLI, and a `pre-push` guard blocks any push whose destination disagrees with the resolved identity. Machine-local identity values live in a gitignored file, so nothing personal is committed to this public repository.
+
+**Tech Stack:** bash, git 2.36+ conditional includes (`includeIf hasconfig:`), GitHub CLI (`gh`), bats for tests, shellcheck + shfmt for lint.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-multi-github-identity-design.md` (approved at commit `e22a66a`).
+
+## Global Constraints
+
+- **This repository is public.** No email addresses, key paths, or account-identifying values in tracked files. Placeholders only. `tests/repository_hygiene.bats` enforces this.
+- **Formatting:** all shell must pass `shfmt -d -i 2 -ci` and `shellcheck -x -S warning -e SC1091`. Run `make lint` before every commit.
+- **Global hooks must fail open outside their remit.** `core.hooksPath` is global; a hook that errors breaks every repository on the machine. See the existing comment in `core/git/git-hooks.symlink/pre-push`.
+- **The pre-push hook must preserve stdin.** Git feeds ref updates to `pre-push` on stdin, and `git lfs pre-push` consumes them. A guard that reads stdin starves LFS.
+- **The pre-push hook must preserve the exact `git lfs pre-push` exit status.** It runs last and its status is authoritative.
+- **The `gh` shim must resolve symlinks when excluding itself** from the `PATH` scan, or it recurses when invoked through a link.
+- **The owner map must be validated, not silently accepted.** Malformed lines and duplicate owners are errors.
+- **The owner-map/include consistency test compares owner-and-slug PAIRS**, not slugs alone.
+- **Owner map semantics — three states, never two:** absent from map = *unmapped* (fail open); maps to `default` = default identity; maps to a secondary slug = requires `~/.gitconfig.<slug>` and `~/.gh-<slug>`, and if either is absent the state is *known but unprovisioned* (fail closed), never "unmapped".
+- **Known-bad test baseline** (pre-existing on `main`, never attribute to this work): `tests/dev_commands.bats`, `tests/dev_config_merge.bats`, `tests/dev_install.bats`, `tests/dev_lifecycle.bats`, `tests/claude_compose_override.bats`. Every other suite must stay green.
+- **Test harness:** `load test_helper` then `setup_dotfiles_test`, which sets `HOME="$TEST_ROOT/home"`, `STUB_BIN`, and `PATH="$STUB_BIN:/usr/bin:/bin"`. `git` is `/usr/bin/git` so it remains available. Use `stub_command <name> <body>` for stubs.
+- **Root resolution:** all new scripts resolve the repo as `DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"`. Tests override `DOTFILES`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `core/git/identity-owners` | Tracked owner→slug map. Data only. |
+| `core/git/identity-lib.sh` | Shared resolution: URL parsing, map load/validate, provisioning checks. Sourced, never executed. |
+| `core/git/gitconfig.symlink` | Conditional include + collapsed credential block. |
+| `core/git/gitconfig.guarzo.symlink.example` | Tracked template with placeholders. |
+| `core/git/gitconfig.guarzo.symlink` | Gitignored, machine-local identity values. Never tracked. |
+| `bin/gh` | PATH shim. Routes `GH_CONFIG_DIR`, refuses mixed-owner. |
+| `bin/git-identity` | Doctor. Reports resolved identity and provisioning state. |
+| `core/git/git-hooks.symlink/pre-push` | Guard, composed before the existing LFS call. |
+| `core/shell/bash_profile.symlink` | Bash login `PATH` coverage, chained to `~/.profile`. |
+| `tests/git_identity.bats` | Library, routing, shim, guard, doctor tests. |
+| `tests/repository_hygiene.bats` | Extended: no real addresses in tracked `.example` files. |
+
+Tasks 1–8 are ordered by dependency. Task 9 (adjacent fixes) and Task 10 (migration) are independent of each other but both depend on 1–8.
+
+---
+
+### Task 1: Owner map and shared resolution library
+
+**Files:**
+- Create: `core/git/identity-owners`
+- Create: `core/git/identity-lib.sh`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces, all sourced from `core/git/identity-lib.sh`:
+  - `identity_url_owner <url>` → prints `<owner>` on stdout for a github.com URL; exit 1 for any non-github.com URL or unparseable input.
+  - `identity_load_map [path]` → validates and loads the map into the associative array `IDENTITY_MAP`; exit 1 with a message on stderr for malformed or duplicate entries.
+  - `identity_owner_slug <owner>` → prints the slug; exit 1 if unmapped.
+  - `identity_slug_configdir <slug>` → prints the `gh` config dir (`$HOME/.config/gh` for `default`, `$HOME/.gh-<slug>` otherwise).
+  - `identity_slug_provisioned <slug>` → exit 0 if usable; exit 1 if a secondary slug is missing `~/.gitconfig.<slug>` or its `gh` config dir. `default` is always provisioned.
+  - `identity_repo_owners` → prints distinct **mapped** owners across all remotes of the current repo, one per line, sorted.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/git_identity.bats`:
+
+```bash
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  LIB="$REPO_ROOT/core/git/identity-lib.sh"
+  MAP="$TEST_ROOT/identity-owners"
+  cat >"$MAP" <<'EOF'
+# owner slug
+gambtho default
+guarzo  guarzo
+EOF
+}
+
+@test "identity_url_owner parses https, ssh, and scp-style github URLs" {
+  run bash -c "source '$LIB'; identity_url_owner https://github.com/guarzo/repo.git"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_url_owner ssh://git@github.com/guarzo/repo.git"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_url_owner git@github.com:guarzo/repo.git"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+}
+
+@test "identity_url_owner rejects non-github hosts" {
+  run bash -c "source '$LIB'; identity_url_owner https://gitlab.com/guarzo/repo.git"
+  [ "$status" -eq 1 ]
+
+  run bash -c "source '$LIB'; identity_url_owner https://msazure.visualstudio.com/x/_git/y"
+  [ "$status" -eq 1 ]
+}
+
+@test "identity_load_map rejects a duplicate owner" {
+  cat >"$MAP" <<'EOF'
+guarzo guarzo
+guarzo default
+EOF
+  run bash -c "source '$LIB'; identity_load_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"duplicate owner"* ]]
+}
+
+@test "identity_load_map rejects a malformed line" {
+  cat >"$MAP" <<'EOF'
+guarzo
+EOF
+  run bash -c "source '$LIB'; identity_load_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"malformed"* ]]
+}
+
+@test "identity_owner_slug maps known owners and rejects unmapped ones" {
+  run bash -c "source '$LIB'; identity_load_map '$MAP'; identity_owner_slug guarzo"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_load_map '$MAP'; identity_owner_slug gambtho"
+  [ "$status" -eq 0 ]
+  [ "$output" = "default" ]
+
+  run bash -c "source '$LIB'; identity_load_map '$MAP'; identity_owner_slug kubernetes-sigs"
+  [ "$status" -eq 1 ]
+}
+
+@test "identity_slug_provisioned distinguishes default, provisioned, and unprovisioned" {
+  run bash -c "source '$LIB'; identity_slug_provisioned default"
+  [ "$status" -eq 0 ]
+
+  run bash -c "source '$LIB'; identity_slug_provisioned guarzo"
+  [ "$status" -eq 1 ]
+
+  touch "$HOME/.gitconfig.guarzo"
+  mkdir -p "$HOME/.gh-guarzo"
+  run bash -c "source '$LIB'; identity_slug_provisioned guarzo"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — `core/git/identity-lib.sh` does not exist.
+
+- [ ] **Step 3: Create the owner map**
+
+Create `core/git/identity-owners`:
+
+```
+# GitHub owner -> identity slug.
+#
+# Tracked and non-secret on purpose: this file must state which owners this
+# machine knows about INDEPENDENTLY of whether their identity files exist.
+# That is what lets consumers tell "unmapped and unrelated" (fail open) apart
+# from "known identity but not provisioned" (fail closed).
+#
+# The default slug uses the standard ~/.config/gh and ~/.gitconfig.local.
+# Any other slug requires ~/.gitconfig.<slug> and ~/.gh-<slug>.
+#
+# Adding an owner here also requires an includeIf block in gitconfig.symlink;
+# tests/git_identity.bats asserts the two agree as owner+slug pairs.
+gambtho default
+guarzo  guarzo
+```
+
+- [ ] **Step 4: Write the library**
+
+Create `core/git/identity-lib.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Shared owner -> identity resolution for bin/gh, bin/git-identity, and the
+# pre-push guard. Sourced, never executed.
+#
+# Every consumer shares these three states, and conflating any two of them
+# reintroduces a silent wrong-identity path:
+#   unmapped            owner absent from the map      -> out of remit
+#   default             owner maps to the default      -> stock gh config
+#   secondary           owner maps to another slug     -> may be UNPROVISIONED
+
+IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
+IDENTITY_MAP_FILE="${IDENTITY_MAP_FILE:-$IDENTITY_DOTFILES_ROOT/core/git/identity-owners}"
+
+declare -gA IDENTITY_MAP
+
+# Print the owner for a github.com URL. Exit 1 for any other host or for input
+# that does not parse -- callers treat that as "out of remit", so being strict
+# here is what keeps unrelated remotes on the fail-open path.
+identity_url_owner() {
+  local url="$1" rest host path
+
+  case "$url" in
+    https://* | http://*)
+      rest="${url#*://}"
+      rest="${rest#*@}"
+      host="${rest%%/*}"
+      path="${rest#*/}"
+      ;;
+    ssh://*)
+      rest="${url#ssh://}"
+      rest="${rest#*@}"
+      host="${rest%%/*}"
+      path="${rest#*/}"
+      ;;
+    *@*:*)
+      rest="${url#*@}"
+      host="${rest%%:*}"
+      path="${rest#*:}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  host="${host%%:*}"
+  [ "$host" = "github.com" ] || return 1
+
+  path="${path#/}"
+  case "$path" in
+    */*) : ;;
+    *) return 1 ;;
+  esac
+
+  printf '%s\n' "${path%%/*}"
+}
+
+# Load and VALIDATE the owner map. A malformed or duplicated entry is an error,
+# never a silently skipped line: a dropped entry would demote a known owner to
+# "unmapped" and turn a blocked push into a silent wrong-identity push.
+identity_load_map() {
+  local file="${1:-$IDENTITY_MAP_FILE}"
+  local line owner slug extra lineno=0
+
+  IDENTITY_MAP=()
+
+  if [ ! -r "$file" ]; then
+    printf 'identity: owner map not readable: %s\n' "$file" >&2
+    return 1
+  fi
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    line="${line%%#*}"
+    # shellcheck disable=SC2086
+    set -- $line
+    [ "$#" -gt 0 ] || continue
+    owner="$1"
+    slug="${2:-}"
+    extra="${3:-}"
+
+    if [ "$#" -ne 2 ] || [ -n "$extra" ]; then
+      printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+      return 1
+    fi
+    case "$owner" in
+      [A-Za-z0-9]*) : ;;
+      *)
+        printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+        return 1
+        ;;
+    esac
+    case "$slug" in
+      [a-z0-9]*) : ;;
+      *)
+        printf 'identity: malformed entry at %s:%d\n' "$file" "$lineno" >&2
+        return 1
+        ;;
+    esac
+    if [ -n "${IDENTITY_MAP[$owner]:-}" ]; then
+      printf 'identity: duplicate owner %s at %s:%d\n' "$owner" "$file" "$lineno" >&2
+      return 1
+    fi
+    IDENTITY_MAP["$owner"]="$slug"
+  done <"$file"
+
+  return 0
+}
+
+identity_owner_slug() {
+  local owner="$1"
+  local slug="${IDENTITY_MAP[$owner]:-}"
+  [ -n "$slug" ] || return 1
+  printf '%s\n' "$slug"
+}
+
+identity_slug_configdir() {
+  local slug="$1"
+  if [ "$slug" = default ]; then
+    printf '%s\n' "${GH_DEFAULT_CONFIG_DIR:-$HOME/.config/gh}"
+  else
+    printf '%s\n' "$HOME/.gh-$slug"
+  fi
+}
+
+# A secondary slug is provisioned only when BOTH its git include and its gh
+# config dir exist. Either alone is a half-configured identity, which looks
+# usable to a naive check and then fails at push time.
+identity_slug_provisioned() {
+  local slug="$1" dir
+  [ "$slug" = default ] && return 0
+  [ -e "$HOME/.gitconfig.$slug" ] || return 1
+  dir="$(identity_slug_configdir "$slug")"
+  [ -d "$dir" ] || return 1
+  return 0
+}
+
+# Distinct MAPPED owners across every remote of the current repo. Unmapped
+# owners are omitted, so "guarzo + an unmapped work org" is not mixed-owner.
+identity_repo_owners() {
+  local url owner slug
+  while IFS= read -r url; do
+    [ -n "$url" ] || continue
+    owner="$(identity_url_owner "$url")" || continue
+    slug="$(identity_owner_slug "$owner")" || continue
+    printf '%s\n' "$owner"
+  done < <(git config --get-regexp '^remote\..*\.url$' 2>/dev/null | cut -d' ' -f2-) | sort -u
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bats tests/git_identity.bats`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Lint**
+
+Run: `make lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/git/identity-owners core/git/identity-lib.sh tests/git_identity.bats
+git commit -m "feat(git): add tracked owner map and identity resolution library"
+```
+
+---
+
+### Task 2: Conditional include and collapsed credential block
+
+**Files:**
+- Modify: `core/git/gitconfig.symlink`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: `identity_load_map` from Task 1 (for the pair-consistency test).
+- Produces: `~/.gitconfig.guarzo` as the include path for slug `guarzo`.
+
+**Why this is riskiest:** collapsing the credential block changes credential resolution for *every* repository including work. Do it in its own commit and verify before anything else layers on top.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git_identity.bats`:
+
+```bash
+@test "gitconfig declares exactly one github credential block" {
+  run grep -c '^\[credential "https://github.com"\]' "$REPO_ROOT/core/git/gitconfig.symlink"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "owner map and conditional includes agree as owner+slug pairs" {
+  # Compare PAIRS, not slugs: a test that only checked slugs would pass while
+  # an owner was wired to the wrong include.
+  local config="$REPO_ROOT/core/git/gitconfig.symlink"
+  local owner slug expected
+  while read -r owner slug; do
+    [ -n "$owner" ] || continue
+    [ "$slug" = default ] && continue
+    expected="[includeIf \"hasconfig:remote.*.url:https://github.com/$owner/**\"]"
+    run grep -Fq "$expected" "$config"
+    [ "$status" -eq 0 ]
+    run grep -A1 -F "$expected" "$config"
+    [[ "$output" == *"~/.gitconfig.$slug"* ]]
+  done < <(grep -v '^[[:space:]]*#' "$REPO_ROOT/core/git/identity-owners" | grep -v '^[[:space:]]*$')
+}
+
+@test "every conditional include corresponds to a mapped owner" {
+  local config="$REPO_ROOT/core/git/gitconfig.symlink"
+  local owner
+  while read -r owner; do
+    run grep -qE "^$owner[[:space:]]" "$REPO_ROOT/core/git/identity-owners"
+    [ "$status" -eq 0 ]
+  done < <(sed -n 's|^\[includeIf "hasconfig:remote\.\*\.url:https://github\.com/\([^/]*\)/\*\*"\]$|\1|p' "$config")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — two credential blocks exist and no `includeIf` is present.
+
+- [ ] **Step 3: Collapse the duplicate credential block**
+
+In `core/git/gitconfig.symlink`, delete this block entirely:
+
+```
+[credential "https://github.com"]
+	helper = 
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = 
+	helper = !/usr/bin/gh auth git-credential
+```
+
+and replace it with one referencing `gh` by name so it resolves through `PATH`
+rather than pinning the older apt binary at `/usr/bin/gh`:
+
+```
+[credential "https://github.com"]
+	helper =
+	helper = !gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !gh auth git-credential
+```
+
+- [ ] **Step 4: Add the conditional include**
+
+Append to `core/git/gitconfig.symlink`:
+
+```
+# Secondary GitHub identity. Routed by remote owner, per
+# core/git/identity-owners. The include path is gitignored and machine-local,
+# so this block is inert on a machine that has not provisioned it -- git
+# silently ignores a missing include file.
+#
+# hasconfig matches ANY configured remote, not the push target, so a repo with
+# remotes owned by two mapped owners resolves ambiguously. That case is not
+# routed: the pre-push guard blocks it and bin/gh refuses to run.
+[includeIf "hasconfig:remote.*.url:https://github.com/guarzo/**"]
+	path = ~/.gitconfig.guarzo
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bats tests/git_identity.bats`
+Expected: PASS.
+
+- [ ] **Step 6: Verify credential resolution did not break**
+
+Run: `git config --get-all credential.https://github.com.helper`
+Expected: exactly one non-empty helper, `!gh auth git-credential`, preceded by the empty reset.
+
+Run: `git -C ~/workspace/headlamp ls-remote --exit-code origin HEAD >/dev/null && echo OK`
+Expected: `OK` — an unrelated repository still authenticates.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/git/gitconfig.symlink tests/git_identity.bats
+git commit -m "fix(git): collapse duplicate github credential block and route guarzo by owner"
+```
+
+---
+
+### Task 3: Machine-local identity file and its template
+
+**Files:**
+- Create: `core/git/gitconfig.guarzo.symlink.example`
+- Modify: `.gitignore`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `core/git/gitconfig.guarzo.symlink` (gitignored, created at provisioning time by Task 8), linking to `~/.gitconfig.guarzo`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git_identity.bats`:
+
+```bash
+@test "the machine-local guarzo identity file is gitignored" {
+  run git -C "$REPO_ROOT" check-ignore -q core/git/gitconfig.guarzo.symlink
+  [ "$status" -eq 0 ]
+}
+
+@test "the guarzo identity template carries placeholders, not real values" {
+  local template="$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example"
+  [ -f "$template" ]
+  run grep -Eq '@(gmail|microsoft|outlook)\.' "$template"
+  [ "$status" -ne 0 ]
+  run grep -Fq 'GH_CONFIG_DIR=$HOME/.gh-guarzo' "$template"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — neither the ignore rule nor the template exists.
+
+- [ ] **Step 3: Add the ignore rule**
+
+Append to `.gitignore`, beside the existing `core/git/gitconfig.local.symlink` entry:
+
+```
+# Machine-local secondary GitHub identity (name, email, signing key). The
+# tracked template is core/git/gitconfig.guarzo.symlink.example.
+core/git/gitconfig.guarzo.symlink
+```
+
+- [ ] **Step 4: Create the template**
+
+Create `core/git/gitconfig.guarzo.symlink.example`:
+
+```
+# Copy to core/git/gitconfig.guarzo.symlink and fill in. That file is
+# gitignored; this template is tracked and must never contain real values.
+#
+# signingKey must be an ABSOLUTE path -- git does not expand ~ for this key on
+# every platform.
+[user]
+	name = YOUR_ACCOUNT_NAME
+	email = you@example.com
+	signingKey = /home/YOUR_USER/.ssh/id_ed25519_guarzo.pub
+[credential "https://github.com"]
+	helper =
+	helper = !GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth git-credential
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bats tests/git_identity.bats`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .gitignore core/git/gitconfig.guarzo.symlink.example tests/git_identity.bats
+git commit -m "feat(git): add gitignored secondary identity file and tracked template"
+```
+
+---
+
+### Task 4: The `gh` PATH shim
+
+**Files:**
+- Create: `bin/gh`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: `identity_load_map`, `identity_repo_owners`, `identity_owner_slug`, `identity_slug_configdir`, `identity_slug_provisioned` from Task 1.
+- Produces: nothing consumed by later tasks.
+
+**Recursion hazard:** the shim must exclude *itself* from the `PATH` scan by comparing fully resolved paths. Comparing raw paths fails when the shim is reached through a symlink, and it then execs itself forever.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git_identity.bats`:
+
+```bash
+setup_shim_repo() {
+  local dir="$1" url="$2"
+  git init -q "$dir"
+  git -C "$dir" remote add origin "$url"
+  export DOTFILES="$TEST_ROOT/dotfiles"
+  mkdir -p "$DOTFILES/core/git"
+  cp "$REPO_ROOT/core/git/identity-lib.sh" "$DOTFILES/core/git/"
+  cp "$MAP" "$DOTFILES/core/git/identity-owners"
+  stub_command gh-real 'echo "real gh: GH_CONFIG_DIR=[${GH_CONFIG_DIR:-unset}] args=$*"'
+  mkdir -p "$STUB_BIN/real"
+  mv "$STUB_BIN/gh-real" "$STUB_BIN/real/gh"
+  export PATH="$STUB_BIN:$STUB_BIN/real:/usr/bin:/bin"
+}
+
+@test "shim routes a guarzo repo to the guarzo gh config dir" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  touch "$HOME/.gitconfig.guarzo"
+  mkdir -p "$HOME/.gh-guarzo"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[$HOME/.gh-guarzo]"* ]]
+}
+
+@test "shim delegates unchanged for a default-owner repo" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[unset]"* ]]
+}
+
+@test "shim delegates unchanged outside a repository" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT"
+  run "$REPO_ROOT/bin/gh" auth status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[unset]"* ]]
+}
+
+@test "shim refuses a mixed-owner repo even when the secondary is unprovisioned" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  git -C "$TEST_ROOT/r" remote add upstream https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr merge
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mixed"* ]]
+  [[ "$output" == *"GH_CONFIG_DIR"* ]]
+}
+
+@test "shim does not treat a mapped owner plus an unmapped org as mixed" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  git -C "$TEST_ROOT/r" remote add fork https://github.com/kubernetes-sigs/repo.git
+  touch "$HOME/.gitconfig.guarzo"
+  mkdir -p "$HOME/.gh-guarzo"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[$HOME/.gh-guarzo]"* ]]
+}
+
+@test "shim refuses an unprovisioned guarzo repo and names the missing step" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not provisioned"* ]]
+}
+
+@test "shim passes through untouched when the caller set GH_CONFIG_DIR" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  git -C "$TEST_ROOT/r" remote add upstream https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  GH_CONFIG_DIR="$HOME/explicit" run "$REPO_ROOT/bin/gh" pr merge
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[$HOME/explicit]"* ]]
+}
+
+@test "shim does not recurse when reached through a symlink" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  ln -s "$REPO_ROOT/bin/gh" "$STUB_BIN/gh"
+  cd "$TEST_ROOT/r"
+  run timeout 10 "$STUB_BIN/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"real gh"* ]]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — `bin/gh` does not exist.
+
+- [ ] **Step 3: Write the shim**
+
+Create `bin/gh` (mode 0755):
+
+```bash
+#!/usr/bin/env bash
+# PATH shim that routes `gh` to the identity owning the current repository's
+# remote. A shell function would reach only interactive zsh; scripts, editors,
+# Codex, and Claude Code's bash tool would all silently use the default
+# account, which is the exact disagreement this design exists to prevent.
+set -euo pipefail
+
+IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
+# shellcheck source=/dev/null
+. "$IDENTITY_DOTFILES_ROOT/core/git/identity-lib.sh"
+
+# Resolve a path through symlinks. Comparing raw paths would fail to recognise
+# this script when it is invoked through a link, and the exec below would then
+# re-enter this same file forever.
+identity_realpath() {
+  local target="$1"
+  if command -v readlink >/dev/null 2>&1 && readlink -f / >/dev/null 2>&1; then
+    readlink -f "$target"
+    return
+  fi
+  local dir base
+  dir="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || return 1
+  base="$(basename "$target")"
+  while [ -L "$dir/$base" ]; do
+    target="$(readlink "$dir/$base")"
+    case "$target" in
+      /*) : ;;
+      *) target="$dir/$target" ;;
+    esac
+    dir="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || return 1
+    base="$(basename "$target")"
+  done
+  printf '%s/%s\n' "$dir" "$base"
+}
+
+find_real_gh() {
+  local self entry candidate
+  local -a entries
+  self="$(identity_realpath "${BASH_SOURCE[0]}")"
+  IFS=: read -r -a entries <<<"$PATH"
+  for entry in "${entries[@]}"; do
+    [ -n "$entry" ] || continue
+    candidate="$entry/gh"
+    [ -x "$candidate" ] || continue
+    [ "$(identity_realpath "$candidate")" = "$self" ] && continue
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  return 1
+}
+
+real_gh="$(find_real_gh)" || {
+  printf 'gh: no real gh found on PATH\n' >&2
+  exit 127
+}
+
+# An explicit GH_CONFIG_DIR means the caller has already chosen. Never
+# second-guess it -- it is also the documented escape hatch for mixed-owner
+# repositories.
+if [ -n "${GH_CONFIG_DIR:-}" ]; then
+  exec "$real_gh" "$@"
+fi
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exec "$real_gh" "$@"
+
+identity_load_map || exec "$real_gh" "$@"
+
+mapfile -t owners < <(identity_repo_owners)
+
+if [ "${#owners[@]}" -eq 0 ]; then
+  exec "$real_gh" "$@"
+fi
+
+if [ "${#owners[@]}" -gt 1 ]; then
+  printf 'gh: refusing to run -- this repository has remotes owned by mixed mapped identities: %s\n' "${owners[*]}" >&2
+  printf 'gh: re-run with an explicit GH_CONFIG_DIR (and GH_REPO if needed) to choose.\n' >&2
+  exit 3
+fi
+
+slug="$(identity_owner_slug "${owners[0]}")"
+
+if [ "$slug" = default ]; then
+  exec "$real_gh" "$@"
+fi
+
+if ! identity_slug_provisioned "$slug"; then
+  printf 'gh: identity "%s" is mapped but not provisioned.\n' "$slug" >&2
+  printf 'gh: expected %s and %s.\n' "$HOME/.gitconfig.$slug" "$(identity_slug_configdir "$slug")" >&2
+  printf 'gh: run bin/git-identity for the remaining steps.\n' >&2
+  exit 4
+fi
+
+GH_CONFIG_DIR="$(identity_slug_configdir "$slug")"
+export GH_CONFIG_DIR
+exec "$real_gh" "$@"
+```
+
+- [ ] **Step 4: Make it executable and run the tests**
+
+```bash
+chmod 755 bin/gh
+bats tests/git_identity.bats
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bin/gh tests/git_identity.bats
+git commit -m "feat(gh): route gh by remote owner with a recursion-safe PATH shim"
+```
+
+---
+
+### Task 5: Bash login PATH coverage
+
+**Files:**
+- Create: `core/shell/bash_profile.symlink`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `~/.bash_profile`, placing `~/.dotfiles/bin` ahead of `/usr/local/bin` for bash login shells.
+
+**Why not `profile.symlink`:** `link_file` in `bin/relink` uses `policy=skip` for any destination that is not already a symlink, and `bin/relink` then calls `log_error`, which exits. A `profile.symlink` would collide with the real `~/.profile` and abort relink for *every* managed dotfile. `~/.bash_profile` does not exist on this machine, so it links cleanly. Bash reads `.bash_profile` instead of `.profile` when present, so chaining preserves the existing file.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git_identity.bats`:
+
+```bash
+@test "bash_profile puts dotfiles/bin ahead of /usr/local/bin in a clean login shell" {
+  local profile="$REPO_ROOT/core/shell/bash_profile.symlink"
+  [ -f "$profile" ]
+  mkdir -p "$HOME/.dotfiles/bin"
+  cp "$profile" "$HOME/.bash_profile"
+  run env -i HOME="$HOME" /bin/bash -lc 'printf "%s\n" "$PATH"'
+  [ "$status" -eq 0 ]
+  local dotfiles_pos local_pos
+  dotfiles_pos=$(printf '%s' "$output" | tr ':' '\n' | grep -n "^$HOME/.dotfiles/bin$" | head -1 | cut -d: -f1)
+  local_pos=$(printf '%s' "$output" | tr ':' '\n' | grep -n '^/usr/local/bin$' | head -1 | cut -d: -f1)
+  [ -n "$dotfiles_pos" ]
+  [ -z "$local_pos" ] || [ "$dotfiles_pos" -lt "$local_pos" ]
+}
+
+@test "bash_profile preserves an existing real ~/.profile" {
+  mkdir -p "$HOME/.dotfiles/bin"
+  cp "$REPO_ROOT/core/shell/bash_profile.symlink" "$HOME/.bash_profile"
+  cat >"$HOME/.profile" <<'EOF'
+export EXISTING_PROFILE_RAN=yes
+PATH="$HOME/preexisting:$PATH"
+EOF
+  run env -i HOME="$HOME" /bin/bash -lc 'printf "%s|%s\n" "$EXISTING_PROFILE_RAN" "$PATH"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == yes\|* ]]
+  [[ "$output" == *"$HOME/preexisting"* ]]
+}
+
+@test "bash_profile is mapped to ~/.bash_profile by the link mapper" {
+  run bash -c "source '$REPO_ROOT/bin/common.sh' >/dev/null 2>&1; managed_link_pairs '$REPO_ROOT' '$HOME' | tr '\0' '\n'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$HOME/.bash_profile"* ]]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — `core/shell/bash_profile.symlink` does not exist.
+
+- [ ] **Step 3: Write the file**
+
+Create `core/shell/bash_profile.symlink`:
+
+```bash
+# ~/.bash_profile -- managed by dotfiles.
+#
+# Bash reads this INSTEAD of ~/.profile when it exists, so source ~/.profile
+# first to preserve whatever is already there (on a stock Debian/Ubuntu box
+# that includes sourcing ~/.bashrc, adding ~/bin and ~/.local/bin, and loading
+# the Cargo environment).
+#
+# Then put the dotfiles bin directory ahead of /usr/local/bin so the bin/gh
+# identity shim wins over the real gh for bash login shells too -- without
+# this, only zsh and its descendants route gh by owner.
+
+if [ -f "$HOME/.profile" ]; then
+  . "$HOME/.profile"
+fi
+
+case ":$PATH:" in
+  *":$HOME/.dotfiles/bin:"*) ;;
+  *) PATH="$HOME/.dotfiles/bin:$PATH" ;;
+esac
+export PATH
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bats tests/git_identity.bats`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/shell/bash_profile.symlink tests/git_identity.bats
+git commit -m "feat(shell): add bash login profile chaining to ~/.profile for shim PATH"
+```
+
+---
+
+### Task 6: Pre-push identity guard
+
+**Files:**
+- Modify: `core/git/git-hooks.symlink/pre-push`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: Task 1 library.
+- Produces: nothing consumed by later tasks.
+
+**Three constraints that are easy to get wrong:**
+1. **stdin** — git feeds ref updates on stdin and `git lfs pre-push` consumes them. The guard must not read stdin at all; it uses only `$1` (remote name) and `$2` (remote URL).
+2. **exit status** — `git lfs pre-push "$@"` runs last so its status is the hook's status.
+3. **fail-open boundary** — open before the destination is known in remit, closed after.
+
+"Resolved identity matches" is defined explicitly: the repository's effective `user.email` equals the `user.email` that the destination slug's include file sets. If either side is empty or unreadable, the identity is *indeterminate*, which is a fail-closed condition — not a pass.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git_identity.bats`:
+
+```bash
+setup_guard_repo() {
+  export DOTFILES="$TEST_ROOT/dotfiles"
+  mkdir -p "$DOTFILES/core/git"
+  cp "$REPO_ROOT/core/git/identity-lib.sh" "$DOTFILES/core/git/"
+  cp "$MAP" "$DOTFILES/core/git/identity-owners"
+  HOOK="$REPO_ROOT/core/git/git-hooks.symlink/pre-push"
+  GUARD_REPO="$TEST_ROOT/g"
+  git init -q "$GUARD_REPO"
+  stub_command git-lfs 'exit 0'
+  stub_command jq 'exit 0'
+}
+
+provision_guarzo() {
+  cat >"$HOME/.gitconfig.guarzo" <<'EOF'
+[user]
+	email = guarzo@example.invalid
+EOF
+  mkdir -p "$HOME/.gh-guarzo"
+}
+
+@test "guard fails open for a non-github destination" {
+  setup_guard_repo
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://gitlab.com/guarzo/repo.git </dev/null
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "guard fails open for an unmapped owner" {
+  setup_guard_repo
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/kubernetes-sigs/repo.git </dev/null
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "guard blocks a guarzo push when the identity is unprovisioned" {
+  setup_guard_repo
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not provisioned"* ]]
+}
+
+@test "guard blocks a guarzo push whose resolved identity disagrees" {
+  setup_guard_repo
+  provision_guarzo
+  git -C "$GUARD_REPO" config user.email someone-else@example.invalid
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"identity"* ]]
+}
+
+@test "guard allows a guarzo push whose resolved identity matches" {
+  setup_guard_repo
+  provision_guarzo
+  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard blocks a mapped destination when the identity is indeterminate" {
+  setup_guard_repo
+  provision_guarzo
+  git -C "$GUARD_REPO" config --unset user.email || true
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+}
+
+@test "composed hook preserves a non-zero git-lfs exit status" {
+  setup_guard_repo
+  provision_guarzo
+  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  stub_command git-lfs 'exit 7'
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -eq 7 ]
+}
+
+@test "a rejecting guard never reaches git lfs pre-push" {
+  setup_guard_repo
+  stub_command git-lfs "echo LFS_RAN >>'$TEST_ROOT/lfs.log'; exit 0"
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  assert_file_absent "$TEST_ROOT/lfs.log"
+}
+
+@test "guard leaves stdin intact for git lfs pre-push" {
+  setup_guard_repo
+  provision_guarzo
+  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  stub_command git-lfs "cat >'$TEST_ROOT/lfs-stdin.txt'; exit 0"
+  cd "$GUARD_REPO"
+  printf 'refs/heads/main aaa refs/heads/main bbb\n' |
+    run "$HOOK" origin https://github.com/guarzo/repo.git
+  run cat "$TEST_ROOT/lfs-stdin.txt"
+  [[ "$output" == *"refs/heads/main"* ]]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — the guard is not present.
+
+- [ ] **Step 3: Rewrite the hook**
+
+Replace `core/git/git-hooks.symlink/pre-push` with:
+
+```bash
+#!/usr/bin/env bash
+# Global pre-push hook: identity guard, then the stock git-lfs hook.
+#
+# ORDER IS LOAD-BEARING. `git lfs pre-push` must run LAST because its exit
+# status is the hook's exit status; running it first and appending the guard
+# would let a passing guard mask a failed LFS upload and push refs whose
+# objects never uploaded.
+#
+# This hook must also never read stdin: git feeds ref updates there and
+# `git lfs pre-push` consumes them. The guard uses only $1 (remote name) and
+# $2 (remote URL).
+#
+# FAIL-OPEN BOUNDARY. core.hooksPath is global, so this hook runs for every
+# repository on the machine. It exits 0 silently for anything outside its
+# remit -- non-github.com hosts and unmapped owners. Once the destination is
+# known to belong to a mapped identity, "cannot verify" becomes a blocking
+# condition rather than a silent pass.
+
+remote_url="${2:-}"
+
+identity_guard() {
+  local url="$1"
+  local root owner slug expected actual
+
+  [ -n "$url" ] || return 0
+
+  root="${DOTFILES:-$HOME/.dotfiles}"
+  [ -r "$root/core/git/identity-lib.sh" ] || return 0
+  # shellcheck source=/dev/null
+  . "$root/core/git/identity-lib.sh"
+
+  owner="$(identity_url_owner "$url")" || return 0
+  identity_load_map || return 0
+  slug="$(identity_owner_slug "$owner")" || return 0
+
+  # Past this point the destination is in remit: fail closed.
+  if [ "$slug" = default ]; then
+    return 0
+  fi
+
+  if ! identity_slug_provisioned "$slug"; then
+    printf 'pre-push: BLOCKED -- pushing to %s but identity "%s" is not provisioned.\n' "$owner" "$slug" >&2
+    printf 'pre-push: expected %s and %s. Run bin/git-identity.\n' "$HOME/.gitconfig.$slug" "$(identity_slug_configdir "$slug")" >&2
+    return 1
+  fi
+
+  expected="$(git config --file "$HOME/.gitconfig.$slug" user.email 2>/dev/null || true)"
+  actual="$(git config user.email 2>/dev/null || true)"
+
+  if [ -z "$expected" ] || [ -z "$actual" ]; then
+    printf 'pre-push: BLOCKED -- cannot determine the identity for %s (expected=%s actual=%s).\n' \
+      "$owner" "${expected:-<empty>}" "${actual:-<empty>}" >&2
+    return 1
+  fi
+
+  if [ "$expected" != "$actual" ]; then
+    printf 'pre-push: BLOCKED -- pushing to %s as %s, but identity "%s" is %s.\n' \
+      "$owner" "$actual" "$slug" "$expected" >&2
+    printf 'pre-push: a repository with remotes under two mapped owners is not routed; see bin/git-identity.\n' >&2
+    return 1
+  fi
+
+  return 0
+}
+
+identity_guard "$remote_url" || exit 1
+
+# Stock git-lfs hook, adapted for a GLOBAL core.hooksPath. git-lfs writes these
+# per-repo, where a missing binary really is an error worth `exit 2`. The
+# dotfiles point core.hooksPath here for EVERY repo, so that exit code turns any
+# machine without git-lfs into one where clone and checkout fail outright --
+# including the repos that never touched LFS. Devcontainer images are the common
+# case: it breaks lazy.nvim's plugin clones with an error naming LFS, not the
+# container. Warn and step aside instead. A genuine LFS repo still checks out,
+# just with pointer files, which is the best available outcome without the
+# binary -- and far better than no checkout at all.
+command -v git-lfs >/dev/null 2>&1 || {
+  printf >&2 '%s\n' "git-lfs not found - skipping 'git lfs pre-push'; any LFS files are left as pointers."
+  exit 0
+}
+git lfs pre-push "$@"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bats tests/git_identity.bats`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the hook did not break unrelated repositories**
+
+Run: `git -C ~/workspace/headlamp push --dry-run origin HEAD 2>&1 | tail -3`
+Expected: normal dry-run output, no `pre-push: BLOCKED`.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add core/git/git-hooks.symlink/pre-push tests/git_identity.bats
+git commit -m "feat(git): guard pushes against identity mismatch before the LFS hook"
+```
+
+---
+
+### Task 7: `bin/git-identity` doctor
+
+**Files:**
+- Create: `bin/git-identity`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: Task 1 library.
+- Produces: nothing consumed by later tasks.
+
+Exit codes: `0` usable; `2` mixed-owner; `3` mapped but unprovisioned; `4` mapped and provisioned but the token is invalid; `5` guarzo SSH remote (unsupported transport). An unmapped owner is `0` — the default identity working as intended.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git_identity.bats`:
+
+```bash
+@test "doctor reports the default identity for an unmapped owner" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/kubernetes-sigs/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"default"* ]]
+}
+
+@test "doctor exits 3 for a mapped but unprovisioned identity" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"not provisioned"* ]]
+}
+
+@test "doctor exits 2 for a mixed-owner repository" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  git -C "$TEST_ROOT/r" remote add upstream https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"mixed"* ]]
+}
+
+@test "doctor exits 5 for a guarzo ssh remote" {
+  setup_shim_repo "$TEST_ROOT/r" git@github.com:guarzo/repo.git
+  touch "$HOME/.gitconfig.guarzo"
+  mkdir -p "$HOME/.gh-guarzo"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 5 ]
+  [[ "$output" == *"SSH"* ]]
+}
+
+@test "doctor exits 4 when the token is invalid" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  touch "$HOME/.gitconfig.guarzo"
+  mkdir -p "$HOME/.gh-guarzo"
+  rm -f "$STUB_BIN/real/gh"
+  stub_command gh 'echo "token invalid" >&2; exit 1'
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"token"* ]]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — `bin/git-identity` does not exist.
+
+- [ ] **Step 3: Write the doctor**
+
+Create `bin/git-identity` (mode 0755):
+
+```bash
+#!/usr/bin/env bash
+# Report which GitHub identity applies to the current repository, and whether
+# it is actually usable. Every failure mode in this design is silent -- a
+# missing include, an unmapped remote, an expired token all present as "you are
+# quietly the default identity" -- so this turns that into one line.
+set -uo pipefail
+
+IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
+# shellcheck source=/dev/null
+. "$IDENTITY_DOTFILES_ROOT/core/git/identity-lib.sh"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  printf 'not inside a git repository\n'
+  exit 0
+fi
+
+if ! identity_load_map; then
+  exit 1
+fi
+
+mapfile -t owners < <(identity_repo_owners)
+
+if [ "${#owners[@]}" -eq 0 ]; then
+  printf 'owner:    <unmapped>\nidentity: default (stock gh config)\n'
+  exit 0
+fi
+
+if [ "${#owners[@]}" -gt 1 ]; then
+  printf 'owner:    %s\n' "${owners[*]}"
+  printf 'identity: MIXED -- this repository is not routed.\n'
+  printf 'Use an explicit GH_CONFIG_DIR, or remove one remote.\n'
+  exit 2
+fi
+
+owner="${owners[0]}"
+slug="$(identity_owner_slug "$owner")"
+printf 'owner:    %s\nidentity: %s\n' "$owner" "$slug"
+
+if [ "$slug" = default ]; then
+  printf 'email:    %s\n' "$(git config user.email 2>/dev/null || echo '<unset>')"
+  exit 0
+fi
+
+if ! identity_slug_provisioned "$slug"; then
+  printf 'status:   NOT PROVISIONED\n'
+  [ -e "$HOME/.gitconfig.$slug" ] || printf '  missing: %s\n' "$HOME/.gitconfig.$slug"
+  [ -d "$(identity_slug_configdir "$slug")" ] || printf '  missing: %s\n' "$(identity_slug_configdir "$slug")"
+  exit 3
+fi
+
+configdir="$(identity_slug_configdir "$slug")"
+printf 'email:    %s\n' "$(git config user.email 2>/dev/null || echo '<unset>')"
+printf 'key:      %s\n' "$(git config user.signingKey 2>/dev/null || echo '<unset>')"
+printf 'ghconfig: %s\n' "$configdir"
+
+# SSH transport is deliberately unsupported: git never invokes a credential
+# helper for it, and user.signingKey does not select an authentication key.
+while IFS= read -r url; do
+  case "$url" in
+    https://*) continue ;;
+  esac
+  if [ "$(identity_url_owner "$url" 2>/dev/null || true)" = "$owner" ]; then
+    printf 'status:   UNSUPPORTED -- SSH remote for a routed identity (%s)\n' "$url"
+    printf 'Re-point the remote at its https:// URL.\n'
+    exit 5
+  fi
+done < <(git config --get-regexp '^remote\..*\.url$' 2>/dev/null | cut -d' ' -f2-)
+
+if ! GH_CONFIG_DIR="$configdir" gh auth status >/dev/null 2>&1; then
+  printf 'status:   TOKEN INVALID OR MISSING\n'
+  printf 'Run: GH_CONFIG_DIR=%s gh auth login\n' "$configdir"
+  exit 4
+fi
+
+printf 'status:   OK\n'
+```
+
+- [ ] **Step 4: Make executable, run tests, lint**
+
+```bash
+chmod 755 bin/git-identity
+bats tests/git_identity.bats
+make lint
+```
+
+Expected: PASS, lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/git-identity tests/git_identity.bats
+git commit -m "feat(git): add bin/git-identity to report the resolved identity"
+```
+
+---
+
+### Task 8: Provisioning through bootstrap and relink
+
+**Files:**
+- Modify: `bin/bootstrap`
+- Test: `tests/git_identity.bats`
+
+**Interfaces:**
+- Consumes: `core/git/gitconfig.guarzo.symlink.example` from Task 3.
+- Produces: `core/git/gitconfig.guarzo.symlink`, linked to `~/.gitconfig.guarzo` by the existing `managed_link_pairs` machinery — no change to `bin/relink` is needed, since `*.symlink` discovery is automatic.
+
+**Non-interactive contract:** `bin/bootstrap --non-interactive` already requires `user.name`/`user.email` to be set beforehand and errors rather than reading stdin (`bin/bootstrap:65`). The secondary identity follows the same rule: **never prompt, never partially create.** Skip unless the file already exists. No new flags.
+
+A half-populated identity file is worse than none — it looks provisioned to the guard and then fails at push time.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/git_identity.bats`:
+
+```bash
+@test "non-interactive bootstrap skips secondary provisioning and reads no stdin" {
+  local fake="$TEST_ROOT/dotfiles-boot"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  run bash -c "
+    set -e
+    source '$REPO_ROOT/bin/bootstrap' >/dev/null 2>&1 || true
+    NON_INTERACTIVE=true DOTFILES_ROOT='$fake' setup_secondary_identity
+  " </dev/null
+  [ "$status" -eq 0 ]
+  assert_file_absent "$fake/core/git/gitconfig.guarzo.symlink"
+}
+
+@test "non-interactive bootstrap links an already-provisioned identity" {
+  local fake="$TEST_ROOT/dotfiles-boot2"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  printf '[user]\n\temail = x@example.invalid\n' >"$fake/core/git/gitconfig.guarzo.symlink"
+  run bash -c "
+    set -e
+    source '$REPO_ROOT/bin/bootstrap' >/dev/null 2>&1 || true
+    NON_INTERACTIVE=true DOTFILES_ROOT='$fake' setup_secondary_identity
+  " </dev/null
+  [ "$status" -eq 0 ]
+  [ -f "$fake/core/git/gitconfig.guarzo.symlink" ]
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bats tests/git_identity.bats`
+Expected: FAIL — `setup_secondary_identity` is not defined.
+
+- [ ] **Step 3: Add the function to `bin/bootstrap`**
+
+Add near the existing gitconfig setup, and call it from the same place that sets up `gitconfig.local`:
+
+```bash
+# Optional secondary GitHub identity (see core/git/identity-owners).
+#
+# --non-interactive NEVER prompts and NEVER partially creates this file, the
+# same contract bootstrap already enforces for the primary identity. A
+# half-populated identity file is worse than none: it looks provisioned to the
+# pre-push guard and then fails at push time.
+setup_secondary_identity() {
+  local template="$DOTFILES_ROOT/core/git/gitconfig.guarzo.symlink.example"
+  local target="$DOTFILES_ROOT/core/git/gitconfig.guarzo.symlink"
+  local name email keypath reply
+
+  [ -f "$template" ] || return 0
+
+  if [ -f "$target" ]; then
+    log_info "Secondary GitHub identity already configured."
+    return 0
+  fi
+
+  if [ "$NON_INTERACTIVE" = true ]; then
+    log_info "Skipping optional secondary GitHub identity (non-interactive)."
+    return 0
+  fi
+
+  printf 'Configure a secondary GitHub identity? [y/N] '
+  read -r reply
+  case "$reply" in
+    [Yy]*) : ;;
+    *) return 0 ;;
+  esac
+
+  printf 'Account name: '
+  read -r name
+  printf 'Account email: '
+  read -r email
+  printf 'Absolute path to its SSH signing public key: '
+  read -r keypath
+
+  if [ -z "$name" ] || [ -z "$email" ] || [ -z "$keypath" ]; then
+    log_warning "Incomplete answers; leaving the secondary identity unconfigured."
+    return 0
+  fi
+
+  sed -e "s|YOUR_ACCOUNT_NAME|$name|" \
+    -e "s|you@example.com|$email|" \
+    -e "s|/home/YOUR_USER/.ssh/id_ed25519_guarzo.pub|$keypath|" \
+    "$template" >"$target"
+
+  log_success "Secondary identity written to $target"
+  log_info "Next: GH_CONFIG_DIR=\$HOME/.gh-guarzo gh auth login"
+}
+```
+
+- [ ] **Step 4: Run tests, lint, and verify relink maps the new files**
+
+```bash
+bats tests/git_identity.bats
+make lint
+bash bin/relink 2>&1 | tail -5
+```
+
+Expected: tests PASS, lint clean, relink completes without reporting skipped destinations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/bootstrap tests/git_identity.bats
+git commit -m "feat(bootstrap): provision the optional secondary identity without prompting non-interactively"
+```
+
+---
+
+### Task 9: Adjacent fixes
+
+**Files:**
+- Modify: `core/git/gitconfig.local.symlink.example`
+- Modify: `README.md`
+- Modify: `tests/repository_hygiene.bats`
+- Delete: `git/gitconfig.local.symlink` (and repoint `~/.gitconfig.local`)
+
+- [ ] **Step 1: Write the failing hygiene test**
+
+Append to `tests/repository_hygiene.bats`:
+
+```bash
+@test "tracked git example files carry no real email addresses" {
+  # Templates keep illustrative placeholders, so allow only the reserved
+  # example domains. Anything else is a personal address in a public repo.
+  run bash -c "
+    grep -hoE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
+      '$REPO_ROOT'/core/git/*.example 2>/dev/null |
+      grep -vE '@example\.(com|invalid|org)$' || true
+  "
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "the stale git/ gitconfig.local copy is gone" {
+  assert_file_absent "$REPO_ROOT/git/gitconfig.local.symlink"
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bats tests/repository_hygiene.bats`
+Expected: FAIL — the example file contains a real gmail address, and the stale copy exists.
+
+- [ ] **Step 3: Scrub the example**
+
+In `core/git/gitconfig.local.symlink.example`, replace the `[user]` block with:
+
+```
+[user]
+	name = YOUR_NAME
+	email = you@example.com
+	# signingkey = YOUR_GPG_KEY_ID
+```
+
+Note: this changes `HEAD` only. The address remains in git history and is already public; rewriting history is out of scope.
+
+- [ ] **Step 4: Repoint the machine-local symlink and remove the stale copy**
+
+```bash
+cp -a ~/.dotfiles/git/gitconfig.local.symlink ~/.dotfiles/core/git/gitconfig.local.symlink
+ln -sfn "$HOME/.dotfiles/core/git/gitconfig.local.symlink" "$HOME/.gitconfig.local"
+rm -f ~/.dotfiles/git/gitconfig.local.symlink
+git -C ~/.dotfiles rm -r --cached --ignore-unmatch git/ 2>/dev/null || true
+```
+
+Verify: `readlink ~/.gitconfig.local` prints the `core/git/` path, and `git config user.email` is unchanged.
+
+- [ ] **Step 5: Replace the README section**
+
+Replace the `## Multiple GitHub Accounts` section (the SSH host-alias recipe) with a description of owner-based routing: the `core/git/identity-owners` map, the gitignored `gitconfig.guarzo.symlink` and its template, `bin/gh`, `bin/git-identity`, the pre-push guard, and the two manual provisioning steps. Add `~/.gitconfig.guarzo` and `~/.bash_profile` to the symlink table. State that SSH transport and mixed-owner repositories are unsupported and detected.
+
+- [ ] **Step 6: Run tests and commit**
+
+```bash
+bats tests/repository_hygiene.bats
+make lint
+git add -A
+git commit -m "docs(git): document owner-based identity routing and scrub the example address"
+```
+
+---
+
+### Task 10: Migrate the three repositories and verify end to end
+
+**Files:** none in this repository. Operates on `~/workspace/{binderplan,slabledger,yetishopify}`.
+
+**Why this is required, not cleanup:** repo-local config outranks `~/.gitconfig` includes, so these three repositories shadow the new mechanism entirely. Until they are migrated, none of the routing above takes effect for them.
+
+- [ ] **Step 1: Record the current values (reversibility)**
+
+```bash
+for repo in binderplan slabledger yetishopify; do
+  printf '=== %s ===\n' "$repo"
+  git -C "$HOME/workspace/$repo" config --local --get-regexp 'user\.|credential' || true
+done | tee /tmp/identity-migration-backup.txt
+```
+
+Expected: each repo shows `user.name`, `user.email`, and a credential helper. Keep this file until Step 5 passes.
+
+- [ ] **Step 2: Complete the two manual provisioning steps**
+
+These require the account holder and cannot be scripted:
+
+```bash
+GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth login # scopes: repo, workflow
+ssh-keygen -t ed25519 -f "$HOME/.ssh/id_ed25519_guarzo" -C "guarzo signing key"
+```
+
+Register `~/.ssh/id_ed25519_guarzo.pub` on the guarzo account **as a signing key** (GitHub keeps authentication and signing keys in separate lists), then append a line for the guarzo email to `~/.ssh/allowed_signers`.
+
+Then create `core/git/gitconfig.guarzo.symlink` from the template with the real values and run `bin/relink`.
+
+Verify: `GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth status` reports a valid token.
+
+- [ ] **Step 3: Strip the repo-local config**
+
+```bash
+for repo in binderplan slabledger yetishopify; do
+  cd "$HOME/workspace/$repo"
+  git config --local --unset-all user.name || true
+  git config --local --unset-all user.email || true
+  git config --local --unset-all credential.helper || true
+  git config --local --unset-all credential.https://github.com.helper || true
+done
+```
+
+- [ ] **Step 4: Verify each repository resolves correctly from the remote alone**
+
+```bash
+for repo in binderplan slabledger yetishopify; do
+  printf '=== %s ===\n' "$repo"
+  (cd "$HOME/workspace/$repo" && "$HOME/.dotfiles/bin/git-identity")
+done
+```
+
+Expected: each prints `owner: guarzo`, `identity: guarzo`, `status: OK`, and an email matching the recorded backup.
+
+- [ ] **Step 5: Verify a real push path and the untouched default identity**
+
+```bash
+cd "$HOME/workspace/slabledger" && git push --dry-run origin HEAD
+cd "$HOME/workspace/headlamp" && "$HOME/.dotfiles/bin/git-identity"
+gh auth status
+```
+
+Expected: the guarzo dry-run authenticates and is not blocked; `headlamp` reports `<unmapped>` / `default`; `gh auth status` still shows the default account active.
+
+- [ ] **Step 6: Full verification**
+
+```bash
+make check 2>&1 | tail -20
+```
+
+Expected: no failures outside the known-bad baseline (`dev_commands`, `dev_config_merge`, `dev_install`, `dev_lifecycle`, `claude_compose_override`). Compare the failure count against the 60 recorded on `main`; any increase is a regression from this work.
+
+- [ ] **Step 7: Clean up and commit**
+
+```bash
+rm -f /tmp/identity-migration-backup.txt
+git -C ~/.dotfiles status --short
+```
+
+Expected: clean tree — this task changes no tracked files.
+
+---
+
+## Self-Review
+
+**Spec coverage:** owner map → Task 1; routing + credential collapse → Task 2; machine-local identity + template + gitignore → Task 3; `gh` shim incl. mixed-owner refusal and recursion safety → Task 4; bash login coverage → Task 5; guard incl. LFS composition, stdin, and the fail-open boundary → Task 6; doctor incl. all five exit codes → Task 7; provisioning and the non-interactive contract → Task 8; adjacent fixes and hygiene → Task 9; migration and manual steps → Task 10. No spec section is unimplemented.
+
+**Reviewer constraints:** (1) validation → Task 1 Step 4, tested Step 1; (2) pair comparison → Task 2 Step 1, second test; (3) explicit match definition → Task 6 preamble and implementation, with the indeterminate case tested; (4) stdin and LFS status → Task 6, three dedicated tests; (5) symlink-resolving self-exclusion → Task 4 `identity_realpath`, tested via the symlink test.
+
+**Type consistency:** all five library functions are named identically across Tasks 1, 4, 6, and 7 (`identity_url_owner`, `identity_load_map`, `identity_owner_slug`, `identity_slug_configdir`, `identity_slug_provisioned`, `identity_repo_owners`). The slug `guarzo` and path `~/.gh-guarzo` are consistent throughout.

--- a/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
+++ b/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
@@ -34,11 +34,14 @@ The manual approach has already drifted and already failed:
 
 ## Goal
 
-Inside any repository whose remote is owned by `guarzo`, git and `gh` act as
+In any repository whose GitHub remotes are owned by `guarzo`, git and `gh` act as
 `guarzo` — credentials, commit author, and commit signature. Everywhere else the
-default identity applies, unchanged. No global state, no `gh auth switch`, no
-per-repository setup step, and nothing personal committed to this public
-repository.
+default identity applies, unchanged. No global state, no `gh auth switch`, and
+nothing personal committed to this public repository.
+
+Where the routing cannot be made automatic, the wrong identity must fail loudly
+rather than silently. That principle drives the pre-push guard below, and it is
+the reason several honest limitations are documented rather than papered over.
 
 ## Constraints and evidence
 
@@ -52,57 +55,67 @@ repository.
 - **Repo-local config outranks `~/.gitconfig` includes.** The three existing
   repositories therefore shadow any mechanism added here. Unwinding their local
   config is a correctness requirement, not cleanup.
-- **Any `*.zsh` file under `core/`, `languages/`, or `tools/` is auto-sourced**
-  by `core/shell/load-custom.zsh`, so a new `core/git/identity.zsh` loads with no
-  registration step.
-- **Claude Code sessions run bash**, not zsh, so a zsh function does not reach
-  them. Per-project `.claude/settings.local.json` `env` blocks do; the global
-  `ai/claude/settings.json` already uses an `env` block, and the private
-  `~/.dotfiles/projects` overlay repository already carries overlays for several
-  `guarzo` projects.
+- **Global hooks must fail open.** `core/git/git-hooks.symlink/pre-push` carries
+  an extended comment explaining that `core.hooksPath` is global, so a hook that
+  errors breaks every repository on the machine, including ones unrelated to the
+  feature. Any hook added here inherits that constraint.
+- **`~/.dotfiles/bin` precedes `/usr/local/bin`** in both zsh and bash, so an
+  executable placed there shadows the real `gh`.
 
 ### Behaviour verified before adopting the design
 
-Tested against git 2.54.0 with a temporary `HOME` and throwaway repositories:
+Tested against git 2.54.0 with a temporary `HOME` and throwaway repositories.
 
 | Case | Result |
 | --- | --- |
 | `https://github.com/guarzo/…` remote | routes to the guarzo include |
-| `git@github.com:guarzo/…` remote | routes to the guarzo include |
 | `https://github.com/gambtho/…` remote | stays on the default identity |
 | Linked worktree of a guarzo repo | inherits guarzo |
 | Linked worktree nested at `.claude/worktrees/` | inherits guarzo |
 | Include file absent | silently ignored, default identity, exit 0 |
 | `git credential fill` in a guarzo repo | runs the helper with `GH_CONFIG_DIR` set to the guarzo directory |
 | `git credential fill` in a gambtho repo | never invokes the guarzo helper |
+| `origin`=gambtho + `upstream`=guarzo, `remote.pushDefault=origin` | **routes to guarzo** — see below |
+| `hasconfig:remote.origin.url:…` (narrowed matcher) | matches nothing, silently; not a supported keyword |
+| `ssh://git@github.com/guarzo/…` remote | does **not** match the scp-style glob |
+| `~/.dotfiles/bin` on `PATH` in `env -i bash -l` | **absent** — only inherited from a zsh parent |
 
 The credential-helper rows were exercised against a stub `gh` on `PATH`,
 confirming that the `!`-prefixed helper runs through a shell, that `$HOME`
 expands inside it, and that the variable reaches the `gh` process — not merely
 that git stores the string.
 
-The last row is what makes the tracked wiring safe to publish: on a machine with
-no guarzo identity the conditional includes are inert rather than broken.
+The "include file absent" row is what makes the tracked wiring safe to publish:
+on a machine with no guarzo identity the conditional includes are inert rather
+than broken.
+
+The last four rows are load-bearing limitations discovered in review, and each
+one shapes the design below.
 
 ## Design
 
-Three layers, each with a single responsibility, both enforcement points driven
-by one rule — who owns the remote.
+Four components. Routing is declarative and covers the common case; a guard
+converts the cases routing cannot cover from silent to loud.
 
 ### 1. Routing (tracked, public)
 
-`core/git/gitconfig.symlink` gains two conditional includes covering both remote
-URL forms:
+`core/git/gitconfig.symlink` gains one conditional include:
 
 ```
 [includeIf "hasconfig:remote.*.url:https://github.com/guarzo/**"]
-	path = ~/.gitconfig.guarzo
-[includeIf "hasconfig:remote.*.url:git@github.com:guarzo/**"]
 	path = ~/.gitconfig.guarzo
 ```
 
 This is the only tracked change to identity behaviour. It names an account owner
 but contains no personal data.
+
+**`hasconfig` matches any configured remote, not the push target.** This was
+verified: a repository with `origin` owned by `gambtho` and `upstream` owned by
+`guarzo` resolves to the guarzo identity even with `remote.pushDefault=origin`.
+The matcher cannot be narrowed — `hasconfig:remote.origin.url:` is not a
+supported keyword and matches nothing at all, without warning. Mixed-owner
+repositories are therefore **out of scope for routing** and are handled by the
+guard in component 4.
 
 The same file's duplicate `[credential "https://github.com"]` block is collapsed
 in the process. Today both `core/git/gitconfig.symlink` and `~/.gitconfig.local`
@@ -111,6 +124,20 @@ later reset discards everything accumulated before it, the effective helper is
 `/usr/bin/gh` (2.45.0, from apt) rather than the `/usr/local/bin/gh` (2.79.0)
 that the shell uses. One block survives, referencing `gh` by name and resolving
 through `PATH`.
+
+#### HTTPS only
+
+Only the HTTPS remote form is routed. SSH transport is explicitly **not
+supported**, because routing it correctly requires more than a credential
+helper: for `git@github.com:guarzo/…` git never invokes a credential helper at
+all, and key selection happens in ssh via the agent, default key files, or
+`~/.ssh/config`. `user.signingKey` controls only commit signing and does not
+select an authentication key, so a design that set only the signing key would
+still authenticate SSH pushes as the default account.
+
+All three guarzo repositories use HTTPS today, so this costs nothing now.
+A guarzo SSH remote is reported as unsupported by `bin/git-identity` and is
+caught by the pre-push guard before any push completes.
 
 ### 2. Identity values (machine-local, gitignored)
 
@@ -134,50 +161,94 @@ key on every platform.
 A tracked `core/git/gitconfig.guarzo.symlink.example` carries the same structure
 with placeholders, mirroring the existing `gitconfig.local.symlink.example`.
 
-### 3. `gh` routing
+### 3. `gh` routing via a `PATH` shim
 
-`core/git/identity.zsh` defines a `gh` wrapper function that resolves the current
-repository's remote owner and prepends `GH_CONFIG_DIR` for `guarzo` repositories
-only. Outside a git repository, or in any repository with another owner, it
-delegates to the real `gh` untouched.
+`bin/gh` is an executable that resolves the current repository's GitHub remote
+owner, sets `GH_CONFIG_DIR` for a matching identity, and then execs the real
+`gh`. It locates the real binary by scanning `PATH` for the first `gh` that is
+not itself, so it cannot recurse, and it delegates unchanged when there is no
+match, no repository, or no configured identity.
 
-For Claude Code sessions, each `guarzo` project's
-`.claude/settings.local.json` gains a static `env` block setting
-`GH_CONFIG_DIR`, delivered through the private `~/.dotfiles/projects` overlay
-repository. A static value is correct there because a given project has exactly
-one identity.
+A shim rather than a shell function because a zsh function reaches only
+interactive zsh: not bash, not scripts, not editor integrations, not Codex, and
+not Claude Code's bash tool. Routing that disagrees between callers in the same
+repository would reintroduce exactly the silent wrong-identity failure this
+design exists to remove.
 
-### 4. Verification command
+**Coverage is bounded by `PATH`.** `~/.dotfiles/bin` precedes `/usr/local/bin` in
+both zsh and bash, but a clean environment (`env -i bash -l`) does not have it at
+all — it is present in bash only by inheritance from a zsh parent, because
+neither `~/.profile` nor `~/.bashrc` adds it. To make the shim's reach match its
+claim, `~/.dotfiles/bin` is added to `PATH` for bash login shells via a
+dotfiles-managed `~/.profile` snippet. `~/.profile` is not dotfiles-managed
+today, so this is new surface and is called out as such.
+
+Even then, cron and other environments that read neither profile are not
+covered. Those must set `GH_CONFIG_DIR` explicitly; this is documented, not
+solved.
+
+Because the shim covers Claude Code's bash sessions, no per-project
+`.claude/settings.local.json` `env` block is required, and none is added. That
+removes the per-repository setup step that an earlier draft depended on.
+
+### 4. Pre-push identity guard
+
+A `pre-push` addition asserts that the identity about to be used matches the
+owner of the URL being pushed to, and aborts the push when they disagree.
+
+This is the component that makes the limitations above safe. It catches:
+
+- mixed-owner repositories, where routing picked an identity from a remote that
+  is not the push target;
+- a guarzo repository whose include file is missing or unprovisioned;
+- a guarzo SSH remote, which routing deliberately does not handle;
+- a push to a guarzo URL from a repository that resolved to the default
+  identity for any other reason.
+
+Per the constraint above, it must fail open on everything outside its remit: a
+non-`github.com` host, a repository whose owner maps to no configured identity,
+a missing `gh` or `jq`, or any internal error all result in `exit 0` and no
+output. It blocks only when it can positively determine that the identity and
+the push destination disagree. The existing hook's own comment is the precedent
+and the cautionary tale — a global hook that errors breaks unrelated
+repositories, including lazy.nvim's plugin clones.
+
+### 5. Verification command
 
 `bin/git-identity` reports, for the current repository: the matched owner, the
 resolved `user.email` and `user.signingKey`, which `gh` config directory applies,
 and whether that directory holds a valid token. It exits zero when the resolved
-identity is usable, and non-zero in exactly two cases: the remote owner matches a
-configured identity whose token is missing or invalid, or the remote owner
-matches an identity whose include file is absent. An unmatched remote owner is
-not an error — it is the default identity working as intended.
-
-This exists because every failure mode in this design is silent — a missing
-include, an unmatched remote, and an expired token all present as "you are
-quietly the default identity." The command turns a silent state into a
-one-line answer.
+identity is usable, and non-zero in exactly these cases: a matched identity whose
+token is missing or invalid; a matched identity whose include file is absent; a
+mixed-owner repository; and a guarzo SSH remote. An unmatched remote owner is not
+an error — it is the default identity working as intended.
 
 ## Data flow
 
 For git, configuration resolves system → `~/.gitconfig` → `~/.gitconfig.local`
-(default identity) → `~/.gitconfig.guarzo` (when the remote matches) →
+(default identity) → `~/.gitconfig.guarzo` (when any remote matches) →
 repository-local `.git/config`. After migration the three `guarzo` repositories
 hold no identity configuration at all and derive everything from their remote.
 
-For `gh`, the wrapper reads the remote owner and sets `GH_CONFIG_DIR` for that
+For `gh`, the shim reads the remote owner and sets `GH_CONFIG_DIR` for that
 single invocation. No global state is modified.
+
+At push time the guard independently re-derives the expected identity from the
+destination URL and compares it against what git actually resolved.
 
 ## Failure handling
 
+**Mixed-owner repositories.** Routing selects an identity from any matching
+remote, which may not be the push target. The guard blocks the push and names
+the disagreement. Not silently mitigated, because it cannot be.
+
+**SSH remotes owned by guarzo.** Not routed. Author and signing identity fall
+back to the default, and the guard blocks the push rather than letting it
+authenticate as the wrong account.
+
 **Clone-time gap.** During `git clone` no remote exists yet, so the default
-identity authenticates. Public `guarzo` repositories clone fine; private ones
-fail outright, which is a visible failure rather than a subtle one. Documented
-workaround, already in use:
+identity authenticates. Public guarzo repositories clone fine; private ones fail
+outright. Documented workaround, already in use:
 `GH_CONFIG_DIR=~/.gh-guarzo gh repo clone guarzo/<repo>`. Every operation after
 the remote exists routes correctly, including the first commit, so authorship is
 never wrong.
@@ -185,28 +256,46 @@ never wrong.
 **Invalid or missing token.** Pushes fail with an authentication error rather
 than falling back to the other identity. `bin/git-identity` reports it directly.
 
-**`gh` outside a repository.** The wrapper keys off the current repository, so
+**`gh` outside a repository.** The shim keys off the current repository, so
 `gh repo clone guarzo/new` from `~` uses the default identity. Documented, not
 solved: solving it would require parsing `gh`'s arguments, which would break on
 `gh` releases.
 
-**Machine without a guarzo identity.** The conditional includes reference a
-missing file, which git ignores silently; the wrapper finds no config directory
-and delegates to real `gh`. A fresh bootstrap is unaffected.
+**Environments without `~/.dotfiles/bin` on `PATH`.** cron and similar contexts
+bypass the shim and use the default identity for `gh`. Git routing is unaffected,
+since it depends on config rather than `PATH`, and the guard still applies.
 
-## Manual provisioning
+**Machine without a guarzo identity.** The conditional include references a
+missing file, which git ignores silently; the shim finds no config directory and
+delegates; the guard maps no owner and exits 0. A fresh bootstrap is unaffected.
 
-Two steps require the account holder and cannot be automated here. Final
-verification is gated on both rather than declared against a dead token.
+## Provisioning
 
-1. `GH_CONFIG_DIR=~/.gh-guarzo gh auth login`, with `repo` and `workflow`
-   scopes. `BROWSER=false` selects the device flow if the browser handoff fails.
-2. Generate `~/.ssh/id_ed25519_guarzo`, register the public half on the guarzo
-   account **as a signing key** (GitHub keeps authentication and signing keys in
-   separate lists), and add a matching line to `~/.ssh/allowed_signers`. That
-   file currently holds one entry, bound to the default identity's address,
-   which is why signature verification across the three repositories currently
-   produces three different results.
+The conditional include is inert until `core/git/gitconfig.guarzo.symlink`
+exists, is populated, and is linked to `~/.gitconfig.guarzo`. Because the real
+file is gitignored, **it does not exist after cloning this repository**, so a
+new machine can complete every other step and still silently use the default
+identity.
+
+Provisioning therefore covers all four of:
+
+1. `bootstrap` copies `gitconfig.guarzo.symlink.example` to
+   `gitconfig.guarzo.symlink` and prompts for the identity values, following the
+   pattern it already uses for `gitconfig.local`. It skips the whole step when
+   the user declines a second identity, leaving the include inert.
+2. `bin/relink` creates the `~/.gitconfig.guarzo` symlink.
+3. `GH_CONFIG_DIR=~/.gh-guarzo gh auth login` with `repo` and `workflow` scopes.
+   `BROWSER=false` selects the device flow if the browser handoff fails. **Manual
+   — requires the account holder.**
+4. Generate `~/.ssh/id_ed25519_guarzo`, register the public half on the guarzo
+   account **as a signing key**, and add a matching line to
+   `~/.ssh/allowed_signers`. That file currently holds one entry, bound to the
+   default identity's address, which is why signature verification across the
+   three repositories currently produces three different results. **Manual.**
+
+Steps 3 and 4 cannot be automated here, and final verification is gated on both
+rather than declared against the currently-invalid token. `bin/git-identity`
+reports which of the four are incomplete.
 
 ## Adjacent fixes in scope
 
@@ -220,14 +309,15 @@ verification is gated on both rather than declared against a dead token.
   `core/git/gitconfig.local.symlink.example` with a placeholder. This changes
   `HEAD` only; the address remains in git history and is already public.
 - Migrate the three `guarzo` repositories off their repo-local identity config.
+- Replace the README's "Multiple GitHub Accounts" section, which documents the
+  SSH host-alias approach this design supersedes.
 
 ## Migration
 
-For each of `binderplan`, `slabledger`, and `yetishopify`: unset the local
-`user.name`, `user.email`, and credential helper entries, then confirm that the
-values resolved from the conditional include match what the local config
-previously set. These repositories are outside this repository and the change is
-reversible from the values recorded before removal.
+For each of `binderplan`, `slabledger`, and `yetishopify`: record the current
+local values, unset the local `user.name`, `user.email`, and credential helper
+entries, then confirm the values resolved from the conditional include match
+what was recorded. Reversible from the recorded values.
 
 ## Testing
 
@@ -235,8 +325,10 @@ A new bats suite follows the existing `setup_dotfiles_test` pattern, using a
 temporary `HOME` and throwaway repositories. Nothing in the suite touches a real
 token or the network.
 
-- Routing by remote owner over HTTPS and SSH resolves email, signing key, and
-  credential helper; a non-`guarzo` remote stays on the default.
+Routing:
+
+- HTTPS guarzo remote resolves email, signing key, and credential helper; a
+  non-guarzo remote stays on the default.
 - Linked worktrees inherit the routed identity, including one nested at
   `.claude/worktrees/`.
 - A missing include file yields the default identity and exit 0.
@@ -244,10 +336,28 @@ token or the network.
   `[credential "https://github.com"]` block — a regression test for the
   duplicate-block bug.
 - `.gitignore` covers `core/git/gitconfig.guarzo.symlink`.
-- The `gh` wrapper selects the guarzo config directory for a guarzo remote,
-  delegates unchanged for other remotes, and delegates outside a repository.
-- `bin/git-identity` reports the routed identity and flags an invalid token,
-  exercised against a stub.
+
+Shim:
+
+- Selects the guarzo config directory for a guarzo remote, delegates unchanged
+  for other remotes and outside a repository, and does not recurse when it is
+  the first `gh` on `PATH`.
+
+Guard:
+
+- Blocks a push to a guarzo URL from a repository resolved to the default
+  identity, and a mixed-owner push whose destination disagrees with the routed
+  identity.
+- Allows a correctly-matched push.
+- Fails open — exit 0, no output — for a non-`github.com` host, an unmapped
+  owner, and a missing `gh` or `jq`. This is the highest-value test in the suite,
+  because a regression here breaks every repository on the machine.
+
+Doctor and hygiene:
+
+- `bin/git-identity` reports the routed identity, and exits non-zero for an
+  invalid token, an absent include file, a mixed-owner repository, and a guarzo
+  SSH remote. Exercised against a stub.
 - Added to `tests/repository_hygiene.bats`: tracked `core/git/*.example` files
   contain no email address outside the reserved `example.com` /
   `example.invalid` domains, so the scrub cannot regress while templates keep
@@ -263,15 +373,14 @@ known-bad set; every other suite must stay green.
 
 ## Out of scope
 
+- **SSH transport routing.** Reasoned above; detected and blocked, not
+  supported.
+- **Mixed-owner repositories.** Detected and blocked, not routed.
 - A registry or generator for arbitrary numbers of identities. The design ships
   exactly one non-default identity, structured so a second is a copy of one
-  conditional-include pair plus one gitignored file.
+  conditional include plus one gitignored file.
 - Rewriting git history to remove the address already published in
   `gitconfig.local.symlink.example`.
-- A `PATH` shim intercepting every `gh` invocation machine-wide. Rejected as
-  disproportionate: it would route work repositories through the same
-  interception layer to solve a problem confined to three personal ones.
+- `gh` routing in environments that read neither `~/.profile` nor a zsh startup
+  file, such as cron.
 - Changing how the default identity authenticates.
-- SSH host aliases. The README's current "Multiple GitHub Accounts" section
-  documents that approach; it is replaced, because it covers only git transport
-  and not `gh`, and requires rewriting each remote URL.

--- a/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
+++ b/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
@@ -94,7 +94,7 @@ one shapes the design below.
 
 ## Design
 
-Four components. Routing is declarative and covers the common case; a guard
+Five components. Routing is declarative and covers the common case; a guard
 converts the cases routing cannot cover from silent to loud.
 
 ### 1. Routing (tracked, public)
@@ -175,17 +175,46 @@ not Claude Code's bash tool. Routing that disagrees between callers in the same
 repository would reintroduce exactly the silent wrong-identity failure this
 design exists to remove.
 
+**Mixed-owner repositories.** The pre-push guard protects `git push` only.
+Repository-contextual `gh` commands — `gh pr merge`, `gh issue close`,
+`gh release delete` — carry the same wrong-account risk with no hook to catch
+them. When the shim finds more than one mapped GitHub owner among the
+repository's remotes it therefore **refuses to run** and exits non-zero with an
+actionable message, rather than guessing.
+
+The refusal covers every `gh` invocation in such a repository rather than only
+the repository-contextual subset, because distinguishing them means parsing
+`gh`'s arguments, which is the same fragility rejected elsewhere in this design.
+The escape hatch is an explicit `GH_CONFIG_DIR` (optionally with `GH_REPO`) in
+the caller's environment: when `GH_CONFIG_DIR` is already set, the shim passes
+through untouched and the caller owns the choice.
+
 **Coverage is bounded by `PATH`.** `~/.dotfiles/bin` precedes `/usr/local/bin` in
 both zsh and bash, but a clean environment (`env -i bash -l`) does not have it at
 all — it is present in bash only by inheritance from a zsh parent, because
-neither `~/.profile` nor `~/.bashrc` adds it. To make the shim's reach match its
-claim, `~/.dotfiles/bin` is added to `PATH` for bash login shells via a
-dotfiles-managed `~/.profile` snippet. `~/.profile` is not dotfiles-managed
-today, so this is new surface and is called out as such.
+neither `~/.profile` nor `~/.bashrc` adds it.
 
-Even then, cron and other environments that read neither profile are not
-covered. Those must set `GH_CONFIG_DIR` explicitly; this is documented, not
-solved.
+Bash login coverage is delivered by a new tracked `core/shell/bash_profile.symlink`
+mapping to `~/.bash_profile`, which sources `~/.profile` if present and then
+prepends `~/.dotfiles/bin` to `PATH`.
+
+This specific shape is required by the existing installer. `link_file` in
+`bin/relink` uses `policy=skip` for any destination that is not already a
+symlink, and `bin/relink` then calls `log_error` — which exits — if any
+destination was skipped. A `profile.symlink` would therefore collide with the
+real `~/.profile` on this machine and abort `bin/relink` for *every* managed
+dotfile, not merely fail to install itself. `~/.bash_profile` does not exist
+here, so it links cleanly.
+
+Chaining rather than replacing preserves the existing `~/.profile`, which
+sources `~/.bashrc`, adds `~/bin` and `~/.local/bin`, and loads the Cargo
+environment. Bash reads `~/.bash_profile` instead of `~/.profile` when the former
+exists — as the stock `~/.profile` header itself notes — so sourcing it first
+keeps current behaviour intact.
+
+Non-bash POSIX login shells continue to read `~/.profile` only and do not get the
+shim. Neither do cron and other environments that read no profile at all. Those
+must set `GH_CONFIG_DIR` explicitly; this is documented, not solved.
 
 Because the shim covers Claude Code's bash sessions, no per-project
 `.claude/settings.local.json` `env` block is required, and none is added. That
@@ -205,13 +234,37 @@ This is the component that makes the limitations above safe. It catches:
 - a push to a guarzo URL from a repository that resolved to the default
   identity for any other reason.
 
-Per the constraint above, it must fail open on everything outside its remit: a
-non-`github.com` host, a repository whose owner maps to no configured identity,
-a missing `gh` or `jq`, or any internal error all result in `exit 0` and no
-output. It blocks only when it can positively determine that the identity and
-the push destination disagree. The existing hook's own comment is the precedent
-and the cautionary tale — a global hook that errors breaks unrelated
-repositories, including lazy.nvim's plugin clones.
+#### Composition with the existing hook
+
+The existing `pre-push` ends with `git lfs pre-push "$@"`, whose exit status
+becomes the hook's exit status. Appending the guard after it would let a guard
+that exits 0 overwrite a non-zero LFS result, pushing refs whose LFS objects
+never uploaded. Order is therefore fixed and load-bearing:
+
+1. Run the identity guard first — it needs only the destination arguments.
+2. Abort immediately, non-zero, if the guard rejects the push.
+3. Run `git lfs pre-push "$@"` last, so its exit status stays authoritative.
+
+#### Fail-open boundary
+
+Fail-open applies *before* the guard establishes that a push is within its remit,
+not after. Blanket fail-open would contradict this design's stated principle that
+an unroutable identity must fail loudly.
+
+| Destination | Condition | Behaviour |
+| --- | --- | --- |
+| Non-`github.com`, or owner maps to no configured identity | any | exit 0, silent |
+| Owner maps to a configured identity | resolved identity matches | allow |
+| Owner maps to a configured identity | resolved identity disagrees | block, actionable message |
+| Owner maps to a configured identity | cannot determine — missing `gh`/`jq`, unreadable config, indeterminate identity | **block**, actionable message |
+
+The first row preserves the constraint that a global hook must not break
+unrelated repositories: a machine with no guarzo identity, or any repository
+pushing elsewhere, never reaches a blocking path. The existing hook's own comment
+is the precedent and the cautionary tale — a global hook that errors breaks
+unrelated repositories, including lazy.nvim's plugin clones. The last row is the
+narrow, deliberate exception: once the destination is known to be a configured
+identity's, "I cannot verify" is not a safe reason to proceed.
 
 ### 5. Verification command
 
@@ -240,7 +293,8 @@ destination URL and compares it against what git actually resolved.
 
 **Mixed-owner repositories.** Routing selects an identity from any matching
 remote, which may not be the push target. The guard blocks the push and names
-the disagreement. Not silently mitigated, because it cannot be.
+the disagreement, and the `gh` shim refuses to run at all. Not silently
+mitigated, because it cannot be.
 
 **SSH remotes owned by guarzo.** Not routed. Author and signing identity fall
 back to the default, and the guard blocks the push rather than letting it
@@ -261,9 +315,10 @@ than falling back to the other identity. `bin/git-identity` reports it directly.
 solved: solving it would require parsing `gh`'s arguments, which would break on
 `gh` releases.
 
-**Environments without `~/.dotfiles/bin` on `PATH`.** cron and similar contexts
-bypass the shim and use the default identity for `gh`. Git routing is unaffected,
-since it depends on config rather than `PATH`, and the guard still applies.
+**Environments without `~/.dotfiles/bin` on `PATH`.** cron, and non-bash POSIX
+login shells, bypass the shim and use the default identity for `gh`. Git routing
+is unaffected, since it depends on config rather than `PATH`, and the guard still
+applies to any push.
 
 **Machine without a guarzo identity.** The conditional include references a
 missing file, which git ignores silently; the shim finds no config directory and
@@ -342,6 +397,17 @@ Shim:
 - Selects the guarzo config directory for a guarzo remote, delegates unchanged
   for other remotes and outside a repository, and does not recurse when it is
   the first `gh` on `PATH`.
+- Refuses to run, non-zero, in a mixed-owner repository, and passes through
+  untouched when the caller has already set `GH_CONFIG_DIR`.
+
+Bash login coverage:
+
+- `core/shell/bash_profile.symlink` puts `~/.dotfiles/bin` ahead of
+  `/usr/local/bin` in `env -i bash -l`, and preserves the effects of a
+  pre-existing real `~/.profile` — exercised against a temporary `HOME`
+  containing one, not an empty home.
+- `managed_link_pairs` maps it to `~/.bash_profile`, and `bin/relink` completes
+  without skipping when that destination is absent.
 
 Guard:
 
@@ -349,9 +415,17 @@ Guard:
   identity, and a mixed-owner push whose destination disagrees with the routed
   identity.
 - Allows a correctly-matched push.
-- Fails open — exit 0, no output — for a non-`github.com` host, an unmapped
-  owner, and a missing `gh` or `jq`. This is the highest-value test in the suite,
-  because a regression here breaks every repository on the machine.
+- Fails **open** — exit 0, no output — for a non-`github.com` host and an
+  unmapped owner. A regression here breaks every repository on the machine.
+- Fails **closed** for a configured destination when `gh` or `jq` is missing or
+  the identity is otherwise indeterminate. Paired with the row above, these two
+  tests pin the boundary that a single blanket rule would blur.
+
+Hook composition:
+
+- With `git-lfs` stubbed to exit non-zero and the guard passing, the composed
+  hook exits non-zero — LFS failures are not masked.
+- With the guard rejecting, `git lfs pre-push` is never reached.
 
 Doctor and hygiene:
 

--- a/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
+++ b/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
@@ -1,0 +1,277 @@
+# Multi-GitHub-identity routing
+
+Route git and `gh` to the right GitHub account automatically, based on who owns
+the remote, so that one machine can hold two identities without any global
+switching.
+
+## Problem
+
+This machine has two GitHub identities. The default is the `gambtho` account,
+logged in to the standard `~/.config/gh`. A second identity, `guarzo`, owns
+three checkouts under `~/workspace` (`binderplan`, `slabledger`, `yetishopify`),
+interleaved with a dozen `gambtho` and work repositories.
+
+A partial solution already exists and was built by hand on 2026-02-23: a second
+`gh` config directory at `~/.gh-guarzo`, plus repo-local `git config` applied
+individually to each of the three repositories, documented in
+`~/.gh-guarzo/SETUP.md`. None of it is in this repository, so it is neither
+reproducible on a new machine nor protected against drift.
+
+The manual approach has already drifted and already failed:
+
+- `slabledger` sets a bare `credential.helper`; `binderplan` and `yetishopify`
+  set the host-scoped `credential.https://github.com.helper`. Same intent, two
+  mechanisms, applied by hand three times.
+- All three override `user.name` and `user.email` but none overrides
+  `user.signingKey`, so all three inherit the default identity's key while
+  `commit.gpgSign` is globally true. The three most recent commits verify as
+  `G` (good), `E` (error), and `N` (unsigned) respectively — one setting missed
+  three times, with three different outcomes.
+- The token in `~/.gh-guarzo/hosts.yml` is currently invalid, so `guarzo`
+  authentication is broken as of this writing.
+- Every new `guarzo` clone requires remembering to repeat the recipe, and
+  forgetting it fails silently as the wrong identity.
+
+## Goal
+
+Inside any repository whose remote is owned by `guarzo`, git and `gh` act as
+`guarzo` — credentials, commit author, and commit signature. Everywhere else the
+default identity applies, unchanged. No global state, no `gh auth switch`, no
+per-repository setup step, and nothing personal committed to this public
+repository.
+
+## Constraints and evidence
+
+- **This repository is public.** `tests/repository_hygiene.bats` already enforces
+  that nothing under `projects/` is tracked. Identity values (email addresses,
+  key paths) must not be tracked here. The established pattern is a gitignored
+  real file beside a tracked `.example` template: `core/git/gitconfig.local.symlink`
+  is listed in `.gitignore` and documented in the README symlink table.
+- **git is 2.54.0**, so `includeIf "hasconfig:remote.*.url:…"` (added in 2.36) is
+  available.
+- **Repo-local config outranks `~/.gitconfig` includes.** The three existing
+  repositories therefore shadow any mechanism added here. Unwinding their local
+  config is a correctness requirement, not cleanup.
+- **Any `*.zsh` file under `core/`, `languages/`, or `tools/` is auto-sourced**
+  by `core/shell/load-custom.zsh`, so a new `core/git/identity.zsh` loads with no
+  registration step.
+- **Claude Code sessions run bash**, not zsh, so a zsh function does not reach
+  them. Per-project `.claude/settings.local.json` `env` blocks do; the global
+  `ai/claude/settings.json` already uses an `env` block, and the private
+  `~/.dotfiles/projects` overlay repository already carries overlays for several
+  `guarzo` projects.
+
+### Behaviour verified before adopting the design
+
+Tested against git 2.54.0 with a temporary `HOME` and throwaway repositories:
+
+| Case | Result |
+| --- | --- |
+| `https://github.com/guarzo/…` remote | routes to the guarzo include |
+| `git@github.com:guarzo/…` remote | routes to the guarzo include |
+| `https://github.com/gambtho/…` remote | stays on the default identity |
+| Linked worktree of a guarzo repo | inherits guarzo |
+| Linked worktree nested at `.claude/worktrees/` | inherits guarzo |
+| Include file absent | silently ignored, default identity, exit 0 |
+| `git credential fill` in a guarzo repo | runs the helper with `GH_CONFIG_DIR` set to the guarzo directory |
+| `git credential fill` in a gambtho repo | never invokes the guarzo helper |
+
+The credential-helper rows were exercised against a stub `gh` on `PATH`,
+confirming that the `!`-prefixed helper runs through a shell, that `$HOME`
+expands inside it, and that the variable reaches the `gh` process — not merely
+that git stores the string.
+
+The last row is what makes the tracked wiring safe to publish: on a machine with
+no guarzo identity the conditional includes are inert rather than broken.
+
+## Design
+
+Three layers, each with a single responsibility, both enforcement points driven
+by one rule — who owns the remote.
+
+### 1. Routing (tracked, public)
+
+`core/git/gitconfig.symlink` gains two conditional includes covering both remote
+URL forms:
+
+```
+[includeIf "hasconfig:remote.*.url:https://github.com/guarzo/**"]
+	path = ~/.gitconfig.guarzo
+[includeIf "hasconfig:remote.*.url:git@github.com:guarzo/**"]
+	path = ~/.gitconfig.guarzo
+```
+
+This is the only tracked change to identity behaviour. It names an account owner
+but contains no personal data.
+
+The same file's duplicate `[credential "https://github.com"]` block is collapsed
+in the process. Today both `core/git/gitconfig.symlink` and `~/.gitconfig.local`
+declare that section, each opening with an empty `helper =` reset; because the
+later reset discards everything accumulated before it, the effective helper is
+`/usr/bin/gh` (2.45.0, from apt) rather than the `/usr/local/bin/gh` (2.79.0)
+that the shell uses. One block survives, referencing `gh` by name and resolving
+through `PATH`.
+
+### 2. Identity values (machine-local, gitignored)
+
+`~/.gitconfig.guarzo` links to `core/git/gitconfig.guarzo.symlink`, which is
+added to `.gitignore`. It holds:
+
+```
+[user]
+	name = <account name>
+	email = <account email>
+	signingKey = /absolute/path/to/.ssh/id_ed25519_guarzo.pub
+[credential "https://github.com"]
+	helper =
+	helper = !GH_CONFIG_DIR=$HOME/.gh-guarzo gh auth git-credential
+```
+
+`user.signingKey` is written as an absolute path, matching the existing
+`gitconfig.local.symlink` convention, because git does not expand `~` for this
+key on every platform.
+
+A tracked `core/git/gitconfig.guarzo.symlink.example` carries the same structure
+with placeholders, mirroring the existing `gitconfig.local.symlink.example`.
+
+### 3. `gh` routing
+
+`core/git/identity.zsh` defines a `gh` wrapper function that resolves the current
+repository's remote owner and prepends `GH_CONFIG_DIR` for `guarzo` repositories
+only. Outside a git repository, or in any repository with another owner, it
+delegates to the real `gh` untouched.
+
+For Claude Code sessions, each `guarzo` project's
+`.claude/settings.local.json` gains a static `env` block setting
+`GH_CONFIG_DIR`, delivered through the private `~/.dotfiles/projects` overlay
+repository. A static value is correct there because a given project has exactly
+one identity.
+
+### 4. Verification command
+
+`bin/git-identity` reports, for the current repository: the matched owner, the
+resolved `user.email` and `user.signingKey`, which `gh` config directory applies,
+and whether that directory holds a valid token. It exits zero when the resolved
+identity is usable, and non-zero in exactly two cases: the remote owner matches a
+configured identity whose token is missing or invalid, or the remote owner
+matches an identity whose include file is absent. An unmatched remote owner is
+not an error — it is the default identity working as intended.
+
+This exists because every failure mode in this design is silent — a missing
+include, an unmatched remote, and an expired token all present as "you are
+quietly the default identity." The command turns a silent state into a
+one-line answer.
+
+## Data flow
+
+For git, configuration resolves system → `~/.gitconfig` → `~/.gitconfig.local`
+(default identity) → `~/.gitconfig.guarzo` (when the remote matches) →
+repository-local `.git/config`. After migration the three `guarzo` repositories
+hold no identity configuration at all and derive everything from their remote.
+
+For `gh`, the wrapper reads the remote owner and sets `GH_CONFIG_DIR` for that
+single invocation. No global state is modified.
+
+## Failure handling
+
+**Clone-time gap.** During `git clone` no remote exists yet, so the default
+identity authenticates. Public `guarzo` repositories clone fine; private ones
+fail outright, which is a visible failure rather than a subtle one. Documented
+workaround, already in use:
+`GH_CONFIG_DIR=~/.gh-guarzo gh repo clone guarzo/<repo>`. Every operation after
+the remote exists routes correctly, including the first commit, so authorship is
+never wrong.
+
+**Invalid or missing token.** Pushes fail with an authentication error rather
+than falling back to the other identity. `bin/git-identity` reports it directly.
+
+**`gh` outside a repository.** The wrapper keys off the current repository, so
+`gh repo clone guarzo/new` from `~` uses the default identity. Documented, not
+solved: solving it would require parsing `gh`'s arguments, which would break on
+`gh` releases.
+
+**Machine without a guarzo identity.** The conditional includes reference a
+missing file, which git ignores silently; the wrapper finds no config directory
+and delegates to real `gh`. A fresh bootstrap is unaffected.
+
+## Manual provisioning
+
+Two steps require the account holder and cannot be automated here. Final
+verification is gated on both rather than declared against a dead token.
+
+1. `GH_CONFIG_DIR=~/.gh-guarzo gh auth login`, with `repo` and `workflow`
+   scopes. `BROWSER=false` selects the device flow if the browser handoff fails.
+2. Generate `~/.ssh/id_ed25519_guarzo`, register the public half on the guarzo
+   account **as a signing key** (GitHub keeps authentication and signing keys in
+   separate lists), and add a matching line to `~/.ssh/allowed_signers`. That
+   file currently holds one entry, bound to the default identity's address,
+   which is why signature verification across the three repositories currently
+   produces three different results.
+
+## Adjacent fixes in scope
+
+- Collapse the duplicate `[credential "https://github.com"]` blocks (above).
+- Repoint `~/.gitconfig.local` at `core/git/gitconfig.local.symlink` and delete
+  the stale `git/gitconfig.local.symlink`. The README symlink table and
+  `.gitignore` both name the `core/git/` path as canonical; the stale copy is
+  untracked only because of a local `.git/info/exclude` entry that no other
+  machine shares.
+- Replace the address in the tracked
+  `core/git/gitconfig.local.symlink.example` with a placeholder. This changes
+  `HEAD` only; the address remains in git history and is already public.
+- Migrate the three `guarzo` repositories off their repo-local identity config.
+
+## Migration
+
+For each of `binderplan`, `slabledger`, and `yetishopify`: unset the local
+`user.name`, `user.email`, and credential helper entries, then confirm that the
+values resolved from the conditional include match what the local config
+previously set. These repositories are outside this repository and the change is
+reversible from the values recorded before removal.
+
+## Testing
+
+A new bats suite follows the existing `setup_dotfiles_test` pattern, using a
+temporary `HOME` and throwaway repositories. Nothing in the suite touches a real
+token or the network.
+
+- Routing by remote owner over HTTPS and SSH resolves email, signing key, and
+  credential helper; a non-`guarzo` remote stays on the default.
+- Linked worktrees inherit the routed identity, including one nested at
+  `.claude/worktrees/`.
+- A missing include file yields the default identity and exit 0.
+- `core/git/gitconfig.symlink` contains exactly one
+  `[credential "https://github.com"]` block — a regression test for the
+  duplicate-block bug.
+- `.gitignore` covers `core/git/gitconfig.guarzo.symlink`.
+- The `gh` wrapper selects the guarzo config directory for a guarzo remote,
+  delegates unchanged for other remotes, and delegates outside a repository.
+- `bin/git-identity` reports the routed identity and flags an invalid token,
+  exercised against a stub.
+- Added to `tests/repository_hygiene.bats`: tracked `core/git/*.example` files
+  contain no email address outside the reserved `example.com` /
+  `example.invalid` domains, so the scrub cannot regress while templates keep
+  their illustrative placeholders.
+
+### Baseline
+
+At the time of writing, `make test` has 60 pre-existing failures across
+`tests/dev_commands.bats`, `tests/dev_config_merge.bats`, `tests/dev_install.bats`,
+`tests/dev_lifecycle.bats`, and `tests/claude_compose_override.bats`. They
+reproduce on `main` and are unrelated to this work. Those five files are the
+known-bad set; every other suite must stay green.
+
+## Out of scope
+
+- A registry or generator for arbitrary numbers of identities. The design ships
+  exactly one non-default identity, structured so a second is a copy of one
+  conditional-include pair plus one gitignored file.
+- Rewriting git history to remove the address already published in
+  `gitconfig.local.symlink.example`.
+- A `PATH` shim intercepting every `gh` invocation machine-wide. Rejected as
+  disproportionate: it would route work repositories through the same
+  interception layer to solve a problem confined to three personal ones.
+- Changing how the default identity authenticates.
+- SSH host aliases. The README's current "Multiple GitHub Accounts" section
+  documents that approach; it is replaced, because it covers only git transport
+  and not `gh`, and requires rewriting each remote URL.

--- a/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
+++ b/docs/superpowers/specs/2026-08-05-multi-github-identity-design.md
@@ -94,8 +94,46 @@ one shapes the design below.
 
 ## Design
 
-Five components. Routing is declarative and covers the common case; a guard
+Six components. Routing is declarative and covers the common case; a guard
 converts the cases routing cannot cover from silent to loud.
+
+### 0. The owner map (tracked, public)
+
+`core/git/identity-owners` is a tracked, non-secret table mapping a GitHub owner
+to an identity slug:
+
+```
+gambtho default
+guarzo  guarzo
+```
+
+It is the single source of truth for "which owners does this machine know about",
+and it exists **independently of provisioning**. That independence is what makes
+the rest of the design coherent, and its absence was a contradiction in an
+earlier draft: if knowledge of `guarzo` were inferred from the presence of
+`~/.gitconfig.guarzo`, the guard could never detect that the file was missing,
+and a push to a guarzo URL on an unprovisioned machine would proceed silently as
+the default identity — the exact failure this design exists to prevent.
+
+Mapping the **default** owner explicitly matters for the same reason. Detecting
+`origin`=gambtho plus `upstream`=guarzo as mixed-owner requires knowing that
+`gambtho` is a mapped owner too, not merely that `guarzo` is.
+
+Three states follow, and every consumer shares them:
+
+| Owner | Meaning |
+| --- | --- |
+| Absent from the map (work orgs, `Azure`, `kubernetes-sigs`, …) | **unmapped** — out of remit, fail open |
+| Maps to `default` | use the default identity, already configured |
+| Maps to a secondary slug | requires `~/.gitconfig.<slug>` and `~/.gh-<slug>`; if either is absent the state is **known but unprovisioned**, never "unmapped" |
+
+`bin/gh`, the pre-push guard, and `bin/git-identity` all read this one file, so
+they cannot disagree about what is known.
+
+The map and the conditional includes are two representations of the same fact, so
+a test asserts every non-`default` slug in the map has a matching `includeIf` in
+`gitconfig.symlink`, and vice versa. Adding a third identity means editing both,
+and the test fails if only one is edited.
 
 ### 1. Routing (tracked, public)
 
@@ -167,7 +205,7 @@ with placeholders, mirroring the existing `gitconfig.local.symlink.example`.
 owner, sets `GH_CONFIG_DIR` for a matching identity, and then execs the real
 `gh`. It locates the real binary by scanning `PATH` for the first `gh` that is
 not itself, so it cannot recurse, and it delegates unchanged when there is no
-match, no repository, or no configured identity.
+match, no repository, or an unmapped owner.
 
 A shim rather than a shell function because a zsh function reaches only
 interactive zsh: not bash, not scripts, not editor integrations, not Codex, and
@@ -178,9 +216,14 @@ design exists to remove.
 **Mixed-owner repositories.** The pre-push guard protects `git push` only.
 Repository-contextual `gh` commands — `gh pr merge`, `gh issue close`,
 `gh release delete` — carry the same wrong-account risk with no hook to catch
-them. When the shim finds more than one mapped GitHub owner among the
-repository's remotes it therefore **refuses to run** and exits non-zero with an
-actionable message, rather than guessing.
+them. When the shim finds more than one distinct **mapped** owner (per component
+0) among the repository's remotes it therefore **refuses to run** and exits
+non-zero with an actionable message, rather than guessing. `gambtho` +
+`guarzo` is mixed; `guarzo` + an unmapped work org is not, because only one
+owner is in remit.
+
+Mixed-owner detection is independent of provisioning: two mapped owners are
+mixed whether or not the secondary identity's files exist.
 
 The refusal covers every `gh` invocation in such a repository rather than only
 the repository-contextual subset, because distinguishing them means parsing
@@ -253,10 +296,11 @@ an unroutable identity must fail loudly.
 
 | Destination | Condition | Behaviour |
 | --- | --- | --- |
-| Non-`github.com`, or owner maps to no configured identity | any | exit 0, silent |
-| Owner maps to a configured identity | resolved identity matches | allow |
-| Owner maps to a configured identity | resolved identity disagrees | block, actionable message |
-| Owner maps to a configured identity | cannot determine — missing `gh`/`jq`, unreadable config, indeterminate identity | **block**, actionable message |
+| Non-`github.com`, or owner **unmapped** | any | exit 0, silent |
+| Mapped owner | resolved identity matches | allow |
+| Mapped owner | resolved identity disagrees | block, actionable message |
+| Mapped owner | **known but unprovisioned** — include file or `gh` config dir absent | **block**, naming the missing provisioning step |
+| Mapped owner | cannot determine — missing `gh`/`jq`, unreadable config, indeterminate identity | **block**, actionable message |
 
 The first row preserves the constraint that a global hook must not break
 unrelated repositories: a machine with no guarzo identity, or any repository
@@ -320,24 +364,55 @@ login shells, bypass the shim and use the default identity for `gh`. Git routing
 is unaffected, since it depends on config rather than `PATH`, and the guard still
 applies to any push.
 
-**Machine without a guarzo identity.** The conditional include references a
-missing file, which git ignores silently; the shim finds no config directory and
-delegates; the guard maps no owner and exits 0. A fresh bootstrap is unaffected.
+**Machine without a guarzo identity provisioned.** `guarzo` is still a *mapped*
+owner, because the owner map is tracked and independent of provisioning. So the
+state is "known but unprovisioned", not "unmapped":
+
+- Routing: the conditional include references a missing file, which git ignores
+  silently, so the repository resolves to the default identity.
+- Shim: `gh` in a guarzo repository refuses to run and names the missing
+  provisioning step.
+- Guard: a push to a guarzo URL is **blocked**, naming the missing step.
+- Everything else on the machine is untouched — unmapped owners never reach a
+  blocking path, so unrelated repositories and a fresh bootstrap behave exactly
+  as before.
+
+This is a deliberate behaviour change from an earlier draft, which claimed the
+whole mechanism stayed inert. Inert was wrong: it meant a push to guarzo from an
+unprovisioned machine would silently succeed as the default identity. Blocking a
+guarzo push until the identity is provisioned is the loud failure this design
+promises, and it is scoped so narrowly that nothing outside guarzo repositories
+can notice.
 
 ## Provisioning
 
 The conditional include is inert until `core/git/gitconfig.guarzo.symlink`
 exists, is populated, and is linked to `~/.gitconfig.guarzo`. Because the real
-file is gitignored, **it does not exist after cloning this repository**, so a
-new machine can complete every other step and still silently use the default
-identity.
+file is gitignored, **it does not exist after cloning this repository**, so a new
+machine can complete every other step and still resolve to the default identity.
+
+The owner map is what keeps that from being silent: `guarzo` stays mapped, so the
+guard blocks a guarzo push and the shim refuses, both naming the missing step,
+instead of quietly acting as the default account.
 
 Provisioning therefore covers all four of:
 
-1. `bootstrap` copies `gitconfig.guarzo.symlink.example` to
-   `gitconfig.guarzo.symlink` and prompts for the identity values, following the
-   pattern it already uses for `gitconfig.local`. It skips the whole step when
-   the user declines a second identity, leaving the include inert.
+1. **Interactive** `bootstrap` offers to copy
+   `gitconfig.guarzo.symlink.example` to `gitconfig.guarzo.symlink` and prompts
+   for the identity values, following the pattern it already uses for
+   `gitconfig.local`. Declining skips the step.
+
+   **`--non-interactive` bootstrap never prompts for a secondary identity and
+   never partially creates one.** It skips provisioning entirely unless
+   `core/git/gitconfig.guarzo.symlink` already exists, in which case it only
+   links it. No new flags are introduced.
+
+   This mirrors the contract `bin/bootstrap` already enforces for the primary
+   identity, where `--non-interactive` requires `user.name` and `user.email` to
+   be configured beforehand and errors out rather than reading from stdin. A
+   prompt here would hang automation at EOF or produce a half-populated identity
+   file, which is worse than none — a half-populated file makes the owner look
+   provisioned to the guard while failing at push time.
 2. `bin/relink` creates the `~/.gitconfig.guarzo` symlink.
 3. `GH_CONFIG_DIR=~/.gh-guarzo gh auth login` with `repo` and `workflow` scopes.
    `BROWSER=false` selects the device flow if the browser handoff fails. **Manual
@@ -380,6 +455,13 @@ A new bats suite follows the existing `setup_dotfiles_test` pattern, using a
 temporary `HOME` and throwaway repositories. Nothing in the suite touches a real
 token or the network.
 
+Owner map:
+
+- Every non-`default` slug in `core/git/identity-owners` has a matching
+  `includeIf` in `gitconfig.symlink`, and vice versa — the two cannot drift.
+- An unmapped owner, a `default` owner, and an unprovisioned mapped owner
+  resolve to three distinct states.
+
 Routing:
 
 - HTTPS guarzo remote resolves email, signing key, and credential helper; a
@@ -399,6 +481,10 @@ Shim:
   the first `gh` on `PATH`.
 - Refuses to run, non-zero, in a mixed-owner repository, and passes through
   untouched when the caller has already set `GH_CONFIG_DIR`.
+- Detects `gambtho` + `guarzo` as mixed **even when the guarzo identity is
+  unprovisioned**, and does not treat `guarzo` + an unmapped work org as mixed.
+- Refuses, naming the missing step, in a guarzo repository whose identity files
+  are absent.
 
 Bash login coverage:
 
@@ -417,15 +503,24 @@ Guard:
 - Allows a correctly-matched push.
 - Fails **open** — exit 0, no output — for a non-`github.com` host and an
   unmapped owner. A regression here breaks every repository on the machine.
-- Fails **closed** for a configured destination when `gh` or `jq` is missing or
-  the identity is otherwise indeterminate. Paired with the row above, these two
+- Fails **closed** for a mapped destination when `gh` or `jq` is missing or the
+  identity is otherwise indeterminate. Paired with the row above, these two
   tests pin the boundary that a single blanket rule would blur.
+- Fails **closed** for a push to a guarzo URL when the include file is absent,
+  naming the missing provisioning step — the case an earlier draft let through
+  silently.
 
 Hook composition:
 
 - With `git-lfs` stubbed to exit non-zero and the guard passing, the composed
   hook exits non-zero — LFS failures are not masked.
 - With the guard rejecting, `git lfs pre-push` is never reached.
+
+Bootstrap:
+
+- `--non-interactive` with no existing `gitconfig.guarzo.symlink` skips
+  secondary provisioning, reads nothing from stdin, and exits successfully.
+- `--non-interactive` with the file already present links it without prompting.
 
 Doctor and hygiene:
 

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -83,3 +83,39 @@ EOF
   run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$LIB"
   [ "$status" -ne 0 ]
 }
+
+@test "gitconfig declares exactly one github credential block" {
+  run grep -c '^\[credential "https://github.com"\]' "$REPO_ROOT/core/git/gitconfig.symlink"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "tracked gitconfig pins no absolute gh path" {
+  run grep -n 'helper = !/.*gh auth git-credential' "$REPO_ROOT/core/git/gitconfig.symlink"
+  [ "$status" -ne 0 ]
+}
+
+@test "owner map and conditional includes agree as owner+slug pairs" {
+  # Compare PAIRS, not slugs: a slug-only check passes while an owner is wired
+  # to the wrong include.
+  local config="$REPO_ROOT/core/git/gitconfig.symlink"
+  local owner slug expected
+  while read -r owner slug; do
+    [ -n "$owner" ] || continue
+    [ "$slug" = default ] && continue
+    expected="[includeIf \"hasconfig:remote.*.url:https://github.com/$owner/**\"]"
+    run grep -Fq "$expected" "$config"
+    [ "$status" -eq 0 ]
+    run grep -A1 -F "$expected" "$config"
+    [[ "$output" == *"~/.gitconfig.$slug"* ]]
+  done < <(grep -v '^[[:space:]]*#' "$REPO_ROOT/core/git/identity-owners" | grep -v '^[[:space:]]*$')
+}
+
+@test "every conditional include corresponds to a mapped owner" {
+  local config="$REPO_ROOT/core/git/gitconfig.symlink"
+  local owner
+  while read -r owner; do
+    run grep -qE "^$owner[[:space:]]" "$REPO_ROOT/core/git/identity-owners"
+    [ "$status" -eq 0 ]
+  done < <(sed -n 's|^\[includeIf "hasconfig:remote\.\*\.url:https://github\.com/\([^/]*\)/\*\*"\]$|\1|p' "$config")
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  LIB="$REPO_ROOT/core/git/identity-lib.sh"
+  MAP="$TEST_ROOT/identity-owners"
+  cat >"$MAP" <<'EOF'
+# owner slug
+gambtho default
+guarzo  guarzo
+EOF
+  export IDENTITY_MAP_FILE="$MAP"
+}
+
+@test "identity_url_owner parses https, ssh, and scp-style github URLs" {
+  run bash -c "source '$LIB'; identity_url_owner https://github.com/guarzo/repo.git"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_url_owner ssh://git@github.com/guarzo/repo.git"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_url_owner git@github.com:guarzo/repo.git"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+}
+
+@test "identity_url_owner rejects non-github hosts" {
+  run bash -c "source '$LIB'; identity_url_owner https://gitlab.com/guarzo/repo.git"
+  [ "$status" -eq 1 ]
+
+  run bash -c "source '$LIB'; identity_url_owner https://msazure.visualstudio.com/x/_git/y"
+  [ "$status" -eq 1 ]
+}
+
+@test "identity_validate_map rejects duplicates and malformed lines" {
+  printf 'guarzo guarzo\nguarzo default\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"duplicate owner"* ]]
+
+  printf 'guarzo\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"malformed"* ]]
+
+  printf 'a b c\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"malformed"* ]]
+}
+
+@test "identity_owner_slug maps known owners and rejects unmapped ones" {
+  run bash -c "source '$LIB'; identity_owner_slug guarzo '$MAP'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_owner_slug gambtho '$MAP'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "default" ]
+
+  run bash -c "source '$LIB'; identity_owner_slug kubernetes-sigs '$MAP'"
+  [ "$status" -eq 1 ]
+}
+
+@test "identity_slug_provisioned distinguishes default, provisioned, unprovisioned" {
+  run bash -c "source '$LIB'; identity_slug_provisioned default"
+  [ "$status" -eq 0 ]
+
+  run bash -c "source '$LIB'; identity_slug_provisioned guarzo"
+  [ "$status" -eq 1 ]
+
+  touch "$HOME/.gitconfig.guarzo"
+  mkdir -p "$HOME/.gh-guarzo"
+  run bash -c "source '$LIB'; identity_slug_provisioned guarzo"
+  [ "$status" -eq 0 ]
+}
+
+@test "library uses no bash-4-only constructs" {
+  run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$LIB"
+  [ "$status" -ne 0 ]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -66,6 +66,20 @@ EOF
   [ "$status" -eq 1 ]
 }
 
+@test "identity_owner_slug case-folds the owner before lookup" {
+  run bash -c "source '$LIB'; identity_owner_slug Guarzo '$MAP'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_owner_slug GUARZO '$MAP'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "guarzo" ]
+
+  run bash -c "source '$LIB'; identity_owner_slug GaMbThO '$MAP'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "default" ]
+}
+
 @test "identity_slug_provisioned distinguishes default, provisioned, unprovisioned" {
   run bash -c "source '$LIB'; identity_slug_provisioned default"
   [ "$status" -eq 0 ]
@@ -238,6 +252,16 @@ EOF
   [[ "$output" == *"real gh"* ]]
 }
 
+@test "shim fails closed with a clear message when the identity library is missing" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  rm -f "$DOTFILES/core/git/identity-lib.sh"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"identity library not found"* ]]
+  [[ "$output" != *": No such file or directory"* ]]
+}
+
 @test "shim uses no bash-4-only constructs" {
   run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$REPO_ROOT/bin/gh"
   [ "$status" -ne 0 ]
@@ -391,6 +415,31 @@ be_default() {
   git config --unset user.email || true
   run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
   [ "$status" -ne 0 ]
+}
+
+@test "guard blocks a mixed-case owner push made under the default identity" {
+  # GitHub owner names are case-insensitive, so a clone of Guarzo/repo is
+  # ordinary. Git's own hasconfig matching is case-sensitive and won't fire,
+  # so the repo's effective identity stays default -- but the guard must
+  # still recognise the destination as the guarzo identity and block, not
+  # silently allow a push under the wrong account.
+  setup_guard
+  provision_guarzo
+  be_default
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/Guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Guarzo"* ]]
+  [[ "$output" == *"guarzo"* ]]
+}
+
+@test "guard still fails open for an unmapped owner in mixed case" {
+  # Case-folding the lookup must not widen the guard's remit to owners that
+  # were never mapped in the first place.
+  setup_guard
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/Kubernetes-SIGS/repo.git </dev/null
+  [ "$status" -eq 0 ]
 }
 
 @test "guard blocks a github push when the owner map is invalid" {

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -133,3 +133,112 @@ EOF
   run grep -Fq 'GH_CONFIG_DIR=$HOME/.gh-guarzo' "$template"
   [ "$status" -eq 0 ]
 }
+
+setup_shim_repo() {
+  local dir="$1" url="$2"
+  git init -q "$dir"
+  git -C "$dir" remote add origin "$url"
+  export DOTFILES="$TEST_ROOT/dotfiles"
+  mkdir -p "$DOTFILES/core/git"
+  cp "$REPO_ROOT/core/git/identity-lib.sh" "$DOTFILES/core/git/"
+  cp "$MAP" "$DOTFILES/core/git/identity-owners"
+  unset IDENTITY_MAP_FILE
+  mkdir -p "$STUB_BIN/real"
+  printf '#!/usr/bin/env bash\necho "real gh: GH_CONFIG_DIR=[${GH_CONFIG_DIR:-unset}] args=$*"\n' \
+    >"$STUB_BIN/real/gh"
+  chmod +x "$STUB_BIN/real/gh"
+  export PATH="$STUB_BIN:$STUB_BIN/real:/usr/bin:/bin"
+}
+
+provision_guarzo_files() {
+  cat >"$HOME/.gitconfig.guarzo" <<'EOF'
+[user]
+	email = guarzo@example.invalid
+	signingKey = /keys/guarzo.pub
+EOF
+  mkdir -p "$HOME/.gh-guarzo"
+}
+
+@test "shim routes a guarzo repo to the guarzo gh config dir" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  provision_guarzo_files
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[$HOME/.gh-guarzo]"* ]]
+}
+
+@test "shim delegates unchanged for a default-owner repo" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[unset]"* ]]
+}
+
+@test "shim delegates unchanged outside a repository" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT"
+  run "$REPO_ROOT/bin/gh" auth status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[unset]"* ]]
+}
+
+@test "shim refuses a mixed-owner repo even when the secondary is unprovisioned" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  git -C "$TEST_ROOT/r" remote add upstream https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr merge
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mixed"* ]]
+}
+
+@test "shim does not treat a mapped owner plus an unmapped org as mixed" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  git -C "$TEST_ROOT/r" remote add fork https://github.com/kubernetes-sigs/repo.git
+  provision_guarzo_files
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[$HOME/.gh-guarzo]"* ]]
+}
+
+@test "shim refuses an unprovisioned guarzo repo and names the missing step" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not provisioned"* ]]
+}
+
+@test "shim refuses when the owner map is invalid" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  printf 'guarzo guarzo\nguarzo default\n' >"$DOTFILES/core/git/identity-owners"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/gh" pr list
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"duplicate owner"* ]]
+}
+
+@test "shim passes through untouched when the caller set GH_CONFIG_DIR" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  git -C "$TEST_ROOT/r" remote add upstream https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  GH_CONFIG_DIR="$HOME/explicit" run "$REPO_ROOT/bin/gh" pr merge
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GH_CONFIG_DIR=[$HOME/explicit]"* ]]
+}
+
+@test "shim does not recurse when reached through a symlink" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  ln -s "$REPO_ROOT/bin/gh" "$STUB_BIN/gh"
+  cd "$TEST_ROOT/r"
+  run timeout 10 "$STUB_BIN/gh" pr list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"real gh"* ]]
+}
+
+@test "shim uses no bash-4-only constructs" {
+  run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$REPO_ROOT/bin/gh"
+  [ "$status" -ne 0 ]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -433,3 +433,61 @@ be_default() {
   run cat "$TEST_ROOT/lfs-stdin.txt"
   [[ "$output" == *"refs/heads/main"* ]]
 }
+
+@test "doctor reports the default identity for an unmapped owner" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/kubernetes-sigs/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"default"* ]]
+}
+
+@test "doctor exits 1 on an invalid owner map" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  printf 'guarzo guarzo\nguarzo default\n' >"$DOTFILES/core/git/identity-owners"
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 1 ]
+}
+
+@test "doctor exits 3 for a mapped but unprovisioned identity" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"NOT PROVISIONED"* ]]
+}
+
+@test "doctor exits 2 for a mixed-owner repository" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/gambtho/repo.git
+  git -C "$TEST_ROOT/r" remote add upstream https://github.com/guarzo/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"MIXED"* ]]
+}
+
+@test "doctor exits 5 for a guarzo ssh remote" {
+  setup_shim_repo "$TEST_ROOT/r" git@github.com:guarzo/repo.git
+  provision_guarzo_files
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 5 ]
+  [[ "$output" == *"SSH"* ]]
+}
+
+@test "doctor exits 4 when the token is invalid" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/guarzo/repo.git
+  provision_guarzo_files
+  rm -f "$STUB_BIN/real/gh"
+  stub_command gh 'echo "token invalid" >&2; exit 1'
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"TOKEN"* ]]
+}
+
+@test "doctor uses no bash-4-only constructs" {
+  run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$REPO_ROOT/bin/git-identity"
+  [ "$status" -ne 0 ]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -643,3 +643,45 @@ be_default() {
   run grep -Fq '/abs/k&y.pub' "$fake/core/git/gitconfig.guarzo.symlink"
   [ "$status" -eq 0 ]
 }
+
+@test "secondary identity render is atomic and leaves no partial file" {
+  # A plain redirect truncates the target before sed runs; a partial file would
+  # look "provisioned" to the pre-push guard and fail at push time instead.
+  local fake="$TEST_ROOT/boot5"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  chmod a-w "$fake/core/git"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=false
+    DOTFILES_ROOT='$fake'
+    printf 'y\nName\nuser@example.invalid\n/abs/key.pub\n' | setup_secondary_identity
+  "
+  chmod u+w "$fake/core/git"
+  # Must not abort bootstrap: the step is optional and runs under set -e.
+  [ "$status" -eq 0 ]
+  # Must not leave a partial or stray file behind.
+  assert_file_absent "$fake/core/git/gitconfig.guarzo.symlink"
+  run bash -c "ls -A '$fake/core/git' | grep -c '^\.gitconfig\.guarzo\.'"
+  [ "$output" -eq 0 ]
+}
+
+@test "a failed secondary identity render does not abort bootstrap under set -e" {
+  # Regression guard: returning non-zero here would stop bootstrap before
+  # install_dotfiles, leaving the machine with no symlinks at all.
+  local fake="$TEST_ROOT/boot6"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  chmod a-w "$fake/core/git"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    set -e
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=false
+    DOTFILES_ROOT='$fake'
+    printf 'y\nName\nuser@example.invalid\n/abs/key.pub\n' | setup_secondary_identity
+    echo REACHED_NEXT_STEP
+  "
+  chmod u+w "$fake/core/git"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REACHED_NEXT_STEP"* ]]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -242,3 +242,36 @@ EOF
   run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$REPO_ROOT/bin/gh"
   [ "$status" -ne 0 ]
 }
+
+@test "bash_profile puts dotfiles/bin ahead of /usr/local/bin in a clean login shell" {
+  local profile="$REPO_ROOT/core/shell/bash_profile.symlink"
+  [ -f "$profile" ]
+  mkdir -p "$HOME/.dotfiles/bin"
+  cp "$profile" "$HOME/.bash_profile"
+  run env -i HOME="$HOME" /bin/bash -lc 'printf "%s\n" "$PATH"'
+  [ "$status" -eq 0 ]
+  local dotfiles_pos local_pos
+  dotfiles_pos=$(printf '%s' "$output" | tr ':' '\n' | grep -n "^$HOME/.dotfiles/bin$" | head -1 | cut -d: -f1)
+  local_pos=$(printf '%s' "$output" | tr ':' '\n' | grep -n '^/usr/local/bin$' | head -1 | cut -d: -f1)
+  [ -n "$dotfiles_pos" ]
+  [ -z "$local_pos" ] || [ "$dotfiles_pos" -lt "$local_pos" ]
+}
+
+@test "bash_profile preserves an existing real ~/.profile" {
+  mkdir -p "$HOME/.dotfiles/bin"
+  cp "$REPO_ROOT/core/shell/bash_profile.symlink" "$HOME/.bash_profile"
+  cat >"$HOME/.profile" <<'EOF'
+export EXISTING_PROFILE_RAN=yes
+PATH="$HOME/preexisting:$PATH"
+EOF
+  run env -i HOME="$HOME" /bin/bash -lc 'printf "%s|%s\n" "$EXISTING_PROFILE_RAN" "$PATH"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == yes\|* ]]
+  [[ "$output" == *"$HOME/preexisting"* ]]
+}
+
+@test "bash_profile is mapped to ~/.bash_profile by the link mapper" {
+  run bash -c "source '$REPO_ROOT/bin/common.sh' >/dev/null 2>&1; managed_link_pairs '$REPO_ROOT' '$HOME' | tr '\0' '\n'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$HOME/.bash_profile"* ]]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -119,3 +119,17 @@ EOF
     [ "$status" -eq 0 ]
   done < <(sed -n 's|^\[includeIf "hasconfig:remote\.\*\.url:https://github\.com/\([^/]*\)/\*\*"\]$|\1|p' "$config")
 }
+
+@test "the machine-local guarzo identity file is gitignored" {
+  run git -C "$REPO_ROOT" check-ignore -q core/git/gitconfig.guarzo.symlink
+  [ "$status" -eq 0 ]
+}
+
+@test "the guarzo identity template carries placeholders, not real values" {
+  local template="$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example"
+  [ -f "$template" ]
+  run grep -Eq '@(gmail|microsoft|outlook)\.' "$template"
+  [ "$status" -ne 0 ]
+  run grep -Fq 'GH_CONFIG_DIR=$HOME/.gh-guarzo' "$template"
+  [ "$status" -eq 0 ]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -573,3 +573,73 @@ be_default() {
   run bash -c "source '$REPO_ROOT/bin/common.sh' >/dev/null 2>&1; managed_link_pairs '$fake' '$HOME' | tr '\0' '\n'"
   [[ "$output" == *"$HOME/.gitconfig.guarzo"* ]]
 }
+
+@test "identity_validate_map rejects a non-canonical uppercase owner" {
+  # An uppercase owner parses fine but can never match, because
+  # identity_owner_slug folds the lookup key -- a silent misconfiguration.
+  printf 'Guarzo guarzo\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"lowercase"* ]]
+}
+
+@test "identity_validate_map rejects a slug containing a path separator" {
+  # Slugs become path components in ~/.gitconfig.<slug> and ~/.gh-<slug>.
+  printf 'evil a/../../tmp/pwned\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"slug"* ]]
+
+  printf 'evil ../escape\n' >"$MAP"
+  run bash -c "source '$LIB'; identity_validate_map '$MAP'"
+  [ "$status" -eq 1 ]
+}
+
+@test "the shipped owner map passes its own validation" {
+  run bash -c "source '$LIB'; identity_validate_map '$REPO_ROOT/core/git/identity-owners'"
+  [ "$status" -eq 0 ]
+}
+
+@test "the primary gitconfig template uses the tokens bootstrap substitutes" {
+  # setup_gitconfig substitutes AUTHORNAME/AUTHOREMAIL; any other placeholder is
+  # copied through literally and every commit is authored as it.
+  local template="$REPO_ROOT/core/git/gitconfig.local.symlink.example"
+  run grep -Fq 'AUTHORNAME' "$template"
+  [ "$status" -eq 0 ]
+  run grep -Fq 'AUTHOREMAIL' "$template"
+  [ "$status" -eq 0 ]
+  run bash -c "sed -e 's|AUTHORNAME|Real Name|g' -e 's|AUTHOREMAIL|real@example.invalid|g' '$template' | grep -cE 'AUTHORNAME|AUTHOREMAIL|YOUR_NAME'"
+  [ "$output" -eq 0 ]
+}
+
+@test "secondary identity provisioning rejects a relative signing key path" {
+  local fake="$TEST_ROOT/boot3"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=false
+    DOTFILES_ROOT='$fake'
+    printf 'y\nName\nuser@example.invalid\nrelative/key.pub\n' | setup_secondary_identity
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"absolute"* ]]
+  assert_file_absent "$fake/core/git/gitconfig.guarzo.symlink"
+}
+
+@test "secondary identity provisioning escapes sed metacharacters in answers" {
+  local fake="$TEST_ROOT/boot4"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=false
+    DOTFILES_ROOT='$fake'
+    printf 'y\nA&B|C\\\\D\nuser@example.invalid\n/abs/k&y.pub\n' | setup_secondary_identity
+  "
+  [ "$status" -eq 0 ]
+  run grep -Fq 'A&B|C\D' "$fake/core/git/gitconfig.guarzo.symlink"
+  [ "$status" -eq 0 ]
+  run grep -Fq '/abs/k&y.pub' "$fake/core/git/gitconfig.guarzo.symlink"
+  [ "$status" -eq 0 ]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -491,3 +491,36 @@ be_default() {
   run grep -nE '(^|[[:space:]])(mapfile|readarray)([[:space:]]|$)|declare -g?A' "$REPO_ROOT/bin/git-identity"
   [ "$status" -ne 0 ]
 }
+
+@test "non-interactive bootstrap skips secondary provisioning and reads no stdin" {
+  local fake="$TEST_ROOT/boot1"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=true
+    DOTFILES_ROOT='$fake'
+    setup_secondary_identity
+  " </dev/null
+  [ "$status" -eq 0 ]
+  assert_file_absent "$fake/core/git/gitconfig.guarzo.symlink"
+}
+
+@test "non-interactive bootstrap leaves an already-provisioned identity for relink" {
+  local fake="$TEST_ROOT/boot2"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/gitconfig.guarzo.symlink.example" "$fake/core/git/"
+  printf '[user]\n\temail = x@example.invalid\n' >"$fake/core/git/gitconfig.guarzo.symlink"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=true
+    DOTFILES_ROOT='$fake'
+    setup_secondary_identity
+  " </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already configured"* ]]
+  run grep -c 'x@example.invalid' "$fake/core/git/gitconfig.guarzo.symlink"
+  [ "$output" -eq 1 ]
+  run bash -c "source '$REPO_ROOT/bin/common.sh' >/dev/null 2>&1; managed_link_pairs '$fake' '$HOME' | tr '\0' '\n'"
+  [[ "$output" == *"$HOME/.gitconfig.guarzo"* ]]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -275,3 +275,161 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"$HOME/.bash_profile"* ]]
 }
+
+setup_guard() {
+  export DOTFILES="$TEST_ROOT/dotfiles"
+  mkdir -p "$DOTFILES/core/git"
+  cp "$REPO_ROOT/core/git/identity-lib.sh" "$DOTFILES/core/git/"
+  cp "$MAP" "$DOTFILES/core/git/identity-owners"
+  unset IDENTITY_MAP_FILE
+  HOOK="$REPO_ROOT/core/git/git-hooks.symlink/pre-push"
+  GUARD_REPO="$TEST_ROOT/g"
+  git init -q "$GUARD_REPO"
+  stub_command git-lfs 'exit 0'
+  cat >"$HOME/.gitconfig.local" <<'EOF'
+[user]
+	email = default@example.invalid
+	signingKey = /keys/default.pub
+EOF
+}
+
+provision_guarzo() {
+  cat >"$HOME/.gitconfig.guarzo" <<'EOF'
+[user]
+	email = guarzo@example.invalid
+	signingKey = /keys/guarzo.pub
+EOF
+  mkdir -p "$HOME/.gh-guarzo"
+}
+
+be_guarzo() {
+  git -C "$GUARD_REPO" config user.email guarzo@example.invalid
+  git -C "$GUARD_REPO" config user.signingKey /keys/guarzo.pub
+}
+
+be_default() {
+  git -C "$GUARD_REPO" config user.email default@example.invalid
+  git -C "$GUARD_REPO" config user.signingKey /keys/default.pub
+}
+
+@test "guard fails open for a non-github destination" {
+  setup_guard
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://gitlab.com/guarzo/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard fails open for an unmapped owner" {
+  setup_guard
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/kubernetes-sigs/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard blocks a guarzo push when the identity is unprovisioned" {
+  setup_guard
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not provisioned"* ]]
+}
+
+@test "guard blocks a guarzo push made under the default identity" {
+  setup_guard
+  provision_guarzo
+  be_default
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+}
+
+@test "guard allows a guarzo push made under the guarzo identity" {
+  setup_guard
+  provision_guarzo
+  be_guarzo
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard blocks the fork case: pushing to gambtho as guarzo" {
+  # origin=gambtho, upstream=guarzo -- hasconfig resolves the repo to guarzo,
+  # and the push targets gambtho. This is the case the guard exists for.
+  setup_guard
+  provision_guarzo
+  be_guarzo
+  git -C "$GUARD_REPO" remote add upstream https://github.com/guarzo/repo.git
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/gambtho/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"gambtho"* ]]
+}
+
+@test "guard allows a gambtho push made under the default identity" {
+  setup_guard
+  provision_guarzo
+  be_default
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/gambtho/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard allows a gambtho push with an unrelated per-repo email" {
+  # A legitimate override must not be a false positive: it matches no identity.
+  setup_guard
+  provision_guarzo
+  git -C "$GUARD_REPO" config user.email project-specific@example.invalid
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/gambtho/repo.git </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "guard blocks a mapped destination when the identity is indeterminate" {
+  setup_guard
+  provision_guarzo
+  cd "$GUARD_REPO"
+  git config --unset user.email || true
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+}
+
+@test "guard blocks a github push when the owner map is invalid" {
+  setup_guard
+  provision_guarzo
+  be_guarzo
+  printf 'guarzo guarzo\nguarzo default\n' >"$DOTFILES/core/git/identity-owners"
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+}
+
+@test "composed hook preserves a non-zero git-lfs exit status" {
+  setup_guard
+  provision_guarzo
+  be_guarzo
+  stub_command git-lfs 'exit 7'
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -eq 7 ]
+}
+
+@test "a rejecting guard never reaches git lfs pre-push" {
+  setup_guard
+  stub_command git-lfs "echo ran >>'$TEST_ROOT/lfs.log'; exit 0"
+  cd "$GUARD_REPO"
+  run "$HOOK" origin https://github.com/guarzo/repo.git </dev/null
+  [ "$status" -ne 0 ]
+  assert_file_absent "$TEST_ROOT/lfs.log"
+}
+
+@test "guard leaves stdin intact for git lfs pre-push" {
+  setup_guard
+  provision_guarzo
+  be_guarzo
+  stub_command git-lfs "cat >'$TEST_ROOT/lfs-stdin.txt'; exit 0"
+  cd "$GUARD_REPO"
+  printf 'refs/heads/main aaa refs/heads/main bbb\n' |
+    "$HOOK" origin https://github.com/guarzo/repo.git
+  run cat "$TEST_ROOT/lfs-stdin.txt"
+  [[ "$output" == *"refs/heads/main"* ]]
+}

--- a/tests/repository_hygiene.bats
+++ b/tests/repository_hygiene.bats
@@ -96,3 +96,21 @@ setup() {
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+@test "tracked git example files carry no real email addresses" {
+  # Templates keep illustrative placeholders, so allow only reserved example
+  # domains. Anything else is a personal address in a public repo.
+  run bash -c "
+    grep -hoE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
+      '$REPO_ROOT'/core/git/*.example 2>/dev/null |
+      grep -vE '@example\.(com|invalid|org)\$' || true
+  "
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "the public repository tracks nothing under git/" {
+  run git -C "$REPO_ROOT" ls-files git/
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
Routes git and `gh` to the correct GitHub account automatically, based on who owns the
repository's remote, so one machine can hold two identities with no `gh auth switch`.

Replaces the hand-applied `git config --local` recipe that had already drifted across three
repositories and missed `user.signingKey` in all of them — their last commits verified as
good, error, and unsigned respectively.

## How it works

A tracked owner map (`core/git/identity-owners`) is the single source of truth for which
GitHub owners this machine knows, **independently of provisioning**. That independence is
what keeps three states distinct: *unmapped* (out of remit, fail open), *default*, and
*known but unprovisioned* (fail closed). Collapsing the last two into "unmapped" is what
would let an unprovisioned machine push silently as the wrong account.

Four consumers share one resolution library (`core/git/identity-lib.sh`):

- **git config** — an `includeIf "hasconfig:remote.*.url:…"` block routes matching remotes
  to a gitignored `~/.gitconfig.guarzo` (author, signing key, credential helper).
- **`bin/gh`** — a PATH shim setting `GH_CONFIG_DIR` by remote owner. Refuses to run in
  mixed-owner repositories, where `gh pr merge` has no hook to protect it.
- **`core/git/git-hooks.symlink/pre-push`** — an identity guard that blocks a push whose
  destination disagrees with the resolved identity.
- **`bin/git-identity`** — a diagnostic, because every failure mode here is otherwise silent.

## Design notes

**`hasconfig` matches any remote, not the push target.** A fork with `origin`=gambtho and
`upstream`=guarzo resolves to guarzo; pushing to gambtho would commit and sign as the wrong
account. The matcher cannot be narrowed — `hasconfig:remote.origin.url:` is not a supported
keyword and silently matches nothing. So mixed-owner repos are explicitly *not routed*: the
guard blocks them and `bin/gh` refuses.

**Identity comparison covers email *and* signing key**, since the original incident had
correct emails throughout.

**Fail-open boundary.** `core.hooksPath` is global, so the guard exits 0 silently for
non-github hosts and unmapped owners — it must never break unrelated repositories. Once the
destination is a mapped owner, every uncertainty blocks instead.

**Hook composition.** The guard runs first and `git lfs pre-push` runs last, so its exit
status stays authoritative; the reverse order would let a passing guard mask a failed LFS
upload. The hook never reads stdin, which `git lfs` consumes.

**Owner matching is case-folded.** `github.com/Guarzo/…` is a URL GitHub accepts. Git's own
`includeIf` stays case-sensitive and can't be fixed from here, so such a repo still resolves
to the default identity — but the guard now recognises the destination and blocks loudly
rather than pushing silently as the wrong account.

## Not supported (detected, not silently mishandled)

- **SSH transport** — git never invokes a credential helper for it, and `user.signingKey`
  does not select an auth key. All current guarzo remotes are HTTPS.
- **Mixed-owner repositories** — blocked and refused, per above.

## Adjacent fixes

- Unpins the GitHub credential helper, which resolved to `/usr/bin/gh` (2.45.0) rather than
  the `/usr/local/bin/gh` (2.79.0) the shell uses.
- Scrubs a real address from the tracked `gitconfig.local.symlink.example` (HEAD only;
  history unchanged and already public).
- Replaces the README's superseded SSH host-alias recipe.

## Verification

51 identity tests, 14 hygiene, 3 portability, 2 LFS, 30 install-orchestration — all green,
lint clean. Full suite sits at exactly the 60 pre-existing failures present on `main`
(`dev_commands`, `dev_config_merge`, `dev_install`, `dev_lifecycle`,
`claude_compose_override`) — unchanged by this branch.

## Follow-up (not in this PR)

Machine migration is deliberately excluded: no symlinks are installed, `~/.gitconfig.local`
still carries its own credential blocks, and the three guarzo repositories still have
repo-local overrides. **The guard and shim activate on merge, not on relink**, since
`~/.git-hooks` and `PATH` already point into `~/.dotfiles` — so provisioning
(`gh auth login` into `~/.gh-guarzo`, plus an SSH signing key registered on the second
account) should happen in the same sitting as the merge. Until then, pushes to those repos
fail closed with a message pointing at `bin/git-identity`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Git and GitHub CLI identity routing based on repository ownership.
  * Added separate credentials for secondary identities, optional interactive setup, and identity diagnostics.
  * Added login-shell setup so identity tools are available automatically.

* **Bug Fixes**
  * Added pre-push safeguards against identity mismatches and ambiguous repositories.
  * Improved handling of unmapped, mixed-owner, and unsupported remote configurations.

* **Documentation**
  * Updated setup, migration, troubleshooting, and identity-management guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->