### PR TITLE
feat(git): resolve the owner map per machine and per profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ __pycache__/
 # (The dev platform's machine-local projects/*/workspace.local.yaml is covered
 # by this rule too.)
 projects/
+
+# Machine-local owner map (see identity-owners.local.example).
+core/git/identity-owners.local

--- a/README.md
+++ b/README.md
@@ -156,6 +156,31 @@ either of these for you):
    Point `signingKey` in `~/.gitconfig.guarzo` at the **absolute path** to the
    `.pub` file — git does not expand `~` for this setting on every platform.
 
+### Per-machine identity roles
+
+`core/git/identity-owners` records *roles* — which account is this machine's
+ambient default, and which need their own routed identity. Roles differ between
+machines: an account that is secondary on one may be the ambient default on
+another. Four sources are consulted, highest precedence first, and the first one
+that exists **replaces** the others outright (they are never merged):
+
+| Source | Scope |
+| --- | --- |
+| `$IDENTITY_MAP_FILE` | explicit override, for tests and one-offs |
+| `core/git/identity-owners.local` | this machine only (gitignored) |
+| `core/git/identity-owners.<profile>` | machines sharing that `~/.dotfiles-profile` |
+| `core/git/identity-owners` | the shared default |
+
+Replace rather than merge is deliberate: merging would let a machine silently
+inherit another machine's roles, which is the failure this design exists to
+prevent. List every owner the machine should know — one you leave out becomes
+unmapped, so nothing routes it and nothing blocks it.
+
+`bin/bootstrap` offers to write the local map, or copy
+`identity-owners.local.example` by hand. `bin/git-identity` prints the map
+actually in effect, which is the first thing to check when routing surprises you
+on a particular machine.
+
 ## Routine Updates
 
 ```bash

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -203,6 +203,14 @@ setup_identity_map() {
     return 0
   fi
 
+  # Something that is not a regular file occupies the path: a directory would
+  # swallow the mv below while reporting success, and the library rejects it at
+  # validation time anyway. Say so instead of installing into it.
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    log_warning "$target exists but is not a regular file; leaving the machine-local map alone."
+    return 0
+  fi
+
   if [ "${NON_INTERACTIVE:-false}" = true ]; then
     log_info "Skipping optional machine-local owner map (non-interactive)."
     return 0
@@ -210,7 +218,9 @@ setup_identity_map() {
 
   log_info "Shared owner map (used unless this machine overrides it):"
   grep -vE '^[[:space:]]*(#|$)' "$shared" 2>/dev/null | sed 's/^/    /'
-  printf 'Does this machine use a different default GitHub account? [y/N] '
+  # Any role may differ, not just the default: a machine can share the default
+  # account and still need a different set of routed secondaries.
+  printf 'Does this machine need a different owner map? [y/N] '
   read -r reply
   case "$reply" in
     [Yy]*) : ;;
@@ -236,10 +246,25 @@ setup_identity_map() {
     printf '# Machine-local owner map, written by bin/bootstrap.\n'
     printf '# Replaces the shared map entirely; see identity-owners.local.example.\n'
     printf '%s default\n' "$default_owner"
+    # Disable pathname expansion while splitting the answer: an unquoted `*`
+    # would otherwise expand to filenames in the current directory.
+    set -f
     for owner in $secondaries; do
       printf '%s %s\n' "$owner" "$owner"
     done
+    set +f
   } >"$temp"
+
+  # Validate with the library itself rather than re-implementing its rules, in a
+  # subshell so sourcing cannot disturb bootstrap's own environment. This catches
+  # malformed names and duplicate owners BEFORE the file is installed -- an
+  # invalid local map replaces the shared one and then fails closed everywhere,
+  # which would be a confusing way to end a bootstrap.
+  if ! (. "$DOTFILES_ROOT/core/git/identity-lib.sh" && identity_validate_map "$temp"); then
+    rm -f "$temp"
+    log_warning "Rejected the answers; leaving the machine-local map unconfigured."
+    return 0
+  fi
 
   if ! mv "$temp" "$target"; then
     rm -f "$temp"

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -183,6 +183,76 @@ setup_secondary_identity() {
   log_info "Next: GH_CONFIG_DIR=\$HOME/.gh-guarzo gh auth login"
 }
 
+# Machine-local owner map. The shared core/git/identity-owners encodes ROLES
+# (which account is the ambient default, which need routing), and roles differ
+# per machine: an account that is secondary here may be the default elsewhere.
+# Writing a local map is how a machine states its own arrangement.
+#
+# Like the secondary identity above, --non-interactive never prompts and never
+# writes a partial file: it skips unless one already exists.
+setup_identity_map() {
+  local example="$DOTFILES_ROOT/core/git/identity-owners.local.example"
+  local target="$DOTFILES_ROOT/core/git/identity-owners.local"
+  local shared="$DOTFILES_ROOT/core/git/identity-owners"
+  local reply default_owner secondaries owner temp
+
+  [ -f "$example" ] || return 0
+
+  if [ -f "$target" ]; then
+    log_info "Machine-local owner map already configured."
+    return 0
+  fi
+
+  if [ "${NON_INTERACTIVE:-false}" = true ]; then
+    log_info "Skipping optional machine-local owner map (non-interactive)."
+    return 0
+  fi
+
+  log_info "Shared owner map (used unless this machine overrides it):"
+  grep -vE '^[[:space:]]*(#|$)' "$shared" 2>/dev/null | sed 's/^/    /'
+  printf 'Does this machine use a different default GitHub account? [y/N] '
+  read -r reply
+  case "$reply" in
+    [Yy]*) : ;;
+    *) return 0 ;;
+  esac
+
+  printf "This machine's default GitHub account (ambient gh login): "
+  read -r default_owner
+  printf 'Other GitHub accounts needing their own identity (space separated, blank for none): '
+  read -r secondaries
+
+  if [ -z "$default_owner" ]; then
+    log_warning "No default account given; leaving the machine-local map unconfigured."
+    return 0
+  fi
+
+  if ! temp="$(mktemp "$DOTFILES_ROOT/core/git/.identity-owners.XXXXXX")"; then
+    log_warning "Could not create a temporary file; leaving the machine-local map unconfigured."
+    return 0
+  fi
+
+  {
+    printf '# Machine-local owner map, written by bin/bootstrap.\n'
+    printf '# Replaces the shared map entirely; see identity-owners.local.example.\n'
+    printf '%s default\n' "$default_owner"
+    for owner in $secondaries; do
+      printf '%s %s\n' "$owner" "$owner"
+    done
+  } >"$temp"
+
+  if ! mv "$temp" "$target"; then
+    rm -f "$temp"
+    log_warning "Failed to install the machine-local owner map."
+    return 0
+  fi
+
+  log_success "Machine-local owner map written to $target"
+  for owner in $secondaries; do
+    log_info "Next for '$owner': GH_CONFIG_DIR=\$HOME/.gh-$owner gh auth login, then create core/git/gitconfig.$owner.symlink"
+  done
+}
+
 setup_profile() {
   if [[ -n "$BOOTSTRAP_PROFILE" ]]; then
     printf '%s\n' "$BOOTSTRAP_PROFILE" >"$HOME/.dotfiles-profile"
@@ -409,6 +479,7 @@ main() {
 
   setup_gitconfig
   setup_secondary_identity
+  setup_identity_map
   setup_profile
   # $HOME/.dotfiles, not $DOTFILES_ROOT: the latter is wherever this script was
   # run from, which may be a disposable linked worktree. The stable root must

--- a/bin/git-identity
+++ b/bin/git-identity
@@ -16,6 +16,10 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 0
 fi
 
+# Name the map in effect. With four possible sources, "which map won?" is the
+# first question when routing behaves unexpectedly on a given machine.
+printf 'map:      %s\n' "$IDENTITY_MAP_FILE"
+
 identity_validate_map || exit 1
 
 owners=""

--- a/core/git/identity-lib.sh
+++ b/core/git/identity-lib.sh
@@ -12,7 +12,51 @@
 #   secondary  maps to another slug        -> may be UNPROVISIONED
 
 IDENTITY_DOTFILES_ROOT="${DOTFILES:-$HOME/.dotfiles}"
-IDENTITY_MAP_FILE="${IDENTITY_MAP_FILE:-$IDENTITY_DOTFILES_ROOT/core/git/identity-owners}"
+
+# The profile recorded by bin/bootstrap. Read the file directly rather than
+# relying on a shell variable: the pre-push hook and the gh shim run outside
+# any zsh startup, so profiles/*.zsh has not been sourced for them.
+identity_profile() {
+  local p=""
+  [ -r "$HOME/.dotfiles-profile" ] || return 1
+  p="$(tr -d '[:space:]' <"$HOME/.dotfiles-profile")"
+  # The name becomes a path component below, so reject anything that is not a
+  # plain lowercase token -- "../../etc" must not select an arbitrary file.
+  case "$p" in
+    "" | *[!a-z0-9-]*) return 1 ;;
+  esac
+  printf '%s\n' "$p"
+}
+
+# Which owner map applies here. Highest precedence first, REPLACE semantics --
+# the first file that exists wins outright and the others are not merged in.
+# Merging would let a machine silently inherit another machine's roles, which
+# is the failure this whole design exists to prevent.
+#
+#   1. $IDENTITY_MAP_FILE   explicit override (tests, one-offs)
+#   2. identity-owners.local     gitignored, this machine only
+#   3. identity-owners.<profile> tracked, shared by machines of that profile
+#   4. identity-owners           tracked, the shared default
+#
+# A selected file that is malformed or unreadable is NOT skipped: validation
+# fails and every consumer fails closed. Falling through to a different map
+# would silently change which account a push authenticates as.
+identity_default_map_file() {
+  local root="$IDENTITY_DOTFILES_ROOT" profile
+
+  if [ -e "$root/core/git/identity-owners.local" ]; then
+    printf '%s\n' "$root/core/git/identity-owners.local"
+    return 0
+  fi
+  if profile="$(identity_profile)" &&
+    [ -e "$root/core/git/identity-owners.$profile" ]; then
+    printf '%s\n' "$root/core/git/identity-owners.$profile"
+    return 0
+  fi
+  printf '%s\n' "$root/core/git/identity-owners"
+}
+
+IDENTITY_MAP_FILE="${IDENTITY_MAP_FILE:-$(identity_default_map_file)}"
 
 # Print the owner for a github.com URL. Exit 1 for any other host or
 # unparseable input; callers treat that as "out of remit".

--- a/core/git/identity-lib.sh
+++ b/core/git/identity-lib.sh
@@ -105,8 +105,15 @@ identity_validate_map() {
   local file="${1:-$IDENTITY_MAP_FILE}"
   local line owner slug extra rest lineno=0 seen=""
 
-  if [ ! -r "$file" ]; then
-    printf 'identity: owner map not readable: %s\n' "$file" >&2
+  # A regular file specifically. A directory or FIFO is readable enough to pass
+  # a bare -r test, but the read loop below then fails immediately and the
+  # function would return success with an EMPTY map -- every owner unmapped,
+  # every consumer failing open. That is the exact inversion of this design's
+  # contract, so the type check belongs here rather than at selection time:
+  # selection keeps its precedence and a bogus path is rejected loudly instead
+  # of silently falling through to a map with different roles.
+  if [ ! -f "$file" ] || [ ! -r "$file" ]; then
+    printf 'identity: owner map is not a readable regular file: %s\n' "$file" >&2
     return 1
   fi
 

--- a/core/git/identity-owners.local.example
+++ b/core/git/identity-owners.local.example
@@ -1,0 +1,16 @@
+# Machine-local GitHub owner -> identity slug map.
+#
+# Copy to core/git/identity-owners.local (gitignored) when THIS machine assigns
+# different roles than the shared map. It REPLACES the shared map completely --
+# list every owner this machine should know, not just the differences. An owner
+# you leave out becomes unmapped: nothing routes it and nothing blocks it.
+#
+# The slug `default` means the stock ~/.config/gh and ~/.gitconfig.local. Any
+# other slug requires ~/.gitconfig.<slug> and ~/.gh-<slug>.
+#
+# Example -- a machine whose ambient account is guarzo, with gambtho secondary:
+#   guarzo  default
+#   gambtho gambtho
+#
+# Owners and slugs must be lowercase [a-z0-9-]; lookups are case-folded, so an
+# uppercase entry here would never match anything.

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -685,3 +685,129 @@ be_default() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"REACHED_NEXT_STEP"* ]]
 }
+
+# ---- machine-local / per-profile owner map resolution ----
+
+setup_map_root() {
+  export DOTFILES="$TEST_ROOT/dotfiles"
+  mkdir -p "$DOTFILES/core/git"
+  cp "$REPO_ROOT/core/git/identity-lib.sh" "$DOTFILES/core/git/"
+  printf 'gambtho default\nguarzo  guarzo\n' >"$DOTFILES/core/git/identity-owners"
+  unset IDENTITY_MAP_FILE
+}
+
+active_map() {
+  bash -c "source '$DOTFILES/core/git/identity-lib.sh'; printf '%s\n' \"\$IDENTITY_MAP_FILE\""
+}
+
+@test "map resolution falls back to the shared tracked map" {
+  setup_map_root
+  run active_map
+  [ "$output" = "$DOTFILES/core/git/identity-owners" ]
+}
+
+@test "a per-profile map beats the shared map" {
+  setup_map_root
+  printf 'personal\n' >"$HOME/.dotfiles-profile"
+  printf 'guarzo default\n' >"$DOTFILES/core/git/identity-owners.personal"
+  run active_map
+  [ "$output" = "$DOTFILES/core/git/identity-owners.personal" ]
+}
+
+@test "a machine-local map beats the per-profile and shared maps" {
+  setup_map_root
+  printf 'personal\n' >"$HOME/.dotfiles-profile"
+  printf 'guarzo default\n' >"$DOTFILES/core/git/identity-owners.personal"
+  printf 'guarzo default\ngambtho gambtho\n' >"$DOTFILES/core/git/identity-owners.local"
+  run active_map
+  [ "$output" = "$DOTFILES/core/git/identity-owners.local" ]
+}
+
+@test "an explicit IDENTITY_MAP_FILE beats every discovered map" {
+  setup_map_root
+  printf 'guarzo default\n' >"$DOTFILES/core/git/identity-owners.local"
+  printf 'gambtho default\n' >"$TEST_ROOT/explicit-map"
+  run bash -c "export IDENTITY_MAP_FILE='$TEST_ROOT/explicit-map'; source '$DOTFILES/core/git/identity-lib.sh'; printf '%s\n' \"\$IDENTITY_MAP_FILE\""
+  [ "$output" = "$TEST_ROOT/explicit-map" ]
+}
+
+@test "a machine-local map REPLACES rather than extends the shared map" {
+  # Replace semantics: an owner present only in the shared map must become
+  # unmapped, or a machine would silently inherit the other machine's roles.
+  setup_map_root
+  printf 'guarzo default\n' >"$DOTFILES/core/git/identity-owners.local"
+  run bash -c "source '$DOTFILES/core/git/identity-lib.sh'; identity_owner_slug guarzo"
+  [ "$status" -eq 0 ]
+  [ "$output" = "default" ]
+  run bash -c "source '$DOTFILES/core/git/identity-lib.sh'; identity_owner_slug gambtho"
+  [ "$status" -eq 1 ]
+}
+
+@test "a malformed machine-local map fails closed instead of falling back" {
+  setup_map_root
+  printf 'Guarzo guarzo\n' >"$DOTFILES/core/git/identity-owners.local"
+  run bash -c "source '$DOTFILES/core/git/identity-lib.sh'; identity_validate_map"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"lowercase"* ]]
+}
+
+@test "a profile name that is not a safe path component is ignored" {
+  setup_map_root
+  printf '../../etc\n' >"$HOME/.dotfiles-profile"
+  run active_map
+  [ "$output" = "$DOTFILES/core/git/identity-owners" ]
+}
+
+@test "the machine-local map is gitignored and has a tracked example" {
+  run git -C "$REPO_ROOT" check-ignore -q core/git/identity-owners.local
+  [ "$status" -eq 0 ]
+  [ -f "$REPO_ROOT/core/git/identity-owners.local.example" ]
+}
+
+@test "the doctor reports which owner map is in effect" {
+  setup_shim_repo "$TEST_ROOT/r" https://github.com/kubernetes-sigs/repo.git
+  cd "$TEST_ROOT/r"
+  run "$REPO_ROOT/bin/git-identity"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"map:"* ]]
+}
+
+@test "non-interactive bootstrap skips the machine-local owner map" {
+  local fake="$TEST_ROOT/boot7"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/identity-owners.local.example" "$fake/core/git/"
+  cp "$REPO_ROOT/core/git/identity-owners" "$fake/core/git/"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=true
+    DOTFILES_ROOT='$fake'
+    setup_identity_map
+  " </dev/null
+  [ "$status" -eq 0 ]
+  assert_file_absent "$fake/core/git/identity-owners.local"
+}
+
+@test "bootstrap writes a valid machine-local map from the answers" {
+  local fake="$TEST_ROOT/boot8"
+  mkdir -p "$fake/core/git"
+  cp "$REPO_ROOT/core/git/identity-owners.local.example" "$fake/core/git/"
+  cp "$REPO_ROOT/core/git/identity-owners" "$fake/core/git/"
+  cp "$REPO_ROOT/core/git/identity-lib.sh" "$fake/core/git/"
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=false
+    DOTFILES_ROOT='$fake'
+    printf 'y\nguarzo\ngambtho\n' | setup_identity_map
+  "
+  [ "$status" -eq 0 ]
+  [ -f "$fake/core/git/identity-owners.local" ]
+  # The generated map must satisfy the library's own validator.
+  run bash -c "source '$fake/core/git/identity-lib.sh'; identity_validate_map '$fake/core/git/identity-owners.local'"
+  [ "$status" -eq 0 ]
+  run bash -c "source '$fake/core/git/identity-lib.sh'; identity_owner_slug guarzo '$fake/core/git/identity-owners.local'"
+  [ "$output" = "default" ]
+  run bash -c "source '$fake/core/git/identity-lib.sh'; identity_owner_slug gambtho '$fake/core/git/identity-owners.local'"
+  [ "$output" = "gambtho" ]
+  run bash -c "ls -A '$fake/core/git' | grep -c '^\.identity-owners\.'"
+  [ "$output" -eq 0 ]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -811,3 +811,81 @@ active_map() {
   run bash -c "ls -A '$fake/core/git' | grep -c '^\.identity-owners\.'"
   [ "$output" -eq 0 ]
 }
+
+@test "a non-regular file at the map path fails closed, not open" {
+  # A directory passes a bare -r test but yields an EMPTY map, which would make
+  # every owner unmapped and every consumer fail open.
+  setup_map_root
+  mkdir -p "$DOTFILES/core/git/identity-owners.local"
+  run bash -c "source '$DOTFILES/core/git/identity-lib.sh'; identity_validate_map"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"regular file"* ]]
+}
+
+setup_map_boot() {
+  MAPBOOT="$TEST_ROOT/$1"
+  mkdir -p "$MAPBOOT/core/git"
+  cp "$REPO_ROOT/core/git/identity-owners.local.example" "$MAPBOOT/core/git/"
+  cp "$REPO_ROOT/core/git/identity-owners" "$MAPBOOT/core/git/"
+  cp "$REPO_ROOT/core/git/identity-lib.sh" "$MAPBOOT/core/git/"
+}
+
+run_map_setup() {
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    NON_INTERACTIVE=false
+    DOTFILES_ROOT='$MAPBOOT'
+    printf '%b' '$1' | setup_identity_map
+  "
+}
+
+@test "bootstrap allows a map that keeps the default but changes secondaries" {
+  setup_map_boot mb1
+  run_map_setup 'y\ngambtho\nacme\n'
+  [ "$status" -eq 0 ]
+  [ -f "$MAPBOOT/core/git/identity-owners.local" ]
+  run bash -c "source '$MAPBOOT/core/git/identity-lib.sh'; identity_owner_slug gambtho '$MAPBOOT/core/git/identity-owners.local'"
+  [ "$output" = "default" ]
+  run bash -c "source '$MAPBOOT/core/git/identity-lib.sh'; identity_owner_slug acme '$MAPBOOT/core/git/identity-owners.local'"
+  [ "$output" = "acme" ]
+  # guarzo came only from the shared map, so replace semantics drop it
+  run bash -c "source '$MAPBOOT/core/git/identity-lib.sh'; identity_owner_slug guarzo '$MAPBOOT/core/git/identity-owners.local'"
+  [ "$status" -eq 1 ]
+}
+
+@test "bootstrap rejects an invalid owner name instead of installing it" {
+  setup_map_boot mb2
+  run_map_setup 'y\nGuarzo\n\n'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Rejected"* ]]
+  assert_file_absent "$MAPBOOT/core/git/identity-owners.local"
+}
+
+@test "bootstrap rejects a duplicate owner across default and secondaries" {
+  setup_map_boot mb3
+  run_map_setup 'y\nguarzo\nguarzo\n'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Rejected"* ]]
+  assert_file_absent "$MAPBOOT/core/git/identity-owners.local"
+}
+
+@test "bootstrap does not glob-expand the secondaries answer" {
+  setup_map_boot mb4
+  run_map_setup 'y\nguarzo\n*\n'
+  [ "$status" -eq 0 ]
+  # '*' is not a valid owner, so it must be rejected -- never expanded to
+  # surrounding filenames such as 'core'.
+  assert_file_absent "$MAPBOOT/core/git/identity-owners.local"
+  [[ "$output" != *"core core"* ]]
+}
+
+@test "bootstrap refuses to install over a non-regular map path" {
+  setup_map_boot mb5
+  mkdir -p "$MAPBOOT/core/git/identity-owners.local"
+  run_map_setup 'y\nguarzo\n\n'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not a regular file"* ]]
+  [ -d "$MAPBOOT/core/git/identity-owners.local" ]
+  run bash -c "ls -A '$MAPBOOT/core/git/identity-owners.local' | wc -l"
+  [ "$output" -eq 0 ]
+}

--- a/tests/git_identity.bats
+++ b/tests/git_identity.bats
@@ -871,12 +871,25 @@ run_map_setup() {
 
 @test "bootstrap does not glob-expand the secondaries answer" {
   setup_map_boot mb4
-  run_map_setup 'y\nguarzo\n*\n'
+  # Run from a directory whose only entry is a VALID owner name. Without this,
+  # '*' expands to repo files like AGENTS.md, validation rejects them, and the
+  # map is absent either way -- the test would pass even with expansion enabled.
+  # With 'acme' as the sole entry, an expansion produces a map that validates
+  # and installs, so the assertion below genuinely detects the bug.
+  local glob_dir="$TEST_ROOT/glob-input"
+  mkdir -p "$glob_dir"
+  : >"$glob_dir/acme"
+  # The cd must happen AFTER sourcing: bin/bootstrap cds to its own repo root at
+  # source time, so any directory set before the source call is discarded.
+  run env BOOTSTRAP_SOURCE_ONLY=1 HOME="$HOME" bash -c "
+    source '$REPO_ROOT/bin/bootstrap'
+    cd '$glob_dir'
+    NON_INTERACTIVE=false
+    DOTFILES_ROOT='$MAPBOOT'
+    printf 'y\nguarzo\n*\n' | setup_identity_map
+  "
   [ "$status" -eq 0 ]
-  # '*' is not a valid owner, so it must be rejected -- never expanded to
-  # surrounding filenames such as 'core'.
   assert_file_absent "$MAPBOOT/core/git/identity-owners.local"
-  [[ "$output" != *"core core"* ]]
 }
 
 @test "bootstrap refuses to install over a non-regular map path" {

--- a/tests/repository_hygiene.bats
+++ b/tests/repository_hygiene.bats
@@ -114,3 +114,16 @@ setup() {
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+@test "every core/git example template is actually tracked" {
+  # A local .git/info/exclude pattern of "git/" once matched core/git/ as well
+  # as the legacy top-level git/, so new templates there were silently dropped:
+  # `git add` refuses an ignored path but still exits 0, so `git add -A &&
+  # git commit` succeeded without the file and only CI noticed.
+  local f
+  for f in "$REPO_ROOT"/core/git/*.example; do
+    [ -e "$f" ] || continue
+    run git -C "$REPO_ROOT" ls-files --error-unmatch "${f#"$REPO_ROOT/"}"
+    [ "$status" -eq 0 ]
+  done
+}


### PR DESCRIPTION
Follow-up to #63.

`core/git/identity-owners` is tracked, so it is shared by every machine — but it
encodes **roles**, and roles are machine-specific. An account that is a routed
secondary on one machine is the ambient default on another. A single shared map
cannot describe both, so the second machine either blocks pushes it should allow
(secondary mapped but unprovisioned) or silently routes to the wrong account.

Hit in practice immediately after #63 landed: a second machine whose ambient
account is the *other* identity started reporting it as mapped-but-unprovisioned.

## Resolution order

Highest precedence first; the first file that exists **replaces** the rest:

| Source | Scope |
| --- | --- |
| `$IDENTITY_MAP_FILE` | explicit override, tests and one-offs |
| `core/git/identity-owners.local` | this machine only (gitignored) |
| `core/git/identity-owners.<profile>` | machines sharing a `~/.dotfiles-profile` |
| `core/git/identity-owners` | shared default |

Replace rather than merge is deliberate. Merging would let a machine silently
inherit another machine's roles — the precise failure this design exists to
prevent. The cost is that a local map must list every owner the machine should
know; one left out becomes unmapped, so nothing routes it and nothing blocks it.

Profiles are read from `~/.dotfiles-profile` directly rather than from a shell
variable, because the pre-push hook and the `gh` shim run outside any zsh
startup. The name is validated before use as a path component, so a profile of
`../../etc` selects nothing.

## Fail-closed preserved

A selected map that is malformed or unreadable is **not** skipped in favour of
the next source. Validation fails and every consumer fails closed, because
falling through would silently change which account a push authenticates as —
the same reasoning that makes an invalid map a hard error in #63.

## Setup

`bin/bootstrap` gains `setup_identity_map`: it shows the shared map, asks whether
this machine differs, and writes the local file atomically. It follows the same
contract as the secondary-identity step — never prompts and never writes a
partial file under `--non-interactive`, and every failure path warns and returns
0 so an optional step cannot abort a run under `set -e`. A tracked
`identity-owners.local.example` documents the format for hand-editing.

`bin/git-identity` now prints the map in effect. With four possible sources,
"which map won?" is the first question when routing surprises you on a machine.

## Verification

70 identity tests (10 new), 14 hygiene, 3 portability, 2 LFS, 30
install-orchestration — all green, lint clean. Full suite unchanged at the
pre-existing 60-failure baseline.

Confirmed no behaviour change on a machine with no local or per-profile map: it
still resolves the shared map. Confirmed a local map cleanly inverts the roles
for the second machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added machine- and profile-specific GitHub identity mappings.
  * Added optional interactive setup during bootstrap for local identity ownership.
  * Added reporting of the active identity mapping source.
* **Documentation**
  * Documented mapping precedence, replacement behavior, unmapped owners, and setup diagnostics.
  * Added guidance and examples for configuring machine-local identity mappings.
* **Bug Fixes**
  * Improved validation for profile names, malformed maps, and invalid file types.
  * Kept local configuration machine-specific and excluded from version control.
* **Tests**
  * Expanded coverage for mapping discovery, validation, bootstrap setup, and repository hygiene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->