### PR TITLE
feat(projectmux): pin the v0.2.0 release

### DIFF
--- a/config/versions.env
+++ b/config/versions.env
@@ -60,10 +60,10 @@ TREE_SITTER_SHA256_ARM64=e47dd59bf2f21ad7c15771546a724464ee3c008a60fbb61c6860bd1
 # Every v0.x tag is a GitHub prerelease, so /releases/latest 404s and
 # /releases/latest/download/ is unusable — an explicit tag is pinned, which
 # the reviewed-digest requirement demands regardless. Digests come from the
-# release's SHA256SUMS; the amd64 binary was additionally downloaded and
-# hashed directly rather than trusted from that file. Upstream publishes no
+# release's SHA256SUMS; both binaries were additionally downloaded and hashed
+# directly rather than trusted from that file. Upstream publishes no
 # darwin assets, and the installer is Linux-only by design.
-PROJECTMUX_VERSION=v0.1.0
-PROJECTMUX_RELEASE_BASE=https://github.com/gambtho/projectmux/releases/download/v0.1.0
-PROJECTMUX_LINUX_AMD64_SHA256=7197eb19215af33f4e57fb26b8038cf701319d84fed4a6167ccb573035f43cda
-PROJECTMUX_LINUX_ARM64_SHA256=7f9dbd1ee2cda2f673b8feeed346f0ea5cc592aa0a4d8c97b7ed5108c8c4599e
+PROJECTMUX_VERSION=v0.2.0
+PROJECTMUX_RELEASE_BASE=https://github.com/gambtho/projectmux/releases/download/v0.2.0
+PROJECTMUX_LINUX_AMD64_SHA256=dc7477a9c415dce14efda3c3d263071f2ca923fbdf445916fbeb209630cc5112
+PROJECTMUX_LINUX_ARM64_SHA256=3ec6bcf137345e8f2465b16eb4f721f9c3cd6890b32b646aa69d637fc3f8c7bb

--- a/tests/dependency_pins.bats
+++ b/tests/dependency_pins.bats
@@ -27,7 +27,7 @@ setup() {
   [[ "$output" == *"artifact yq v4.45.1"* ]]
   [[ "$output" == *"artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"artifact vekil v0.14.0"* ]]
-  [[ "$output" == *"artifact projectmux v0.1.0"* ]]
+  [[ "$output" == *"artifact projectmux v0.2.0"* ]]
   [[ "$output" == *"artifact nerd-fonts v3.4.0"* ]]
   [[ "$output" == *"artifact nerd-font-cascadia-mono v3.4.0 $NERD_FONT_CASCADIA_MONO_SHA256"* ]]
   [[ "$output" == *"artifact nerd-font-hack v3.4.0 $NERD_FONT_HACK_SHA256"* ]]
@@ -112,7 +112,7 @@ case "$url" in
     printf 'curl: (22) The requested URL returned error: 404\n' >&2
     exit 22
     ;;
-  *gambtho/projectmux/releases) printf '[{"tag_name":"v0.1.0","prerelease":true}]\n' ;;
+  *gambtho/projectmux/releases) printf '[{"tag_name":"v0.2.0","prerelease":true}]\n' ;;
 esac
 SCRIPT
   chmod +x "$STUB_BIN/curl"
@@ -125,7 +125,7 @@ SCRIPT
   [[ "$output" == *"current artifact yq v4.45.1"* ]]
   [[ "$output" == *"current artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"current artifact vekil v0.14.0"* ]]
-  [[ "$output" == *"current artifact projectmux v0.1.0"* ]]
+  [[ "$output" == *"current artifact projectmux v0.2.0"* ]]
   [[ "$output" == *"current artifact nerd-fonts v3.4.0"* ]]
 }
 

--- a/tests/projectmux_install.bats
+++ b/tests/projectmux_install.bats
@@ -13,7 +13,7 @@ setup() {
 source_installer() {
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
-    PROJECTMUX_STATE_DIR="$TEST_ROOT/state" \
+    PROJECTMUX_STATE_ROOT="$TEST_ROOT/state" \
     PROJECTMUX_CONFIG_ROOT="$TEST_ROOT/config/projectmux" \
     "$@"
 }
@@ -271,7 +271,7 @@ source_installer() {
 @test "pinned install publishes a regular file and records the version" {
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
-    PROJECTMUX_STATE_DIR="$TEST_ROOT/state" \
+    PROJECTMUX_STATE_ROOT="$TEST_ROOT/state" \
     bash -c '
       source "$1/tools/projectmux/install.sh"
       download_verified_artifact() { printf "binary" >"$3"; }
@@ -280,7 +280,7 @@ source_installer() {
     ' _ "$REPO_ROOT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MARKER=v0.1.0"* ]]
+  [[ "$output" == *"MARKER=v0.2.0"* ]]
   [ -f "$TEST_ROOT/bin/projectmux" ]
   [ ! -L "$TEST_ROOT/bin/projectmux" ]
   [ -x "$TEST_ROOT/bin/projectmux" ]
@@ -290,13 +290,13 @@ source_installer() {
   mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/state"
   printf 'installed' >"$TEST_ROOT/bin/projectmux"
   chmod 0755 "$TEST_ROOT/bin/projectmux"
-  printf 'v0.1.0\n' >"$TEST_ROOT/state/installed-version"
+  printf 'v0.2.0\n' >"$TEST_ROOT/state/installed-version"
 
   # return 99 rather than a stub download: if the short-circuit fails to fire,
   # the install errors instead of quietly succeeding with fabricated content.
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
-    PROJECTMUX_STATE_DIR="$TEST_ROOT/state" \
+    PROJECTMUX_STATE_ROOT="$TEST_ROOT/state" \
     bash -c '
       source "$1/tools/projectmux/install.sh"
       download_verified_artifact() { return 99; }
@@ -309,7 +309,7 @@ source_installer() {
   # Exact equality, not a substring: the short-circuit compares installed_marker
   # to the bare tag, so a future change that leaves stray whitespace in the
   # marker read must fail this test rather than pass on a loose match.
-  [ "${lines[-1]}" = "EXACT=v0.1.0" ]
+  [ "${lines[-1]}" = "EXACT=v0.2.0" ]
 }
 
 @test "a matching marker with a symlink destination still reinstalls" {
@@ -319,11 +319,11 @@ source_installer() {
   ln -s "$TEST_ROOT/local/projectmux" "$TEST_ROOT/bin/projectmux"
   # The pathological pair the Reconciliation invariant describes: a pinned
   # marker naming a version the destination does not actually hold.
-  printf 'v0.1.0\n' >"$TEST_ROOT/state/installed-version"
+  printf 'v0.2.0\n' >"$TEST_ROOT/state/installed-version"
 
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
-    PROJECTMUX_STATE_DIR="$TEST_ROOT/state" \
+    PROJECTMUX_STATE_ROOT="$TEST_ROOT/state" \
     bash -c '
       source "$1/tools/projectmux/install.sh"
       download_verified_artifact() { printf "pinned" >"$3"; }
@@ -346,7 +346,7 @@ source_installer() {
 
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
-    PROJECTMUX_STATE_DIR="$TEST_ROOT/state" \
+    PROJECTMUX_STATE_ROOT="$TEST_ROOT/state" \
     bash -c '
       source "$1/tools/projectmux/install.sh"
       download_verified_artifact() { printf "pinned" >"$3"; }
@@ -355,7 +355,7 @@ source_installer() {
     ' _ "$REPO_ROOT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MARKER=v0.1.0"* ]]
+  [[ "$output" == *"MARKER=v0.2.0"* ]]
   [ -f "$TEST_ROOT/bin/projectmux" ]
   [ ! -L "$TEST_ROOT/bin/projectmux" ]
   [ "$(cat "$TEST_ROOT/bin/projectmux")" = pinned ]
@@ -369,7 +369,7 @@ source_installer() {
 
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
-    PROJECTMUX_STATE_DIR="$TEST_ROOT/state" \
+    PROJECTMUX_STATE_ROOT="$TEST_ROOT/state" \
     bash -c '
       source "$1/tools/projectmux/install.sh"
       download_verified_artifact() { printf "checksum mismatch\n" >&2; return 1; }

--- a/tools/projectmux/README.md
+++ b/tools/projectmux/README.md
@@ -98,7 +98,7 @@ systemctl --user enable --now projectmux-autostart.service
 |---|---|---|
 | `PROJECTMUX_LOCAL_BINARY` | unset | Symlink this build instead of installing the pin |
 | `PROJECTMUX_INSTALL_DIR` | `~/.local/bin` | Where the binary is published |
-| `PROJECTMUX_STATE_DIR` | `$XDG_STATE_HOME/projectmux` | Holds `installed-version` |
+| `PROJECTMUX_STATE_ROOT` | `$XDG_STATE_HOME/projectmux` | Holds `installed-version` |
 | `PROJECTMUX_CONFIG_ROOT` | `$XDG_CONFIG_HOME/projectmux` | Holds `defaults.yaml` and `workspaces/` |
 | `PROJECTMUX_REPOSITORY_ROOTS` | `$DEV_REPO_ROOT`, else `~/workspace` | `:`-separated roots written into `defaults.yaml` |
 

--- a/tools/projectmux/install.sh
+++ b/tools/projectmux/install.sh
@@ -19,8 +19,8 @@ source "$DOTFILES_ROOT/config/versions.env"
 
 PROJECTMUX_INSTALL_DIR="${PROJECTMUX_INSTALL_DIR:-$HOME/.local/bin}"
 PROJECTMUX_BIN="$PROJECTMUX_INSTALL_DIR/projectmux"
-PROJECTMUX_STATE_DIR="${PROJECTMUX_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/projectmux}"
-MARKER_FILE="$PROJECTMUX_STATE_DIR/installed-version"
+PROJECTMUX_STATE_ROOT="${PROJECTMUX_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/projectmux}"
+MARKER_FILE="$PROJECTMUX_STATE_ROOT/installed-version"
 PROJECTMUX_CONFIG_ROOT="${PROJECTMUX_CONFIG_ROOT:-${XDG_CONFIG_HOME:-$HOME/.config}/projectmux}"
 DEFAULTS_TEMPLATE="$DOTFILES_ROOT/tools/projectmux/defaults.yaml.template"
 SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
@@ -133,8 +133,8 @@ installed_marker() {
 # file, so a concurrent reader never sees a half-written version string.
 write_marker() {
   local value="$1"
-  prepare_destination_directory "$PROJECTMUX_STATE_DIR"
-  STAGED_MARKER=$(mktemp "$PROJECTMUX_STATE_DIR/.installed-version.XXXXXX")
+  prepare_destination_directory "$PROJECTMUX_STATE_ROOT"
+  STAGED_MARKER=$(mktemp "$PROJECTMUX_STATE_ROOT/.installed-version.XXXXXX")
   printf '%s\n' "$value" >"$STAGED_MARKER"
   chmod 0644 "$STAGED_MARKER"
   publish_file "$STAGED_MARKER" "$MARKER_FILE"
@@ -201,7 +201,7 @@ install_pinned_binary() {
   esac
 
   prepare_destination_directory "$bin_dir"
-  prepare_destination_directory "$PROJECTMUX_STATE_DIR"
+  prepare_destination_directory "$PROJECTMUX_STATE_ROOT"
   validate_install_target "$PROJECTMUX_BIN"
 
   # Both halves of this condition are load-bearing; do not reduce it to the
@@ -344,7 +344,7 @@ report_plan() {
   printf 'ProjectMux install plan:\n'
   printf '  version:    %s\n' "$PROJECTMUX_VERSION"
   printf '  binary:     %s\n' "$PROJECTMUX_BIN"
-  printf '  state:      %s\n' "$PROJECTMUX_STATE_DIR"
+  printf '  state:      %s\n' "$PROJECTMUX_STATE_ROOT"
   printf '  config:     %s\n' "$PROJECTMUX_CONFIG_ROOT"
   printf '  unit:       %s (written, not enabled)\n' "$SERVICE_UNIT"
   printf '  installed:  %s\n' "$(installed_marker || printf '(none)')"


### PR DESCRIPTION
Bumps the ProjectMux pin from v0.1.0 to v0.2.0 and renames the installer's
state-root variable to match what the application actually reads.

## Pin

`config/versions.env` is the single manifest for this family (enforced by
`tests/dependency_pins.bats`), so the tag, release base, and both Linux digests
change in one place. The digests come from the v0.2.0 release's `SHA256SUMS`
asset.

## Environment variable rename

`PROJECTMUX_STATE_DIR` -> `PROJECTMUX_STATE_ROOT`. ProjectMux reads
`PROJECTMUX_STATE_ROOT` and `PROJECTMUX_CONFIG_ROOT`; the installer already used
the `_ROOT` spelling for config and only the state variable was out of step.

The default location is unchanged (`$XDG_STATE_HOME/projectmux`), so an existing
`installed-version` marker is still found where it was written -- no migration.
The variable existed nowhere outside the installer, its README table, and its
tests: no shell rc, no alias, no env file, and the systemd unit sets no
environment at all.

## Verification

Both release assets were downloaded and checked against the pinned digests:

```
projectmux-linux-amd64: OK
projectmux-linux-arm64: OK
```

The installer's real `download_verified_artifact` path was then run end-to-end
against redirected roots for both architectures -- not a stubbed download:

```
Downloading ProjectMux v0.2.0 for linux/amd64...
SUCCESS  Installed ProjectMux v0.2.0
MARKER=v0.2.0
INFO     ProjectMux v0.2.0 is already installed   # rerun short-circuits
Downloading ProjectMux v0.2.0 for linux/arm64...
SUCCESS  Installed ProjectMux v0.2.0
```

`file` confirmed x86-64 and ARM aarch64 ELF respectively, and the downloaded
binary reports `v0.2.0`. `make check` passes (syntax, shellcheck, shfmt, bats,
python-test, validate).

## Reviewer note

Test literals in `tests/dependency_pins.bats` and `tests/projectmux_install.bats`
hardcode the tag rather than interpolating `$PROJECTMUX_VERSION`, so a bump has
to touch them. That is deliberate in this repo -- interpolating would make the
marker assertions tautological -- but it is the part most likely to be missed on
the next bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated ProjectMux to version 0.2.0 with refreshed release downloads and integrity checks.
  * Renamed the state directory override to `PROJECTMUX_STATE_ROOT`; the default location remains unchanged.
* **Documentation**
  * Updated configuration guidance and checksum verification comments.
* **Bug Fixes**
  * Updated installation and version validation scenarios to support the new release and state variable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->