### PR TITLE
fix(codex-review): fall back to danger-full-access when bubblewrap cannot initialize

### DIFF
--- a/ai/marketplace/plugins/my/commands/codex-review.md
+++ b/ai/marketplace/plugins/my/commands/codex-review.md
@@ -2,7 +2,7 @@
 name: codex-review
 description: Get a second opinion from Codex on a spec or implementation plan — reviews the doc you have been working on, against the actual code
 argument-hint: "[path — defaults to the doc most recently discussed in this session] [--with-spec | --with-plan]"
-allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git status:*), Bash(git diff:*), Bash(ls:*), Bash(test:*), Bash(bwrap --ro-bind / / --dev /dev true), Bash(sha256sum:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
+allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(cd:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git status:*), Bash(git diff:*), Bash(ls:*), Bash(test:*), Bash(bwrap --ro-bind / / --dev /dev true), Bash(sha256sum:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
 ---
 
 # Codex Review — Second Opinion on a Spec or Plan
@@ -269,7 +269,7 @@ git diff HEAD
 sha256sum {absolute path of each document resolved in Phase 1, quoted}
 ```
 
-Run this Bash call with `ROOT` as its working directory, and give `sha256sum` absolute quoted paths — never bare relative ones. Phase 0d supports reviewing a doc in a *different* worktree than the session's, and there a bare `git status` in the session's directory reports on the wrong checkout, and the guard reports clean no matter what Codex wrote. Do **not** reach for `git -C` instead: this command's frontmatter grants `Bash(git status:*)`, which `git -C ...` does not match, so it would prompt.
+Run all three from `ROOT`, as `cd "$ROOT" && {command}`, and give `sha256sum` absolute quoted paths — never bare relative ones. Phase 0d supports reviewing a doc in a *different* worktree than the session's, and there a bare `git status` in the session's directory reports on the wrong checkout, and the guard reports clean no matter what Codex wrote. `cd` is the form to use because it is the only way to set a Bash call's working directory, and this command's frontmatter grants `Bash(cd:*)` for it. Do **not** reach for `git -C` instead: the frontmatter grants `Bash(git status:*)`, which `git -C ...` does not match, so it would prompt.
 
 Store them as `PRE_STATUS`, `PRE_DIFF`, and `PRE_HASHES`.
 
@@ -289,11 +289,13 @@ the repo — the smaller half of the exposure.
 A mismatch in any of the three captures is reported in Phase 4a. Do not repair,
 revert, or stage anything: report it and let the user decide.
 
-One gap remains by choice: a file that was already untracked before the run
+Two gaps remain by choice. A file that was already untracked before the run
 shows `?? path` in both captures and is not covered by `git diff HEAD`, so a
-write into a pre-existing untracked file is invisible. Closing it means hashing
-every file under `ROOT` twice per review. Untracked files *appearing* or
-*disappearing* are caught by the status comparison.
+write into a pre-existing untracked file is invisible. A file matched by
+`.gitignore` is absent from all three captures entirely, so a write into an
+ignored file is invisible whether or not it existed before. Closing either
+means hashing every file under `ROOT` twice per review. Untracked files
+*appearing* or *disappearing* are still caught by the status comparison.
 
 ---
 
@@ -327,14 +329,14 @@ This takes a few minutes on a substantial plan. If the Bash call times out, say 
 | Connection refused to `172.17.0.1:1337` | Vekil proxy is down | Tell the user; do not fall back to a direct API call |
 | Codex reports `main` as the branch, or can't find the doc | `-C` pointed at the main checkout, not the worktree (Phase 0d) | Re-derive `ROOT` and re-run |
 | Git commands fail inside Codex, in a worktree only | Sandbox can't reach `.git/worktrees/` in the main checkout | Re-run with `--add-dir {main checkout}/.git`; report if that's needed, it's a regression |
-| `bwrap: No permissions to create a new namespace`, or `bwrap: Creating new namespace failed` | The container forbids user namespaces; Codex's Linux sandbox cannot initialize | Detection missed the container. Follow **Re-entry after a missed container** below |
+| Any `bwrap:` error, or any message about creating, entering, or having permission for a namespace — e.g. `bwrap: No permissions to create a new namespace`, `bwrap: Creating new namespace failed` | The container forbids user namespaces; Codex's Linux sandbox cannot initialize | Detection missed the container. Follow **Re-entry after a missed container** below |
 | Non-zero exit | Run failed | Report the stderr tail verbatim; do not fabricate a review |
 
-bwrap's wording varies by build, so both observed forms are listed. Phase 0e keys off the probe's **exit status**, never the message text.
+bwrap's wording varies by build, so match the *shape* of the failure rather than either exact string — the two above are the observed forms, not the whole set, and a wording that falls through to `Non-zero exit` loses the re-entry that makes the review possible at all. Phase 0e's probe has no such problem: it keys off the **exit status**, never the message text.
 
 Match the specific rows before the general one: `Non-zero exit` is the fallback for a failure none of the rows above describe. A non-zero exit means the output is not a review, whether or not `review.md` exists. A run that fails partway can leave a partial or stale `review.md` behind; do not read it as findings, do not group it by severity, and do not add a verdict to it.
 
-**Re-entry after a missed container.** The bwrap rows fire exactly when Phase 0e chose `read-only` for a container that cannot initialize bubblewrap — so Phase 2e was skipped and no pre-run captures exist. Do **not** re-run with a hand-edited `--sandbox` flag: that runs Codex unsandboxed against a bind-mounted working tree with no integrity guard, which is the one case the guard exists for. Instead:
+**Re-entry after a missed container.** The bwrap row fires exactly when Phase 0e chose `read-only` for a container that cannot initialize bubblewrap — so Phase 2e was skipped and no pre-run captures exist. Do **not** re-run with a hand-edited `--sandbox` flag: that runs Codex unsandboxed against a bind-mounted working tree with no integrity guard, which is the one case the guard exists for. Instead:
 
 1. Report that detection missed the container, and say which markers you checked.
 2. Set `SANDBOX_MODE` to `danger-full-access`.

--- a/ai/marketplace/plugins/my/commands/codex-review.md
+++ b/ai/marketplace/plugins/my/commands/codex-review.md
@@ -231,9 +231,6 @@ COVERAGE GAPS:            (PAIR mode only; omit the section otherwise)
 
 SUMMARY:
 {3-5 sentences: is this doc ready to build from, and what is the biggest risk}
-```
-
-Severity is `Blocking` (would produce wrong or broken work), `Concern` (worth resolving before starting), or `Nit` (author's discretion). Confidence is `HIGH` / `MEDIUM` / `LOW`. Tell Codex to **prefer few high-confidence findings over many speculative ones**, and to cite `file:line` for every claim about existing code.
 
 If you cannot read the repository — sandbox failure, missing files, any
 environmental block — do NOT return a VERDICT line. Return exactly:
@@ -242,6 +239,9 @@ STATUS: INCOMPLETE
 REASON: {what blocked you}
 
 A verdict you cannot support by reading the code is worse than no verdict.
+```
+
+Severity is `Blocking` (would produce wrong or broken work), `Concern` (worth resolving before starting), or `Nit` (author's discretion). Confidence is `HIGH` / `MEDIUM` / `LOW`. Tell Codex to **prefer few high-confidence findings over many speculative ones**, and to cite `file:line` for every claim about existing code.
 
 ## Phase 2e: Integrity Guard (danger-full-access only)
 
@@ -336,7 +336,7 @@ either way about the document.
 Skip Phase 4b entirely; there are no findings to apply. Do not group it by
 severity, do not add "My take", and never present it as a verdict.
 
-Present Codex's review in the conversation, grouped by severity, Blocking first. Keep its wording for the findings themselves — the value here is an independent voice, not your paraphrase.
+Otherwise, for a normal (non-INCOMPLETE) review, present Codex's review in the conversation, grouped by severity, Blocking first. Keep its wording for the findings themselves — the value here is an independent voice, not your paraphrase.
 
 Then add your own short assessment, clearly separated:
 

--- a/ai/marketplace/plugins/my/commands/codex-review.md
+++ b/ai/marketplace/plugins/my/commands/codex-review.md
@@ -235,6 +235,14 @@ SUMMARY:
 
 Severity is `Blocking` (would produce wrong or broken work), `Concern` (worth resolving before starting), or `Nit` (author's discretion). Confidence is `HIGH` / `MEDIUM` / `LOW`. Tell Codex to **prefer few high-confidence findings over many speculative ones**, and to cite `file:line` for every claim about existing code.
 
+If you cannot read the repository — sandbox failure, missing files, any
+environmental block — do NOT return a VERDICT line. Return exactly:
+
+STATUS: INCOMPLETE
+REASON: {what blocked you}
+
+A verdict you cannot support by reading the code is worse than no verdict.
+
 ## Phase 2e: Integrity Guard (danger-full-access only)
 
 Skip this phase entirely when `SANDBOX_MODE` is `read-only` — a read-only
@@ -316,6 +324,17 @@ Codex was asked to review, not modify. Inspect these before trusting the review.
 ```
 
 Then continue with the normal report. A clean guard needs no mention.
+
+**If the review begins `STATUS: INCOMPLETE`**, it is not a review. Report it as an environment failure, quote the `REASON:` verbatim, and state that no design conclusion follows:
+
+```
+Codex could not complete this review: {REASON}
+Nothing was inspected, so no design conclusion follows — this is not a signal
+either way about the document.
+```
+
+Skip Phase 4b entirely; there are no findings to apply. Do not group it by
+severity, do not add "My take", and never present it as a verdict.
 
 Present Codex's review in the conversation, grouped by severity, Blocking first. Keep its wording for the findings themselves — the value here is an independent voice, not your paraphrase.
 

--- a/ai/marketplace/plugins/my/commands/codex-review.md
+++ b/ai/marketplace/plugins/my/commands/codex-review.md
@@ -2,7 +2,7 @@
 name: codex-review
 description: Get a second opinion from Codex on a spec or implementation plan — reviews the doc you have been working on, against the actual code
 argument-hint: "[path — defaults to the doc most recently discussed in this session] [--with-spec | --with-plan]"
-allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git status:*), Bash(ls:*), Bash(test:*), Bash(bwrap:*), Bash(sha256sum:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
+allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git status:*), Bash(ls:*), Bash(test:*), Bash(bwrap --ro-bind / / --dev /dev true), Bash(sha256sum:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
 ---
 
 # Codex Review — Second Opinion on a Spec or Plan
@@ -59,13 +59,17 @@ bubblewrap, which needs an unprivileged user namespace; many containers forbid
 `clone(CLONE_NEWUSER)`. Discovering that by running a full review wastes minutes
 and tokens and returns nothing usable, so determine it up front.
 
-**First, is this a container?** Stop at the first hit:
+**First, is this a container?** Run these exact checks and stop at the first hit:
 
-1. `$REMOTE_CONTAINERS` or `$CODESPACES` is non-empty — VS Code Dev Containers
-   and Codespaces respectively. Checked first because they name a devcontainer
-   specifically.
-2. `/.dockerenv` exists — Docker.
-3. `/run/.containerenv` exists — Podman.
+1. `test -n "$REMOTE_CONTAINERS"` or `test -n "$CODESPACES"` — VS Code Dev
+   Containers and Codespaces respectively. Checked first because they name a
+   devcontainer specifically.
+2. `test -f /.dockerenv` — Docker.
+3. `test -f /run/.containerenv` — Podman.
+
+Use those forms. `env | grep`, `printenv`, and `echo` are not covered by this
+command's `Bash(test:*)` grant and stall an otherwise silent preflight on a
+permission prompt.
 
 A plain `docker run` also trips markers 2 and 3. That is correct: the same
 namespace policy applies, so the same decision follows.
@@ -87,6 +91,10 @@ Set `SANDBOX_MODE`:
 | yes       | non-zero or absent | `danger-full-access` |
 
 Outside a container the probe never runs and `SANDBOX_MODE` is `read-only`.
+
+The `{why}` in the Phase 1c confirmation names the row that fired, one string per
+row, top to bottom: `no container`, `container detected; bwrap probe succeeded`,
+`container detected; bwrap probe failed`. A run always prints one of the three.
 
 Do **not** prompt before escalating. In a container the escalation is automatic
 by design: the container is the external isolation boundary, which is the case
@@ -243,6 +251,8 @@ A verdict you cannot support by reading the code is worse than no verdict.
 
 Severity is `Blocking` (would produce wrong or broken work), `Concern` (worth resolving before starting), or `Nit` (author's discretion). Confidence is `HIGH` / `MEDIUM` / `LOW`. Tell Codex to **prefer few high-confidence findings over many speculative ones**, and to cite `file:line` for every claim about existing code.
 
+---
+
 ## Phase 2e: Integrity Guard (danger-full-access only)
 
 Skip this phase entirely when `SANDBOX_MODE` is `read-only` — a read-only
@@ -255,13 +265,15 @@ write. That is probably enough; this phase makes "probably" checkable.
 
 ```
 git status --short
-sha256sum {each document resolved in Phase 1}
+sha256sum {absolute path of each document resolved in Phase 1, quoted}
 ```
+
+Run this Bash call with `ROOT` as its working directory, and give `sha256sum` absolute quoted paths — never bare relative ones. Phase 0d supports reviewing a doc in a *different* worktree than the session's, and there a bare `git status` in the session's directory reports on the wrong checkout, and the guard reports clean no matter what Codex wrote. Do **not** reach for `git -C` instead: this command's frontmatter grants `Bash(git status:*)`, which `git -C ...` does not match, so it would prompt.
 
 Store them as `PRE_STATUS` and `PRE_HASHES`.
 
-**After the run**, capture the same two into `POST_STATUS` and `POST_HASHES`
-and compare.
+**After the run**, capture the same two the same way — same working directory,
+same absolute paths — into `POST_STATUS` and `POST_HASHES` and compare.
 
 Why hashes and not `git checkout`: Phase 0d has Codex read the **working tree**,
 so reviewing a document before it is committed is the normal path here. `git
@@ -288,6 +300,9 @@ Store `"$WORKDIR/review.md"` as `OUT_FILE`.
 - `--sandbox "$SANDBOX_MODE"` — `read-only` unless Phase 0e determined that this
   container cannot initialize bubblewrap. Do **not** hand-edit this to
   `danger-full-access`; let Phase 0e decide, so the integrity guard runs with it.
+  If the run fails because detection missed, the re-entry procedure below
+  re-decides `SANDBOX_MODE` and re-enters Phase 2e — the flag on this line still
+  stays as written.
 - `-C "$ROOT"` — pins the working root to the current checkout/worktree.
 - `-o` — writes only the final message, so you get the review without the reasoning transcript.
 - `-` — reads the prompt from stdin, avoiding shell-quoting problems with a long prompt.
@@ -302,10 +317,25 @@ This takes a few minutes on a substantial plan. If the Bash call times out, say 
 | Connection refused to `172.17.0.1:1337` | Vekil proxy is down | Tell the user; do not fall back to a direct API call |
 | Codex reports `main` as the branch, or can't find the doc | `-C` pointed at the main checkout, not the worktree (Phase 0d) | Re-derive `ROOT` and re-run |
 | Git commands fail inside Codex, in a worktree only | Sandbox can't reach `.git/worktrees/` in the main checkout | Re-run with `--add-dir {main checkout}/.git`; report if that's needed, it's a regression |
-| `bwrap: No permissions to create a new namespace`, or `bwrap: Creating new namespace failed` | The container forbids user namespaces; Codex's Linux sandbox cannot initialize | Phase 0e should have selected `danger-full-access` — if you see this, detection missed the container. Report it and re-run with `--sandbox danger-full-access` |
-| Non-zero exit, no output file | Run failed | Report the stderr tail verbatim; do not fabricate a review |
+| `bwrap: No permissions to create a new namespace`, or `bwrap: Creating new namespace failed` | The container forbids user namespaces; Codex's Linux sandbox cannot initialize | Detection missed the container. Follow **Re-entry after a missed container** below |
+| Non-zero exit | Run failed | Report the stderr tail verbatim; do not fabricate a review |
 
 bwrap's wording varies by build, so both observed forms are listed. Phase 0e keys off the probe's **exit status**, never the message text.
+
+Match the specific rows before the general one: `Non-zero exit` is the fallback for a failure none of the rows above describe. A non-zero exit means the output is not a review, whether or not `review.md` exists. A run that fails partway can leave a partial or stale `review.md` behind; do not read it as findings, do not group it by severity, and do not add a verdict to it.
+
+**Re-entry after a missed container.** The bwrap rows fire exactly when Phase 0e chose `read-only` for a container that cannot initialize bubblewrap — so Phase 2e was skipped and no `PRE_STATUS`/`PRE_HASHES` exist. Do **not** re-run with a hand-edited `--sandbox` flag: that runs Codex unsandboxed against a bind-mounted working tree with no integrity guard, which is the one case the guard exists for. Instead:
+
+1. Report that detection missed the container, and say which markers you checked.
+2. Set `SANDBOX_MODE` to `danger-full-access`.
+3. Re-enter at **Phase 2e** and capture `PRE_STATUS` and `PRE_HASHES`.
+4. Re-run the Phase 3 command **unchanged** — `--sandbox "$SANDBOX_MODE"` now
+   resolves to `danger-full-access` on its own.
+5. Capture `POST_STATUS` and `POST_HASHES`, and report any difference through
+   Phase 4a like any other unsandboxed run.
+
+Re-decide `SANDBOX_MODE` once. If the same error recurs under
+`danger-full-access`, stop and report it — that is a different failure.
 
 Then read `OUT_FILE` with the Read tool.
 
@@ -323,7 +353,7 @@ WARNING: files changed during an unsandboxed review run.
 Codex was asked to review, not modify. Inspect these before trusting the review.
 ```
 
-Then continue with the normal report. A clean guard needs no mention.
+Then continue with the report. A clean guard needs no mention.
 
 **If the review begins `STATUS: INCOMPLETE`**, it is not a review. Report it as an environment failure, quote the `REASON:` verbatim, and state that no design conclusion follows:
 

--- a/ai/marketplace/plugins/my/commands/codex-review.md
+++ b/ai/marketplace/plugins/my/commands/codex-review.md
@@ -2,7 +2,7 @@
 name: codex-review
 description: Get a second opinion from Codex on a spec or implementation plan — reviews the doc you have been working on, against the actual code
 argument-hint: "[path — defaults to the doc most recently discussed in this session] [--with-spec | --with-plan]"
-allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git status:*), Bash(ls:*), Bash(test:*), Bash(bwrap --ro-bind / / --dev /dev true), Bash(sha256sum:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
+allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git status:*), Bash(git diff:*), Bash(ls:*), Bash(test:*), Bash(bwrap --ro-bind / / --dev /dev true), Bash(sha256sum:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
 ---
 
 # Codex Review — Second Opinion on a Spec or Plan
@@ -261,19 +261,23 @@ sandbox cannot write, so there is nothing to guard.
 Under `danger-full-access` the prompt is the only thing telling Codex not to
 write. That is probably enough; this phase makes "probably" checkable.
 
-**Before running Codex**, capture both:
+**Before running Codex**, capture all three:
 
 ```
 git status --short
+git diff HEAD
 sha256sum {absolute path of each document resolved in Phase 1, quoted}
 ```
 
 Run this Bash call with `ROOT` as its working directory, and give `sha256sum` absolute quoted paths — never bare relative ones. Phase 0d supports reviewing a doc in a *different* worktree than the session's, and there a bare `git status` in the session's directory reports on the wrong checkout, and the guard reports clean no matter what Codex wrote. Do **not** reach for `git -C` instead: this command's frontmatter grants `Bash(git status:*)`, which `git -C ...` does not match, so it would prompt.
 
-Store them as `PRE_STATUS` and `PRE_HASHES`.
+Store them as `PRE_STATUS`, `PRE_DIFF`, and `PRE_HASHES`.
 
-**After the run**, capture the same two the same way — same working directory,
-same absolute paths — into `POST_STATUS` and `POST_HASHES` and compare.
+`git diff HEAD` is not redundant with `git status --short`. Status reports a tracked file's *state*, not its contents: a file already modified before the run shows ` M path` both before and after, so a write by Codex into an already-dirty file is invisible to a status comparison. Reviews normally run mid-feature against a dirty worktree, so that is the common case, not an edge case. Comparing `PRE_DIFF` to `POST_DIFF` catches it. You do not need to echo the diff — only whether it changed.
+
+**After the run**, capture the same three the same way — same working directory,
+same absolute paths — into `POST_STATUS`, `POST_DIFF`, and `POST_HASHES` and
+compare.
 
 Why hashes and not `git checkout`: Phase 0d has Codex read the **working tree**,
 so reviewing a document before it is committed is the normal path here. `git
@@ -282,8 +286,14 @@ workspace is usually a bind mount from the host, so a write is not confined by
 the container boundary either. The container bounds what Codex reaches *outside*
 the repo — the smaller half of the exposure.
 
-A mismatch in either capture is reported in Phase 4a. Do not repair, revert, or
-stage anything: report it and let the user decide.
+A mismatch in any of the three captures is reported in Phase 4a. Do not repair,
+revert, or stage anything: report it and let the user decide.
+
+One gap remains by choice: a file that was already untracked before the run
+shows `?? path` in both captures and is not covered by `git diff HEAD`, so a
+write into a pre-existing untracked file is invisible. Closing it means hashing
+every file under `ROOT` twice per review. Untracked files *appearing* or
+*disappearing* are caught by the status comparison.
 
 ---
 
@@ -324,14 +334,14 @@ bwrap's wording varies by build, so both observed forms are listed. Phase 0e key
 
 Match the specific rows before the general one: `Non-zero exit` is the fallback for a failure none of the rows above describe. A non-zero exit means the output is not a review, whether or not `review.md` exists. A run that fails partway can leave a partial or stale `review.md` behind; do not read it as findings, do not group it by severity, and do not add a verdict to it.
 
-**Re-entry after a missed container.** The bwrap rows fire exactly when Phase 0e chose `read-only` for a container that cannot initialize bubblewrap — so Phase 2e was skipped and no `PRE_STATUS`/`PRE_HASHES` exist. Do **not** re-run with a hand-edited `--sandbox` flag: that runs Codex unsandboxed against a bind-mounted working tree with no integrity guard, which is the one case the guard exists for. Instead:
+**Re-entry after a missed container.** The bwrap rows fire exactly when Phase 0e chose `read-only` for a container that cannot initialize bubblewrap — so Phase 2e was skipped and no pre-run captures exist. Do **not** re-run with a hand-edited `--sandbox` flag: that runs Codex unsandboxed against a bind-mounted working tree with no integrity guard, which is the one case the guard exists for. Instead:
 
 1. Report that detection missed the container, and say which markers you checked.
 2. Set `SANDBOX_MODE` to `danger-full-access`.
-3. Re-enter at **Phase 2e** and capture `PRE_STATUS` and `PRE_HASHES`.
+3. Re-enter at **Phase 2e** and take all three pre-run captures.
 4. Re-run the Phase 3 command **unchanged** — `--sandbox "$SANDBOX_MODE"` now
    resolves to `danger-full-access` on its own.
-5. Capture `POST_STATUS` and `POST_HASHES`, and report any difference through
+5. Take the matching post-run captures, and report any difference through
    Phase 4a like any other unsandboxed run.
 
 Re-decide `SANDBOX_MODE` once. If the same error recurs under

--- a/ai/marketplace/plugins/my/commands/codex-review.md
+++ b/ai/marketplace/plugins/my/commands/codex-review.md
@@ -235,6 +235,36 @@ SUMMARY:
 
 Severity is `Blocking` (would produce wrong or broken work), `Concern` (worth resolving before starting), or `Nit` (author's discretion). Confidence is `HIGH` / `MEDIUM` / `LOW`. Tell Codex to **prefer few high-confidence findings over many speculative ones**, and to cite `file:line` for every claim about existing code.
 
+## Phase 2e: Integrity Guard (danger-full-access only)
+
+Skip this phase entirely when `SANDBOX_MODE` is `read-only` — a read-only
+sandbox cannot write, so there is nothing to guard.
+
+Under `danger-full-access` the prompt is the only thing telling Codex not to
+write. That is probably enough; this phase makes "probably" checkable.
+
+**Before running Codex**, capture both:
+
+```
+git status --short
+sha256sum {each document resolved in Phase 1}
+```
+
+Store them as `PRE_STATUS` and `PRE_HASHES`.
+
+**After the run**, capture the same two into `POST_STATUS` and `POST_HASHES`
+and compare.
+
+Why hashes and not `git checkout`: Phase 0d has Codex read the **working tree**,
+so reviewing a document before it is committed is the normal path here. `git
+checkout --` cannot restore an uncommitted document, and in a devcontainer the
+workspace is usually a bind mount from the host, so a write is not confined by
+the container boundary either. The container bounds what Codex reaches *outside*
+the repo — the smaller half of the exposure.
+
+A mismatch in either capture is reported in Phase 4a. Do not repair, revert, or
+stage anything: report it and let the user decide.
+
 ---
 
 ## Phase 3: Run Codex
@@ -276,6 +306,16 @@ Then read `OUT_FILE` with the Read tool.
 ## Phase 4: Report and Offer to Apply
 
 ### 4a: Report
+
+**If the Phase 2e integrity guard found a difference**, lead the report with it — above the verdict, above the findings — naming every path whose status or hash changed:
+
+```
+WARNING: files changed during an unsandboxed review run.
+  {path}  {status change or hash mismatch}
+Codex was asked to review, not modify. Inspect these before trusting the review.
+```
+
+Then continue with the normal report. A clean guard needs no mention.
 
 Present Codex's review in the conversation, grouped by severity, Blocking first. Keep its wording for the findings themselves — the value here is an independent voice, not your paraphrase.
 

--- a/ai/marketplace/plugins/my/commands/codex-review.md
+++ b/ai/marketplace/plugins/my/commands/codex-review.md
@@ -2,7 +2,7 @@
 name: codex-review
 description: Get a second opinion from Codex on a spec or implementation plan — reviews the doc you have been working on, against the actual code
 argument-hint: "[path — defaults to the doc most recently discussed in this session] [--with-spec | --with-plan]"
-allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(ls:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
+allowed-tools: Bash(codex --version), Bash(codex exec:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git status:*), Bash(ls:*), Bash(test:*), Bash(bwrap:*), Bash(sha256sum:*), Bash(mktemp:*), Bash(rm -rf /tmp/codex-review-*), Read, Write, Edit, Glob, Grep
 ---
 
 # Codex Review — Second Opinion on a Spec or Plan
@@ -52,6 +52,48 @@ Two things follow:
 
 To review a doc in a *different* worktree than the session's, pass its path explicitly and set `ROOT` to that worktree's root — not the session's. Reviewing a plan from tree A against the code in tree B is the one failure mode here that produces confidently wrong findings.
 
+### 0e: Select the Sandbox Mode
+
+Decide the sandbox **before** building the prompt. Codex's Linux sandbox is
+bubblewrap, which needs an unprivileged user namespace; many containers forbid
+`clone(CLONE_NEWUSER)`. Discovering that by running a full review wastes minutes
+and tokens and returns nothing usable, so determine it up front.
+
+**First, is this a container?** Stop at the first hit:
+
+1. `$REMOTE_CONTAINERS` or `$CODESPACES` is non-empty — VS Code Dev Containers
+   and Codespaces respectively. Checked first because they name a devcontainer
+   specifically.
+2. `/.dockerenv` exists — Docker.
+3. `/run/.containerenv` exists — Podman.
+
+A plain `docker run` also trips markers 2 and 3. That is correct: the same
+namespace policy applies, so the same decision follows.
+
+**If and only if it is a container, probe bubblewrap:**
+
+```
+bwrap --ro-bind / / --dev /dev true
+```
+
+This returns in milliseconds and costs no tokens. A missing `bwrap` binary counts as a failed probe, not an error. Codex bundles its own copy, so the system binary's absence tells you about the environment rather than blocking the run.
+
+Set `SANDBOX_MODE`:
+
+| Container | `bwrap` probe | `SANDBOX_MODE` |
+|-----------|---------------|----------------|
+| no        | not run       | `read-only` |
+| yes       | exit 0        | `read-only` |
+| yes       | non-zero or absent | `danger-full-access` |
+
+Outside a container the probe never runs and `SANDBOX_MODE` is `read-only`.
+
+Do **not** prompt before escalating. In a container the escalation is automatic
+by design: the container is the external isolation boundary, which is the case
+Codex's unsandboxed mode exists for. Announce the mode in Phase 1c so the choice
+is visible, and run the Phase 2e integrity guard so a write cannot pass
+unnoticed.
+
 ---
 
 ## Phase 1: Resolve the Target
@@ -94,8 +136,9 @@ If the flag is given and no sibling is found, say so and review the single doc r
 
 ```
 Codex review — {MODE}
-  tree: {ROOT}  {"(worktree {name}, branch {branch})" if under .claude/worktrees/}
-  doc:  {path}   {"— picked from this session" | "— newest on disk (guess)"}
+  tree:    {ROOT}  {"(worktree {name}, branch {branch})" if under .claude/worktrees/}
+  sandbox: {SANDBOX_MODE} ({why})
+  doc:     {path}   {"— picked from this session" | "— newest on disk (guess)"}
   {"spec:/plan:" lines instead, in PAIR mode}
 ```
 
@@ -197,14 +240,16 @@ Severity is `Blocking` (would produce wrong or broken work), `Concern` (worth re
 ## Phase 3: Run Codex
 
 ```
-codex exec --sandbox read-only -C "$ROOT" --color never -o "$WORKDIR/review.md" - < "$PROMPT_FILE"
+codex exec --sandbox "$SANDBOX_MODE" -C "$ROOT" --color never -o "$WORKDIR/review.md" - < "$PROMPT_FILE"
 ```
 
 Store `"$WORKDIR/review.md"` as `OUT_FILE`.
 
 **Quote every path substitution**, as above. `ROOT` is a worktree path and can contain spaces; unquoted it breaks `-C`, `-o`, and the input redirect — and unquoted cleanup in Phase 5 then targets the wrong thing.
 
-- `--sandbox read-only` — Codex can read the whole repo but cannot modify it. Do **not** loosen this; a reviewer has no reason to write.
+- `--sandbox "$SANDBOX_MODE"` — `read-only` unless Phase 0e determined that this
+  container cannot initialize bubblewrap. Do **not** hand-edit this to
+  `danger-full-access`; let Phase 0e decide, so the integrity guard runs with it.
 - `-C "$ROOT"` — pins the working root to the current checkout/worktree.
 - `-o` — writes only the final message, so you get the review without the reasoning transcript.
 - `-` — reads the prompt from stdin, avoiding shell-quoting problems with a long prompt.
@@ -219,7 +264,10 @@ This takes a few minutes on a substantial plan. If the Bash call times out, say 
 | Connection refused to `172.17.0.1:1337` | Vekil proxy is down | Tell the user; do not fall back to a direct API call |
 | Codex reports `main` as the branch, or can't find the doc | `-C` pointed at the main checkout, not the worktree (Phase 0d) | Re-derive `ROOT` and re-run |
 | Git commands fail inside Codex, in a worktree only | Sandbox can't reach `.git/worktrees/` in the main checkout | Re-run with `--add-dir {main checkout}/.git`; report if that's needed, it's a regression |
+| `bwrap: No permissions to create a new namespace`, or `bwrap: Creating new namespace failed` | The container forbids user namespaces; Codex's Linux sandbox cannot initialize | Phase 0e should have selected `danger-full-access` — if you see this, detection missed the container. Report it and re-run with `--sandbox danger-full-access` |
 | Non-zero exit, no output file | Run failed | Report the stderr tail verbatim; do not fabricate a review |
+
+bwrap's wording varies by build, so both observed forms are listed. Phase 0e keys off the probe's **exit status**, never the message text.
 
 Then read `OUT_FILE` with the Read tool.
 

--- a/tests/codex_review_sandbox.bats
+++ b/tests/codex_review_sandbox.bats
@@ -76,7 +76,27 @@ setup() {
 @test "codex-review hashes reviewed docs around an unsandboxed run" {
   run grep -F 'sha256sum {absolute path of each document resolved in Phase 1, quoted}' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
-  run grep -F 'git status --short' "$CODEX_REVIEW"
+  # -Fx: `git status --short` is also named in the surrounding prose, so a
+  # substring match survives deletion of the capture command itself.
+  run grep -Fx 'git status --short' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'Store them as `PRE_STATUS`, `PRE_DIFF`, and `PRE_HASHES`.' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review detects writes into an already-modified file" {
+  # `git status --short` prints ` M path` both before and after a further edit,
+  # so a status-only guard misses writes into a file that was already dirty --
+  # the normal case when reviewing mid-feature. PRE_DIFF/POST_DIFF catch it.
+  # -Fx, not -F: `git diff HEAD` also appears twice in the surrounding prose, so
+  # a substring match stays green even if the capture command itself is deleted.
+  run grep -Fx 'git diff HEAD' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'a file already modified before the run shows ` M path` both before and after' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'POST_STATUS`, `POST_DIFF`, and `POST_HASHES`' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'Bash(git diff:*)' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
 }
 
@@ -92,16 +112,16 @@ setup() {
   [ "$status" -eq 0 ]
   run grep -F 'Set `SANDBOX_MODE` to `danger-full-access`.' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
-  run grep -F 'Re-enter at **Phase 2e** and capture `PRE_STATUS` and `PRE_HASHES`.' "$CODEX_REVIEW"
+  run grep -F 'Re-enter at **Phase 2e** and take all three pre-run captures.' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
   run grep -F 'Do **not** re-run with a hand-edited `--sandbox` flag' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
   # Steps 4-5 are what make the re-entry safe rather than merely re-decided:
-  # re-running unchanged is why the flag never gets hand-edited, and the POST_
+  # re-running unchanged is why the flag never gets hand-edited, and the post-run
   # captures are the half of the guard that detects a write.
   run grep -F 'Re-run the Phase 3 command **unchanged**' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
-  run grep -F 'Capture `POST_STATUS` and `POST_HASHES`, and report any difference through' "$CODEX_REVIEW"
+  run grep -F 'Take the matching post-run captures, and report any difference through' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/codex_review_sandbox.bats
+++ b/tests/codex_review_sandbox.bats
@@ -47,3 +47,27 @@ setup() {
   run grep -F 'never the message text' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
 }
+
+@test "codex-review guards document integrity only when unsandboxed" {
+  run grep -F '## Phase 2e: Integrity Guard (danger-full-access only)' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'Skip this phase entirely when `SANDBOX_MODE` is `read-only`' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review hashes reviewed docs around an unsandboxed run" {
+  run grep -F 'sha256sum' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'git status --short' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review explains why git checkout is not the safety net" {
+  run grep -F 'cannot restore an uncommitted document' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review leads the report with any detected write" {
+  run grep -F 'lead the report with it — above the verdict, above the findings' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}

--- a/tests/codex_review_sandbox.bats
+++ b/tests/codex_review_sandbox.bats
@@ -96,6 +96,13 @@ setup() {
   [ "$status" -eq 0 ]
   run grep -F 'Do **not** re-run with a hand-edited `--sandbox` flag' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
+  # Steps 4-5 are what make the re-entry safe rather than merely re-decided:
+  # re-running unchanged is why the flag never gets hand-edited, and the POST_
+  # captures are the half of the guard that detects a write.
+  run grep -F 'Re-run the Phase 3 command **unchanged**' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'Capture `POST_STATUS` and `POST_HASHES`, and report any difference through' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
 }
 
 @test "codex-review treats any non-zero exit as a failed run" {

--- a/tests/codex_review_sandbox.bats
+++ b/tests/codex_review_sandbox.bats
@@ -8,8 +8,10 @@ setup() {
 }
 
 @test "codex-review may run the bubblewrap capability probe" {
-  run grep -F 'Bash(bwrap:*)' "$CODEX_REVIEW"
+  run grep -F 'Bash(bwrap --ro-bind / / --dev /dev true)' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
+  run grep -F 'Bash(bwrap:*)' "$CODEX_REVIEW"
+  [ "$status" -ne 0 ]
 }
 
 @test "codex-review detects containers before choosing a sandbox" {
@@ -30,6 +32,22 @@ setup() {
 
 @test "codex-review keeps read-only outside containers" {
   run grep -F 'Outside a container the probe never runs and `SANDBOX_MODE` is `read-only`.' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review passes the selected sandbox mode to codex exec" {
+  run grep -F 'codex exec --sandbox "$SANDBOX_MODE"' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'codex exec --sandbox read-only' "$CODEX_REVIEW"
+  [ "$status" -ne 0 ]
+}
+
+@test "codex-review escalates only the container-without-bubblewrap row" {
+  run grep -F '| yes       | non-zero or absent | `danger-full-access` |' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F '| yes       | exit 0        | `read-only` |' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F '| no        | not run       | `read-only` |' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
 }
 
@@ -56,9 +74,34 @@ setup() {
 }
 
 @test "codex-review hashes reviewed docs around an unsandboxed run" {
-  run grep -F 'sha256sum' "$CODEX_REVIEW"
+  run grep -F 'sha256sum {absolute path of each document resolved in Phase 1, quoted}' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
   run grep -F 'git status --short' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review anchors the integrity captures to the reviewed tree" {
+  run grep -F 'Run this Bash call with `ROOT` as its working directory' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'reports on the wrong checkout, and the guard reports clean no matter what Codex wrote' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review re-enters Phase 2e instead of hand-editing the sandbox flag" {
+  run grep -F '**Re-entry after a missed container.**' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'Set `SANDBOX_MODE` to `danger-full-access`.' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'Re-enter at **Phase 2e** and capture `PRE_STATUS` and `PRE_HASHES`.' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'Do **not** re-run with a hand-edited `--sandbox` flag' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review treats any non-zero exit as a failed run" {
+  run grep -F '| Non-zero exit | Run failed |' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'A non-zero exit means the output is not a review, whether or not `review.md` exists.' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/codex_review_sandbox.bats
+++ b/tests/codex_review_sandbox.bats
@@ -100,8 +100,36 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "codex-review can cd to the reviewed tree without prompting" {
+  # The captures must run from ROOT, and `cd` is the only way to set a Bash
+  # call's working directory -- so the grant has to be there or the guard
+  # stops for a permission prompt mid-preflight.
+  # Pinned with a frontmatter neighbour: the prose below also names
+  # `Bash(cd:*)`, so a bare substring match survives deleting the grant.
+  run grep -F 'Bash(codex exec:*), Bash(cd:*),' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'as `cd "$ROOT" && {command}`' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review matches any bwrap namespace failure, not two exact strings" {
+  # A third bwrap wording falling through to the generic `Non-zero exit` row
+  # loses the re-entry -- the whole point of the branch.
+  run grep -F 'Any `bwrap:` error, or any message about creating, entering, or having permission for a namespace' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'the two above are the observed forms, not the whole set' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review names the ignored-file gap in the integrity guard" {
+  run grep -F 'A file matched by' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'is absent from all three captures entirely' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
 @test "codex-review anchors the integrity captures to the reviewed tree" {
-  run grep -F 'Run this Bash call with `ROOT` as its working directory' "$CODEX_REVIEW"
+  run grep -F 'Run all three from `ROOT`' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
   run grep -F 'reports on the wrong checkout, and the guard reports clean no matter what Codex wrote' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]

--- a/tests/codex_review_sandbox.bats
+++ b/tests/codex_review_sandbox.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_dotfiles_test
+  CODEX_REVIEW="$REPO_ROOT/ai/marketplace/plugins/my/commands/codex-review.md"
+}
+
+@test "codex-review may run the bubblewrap capability probe" {
+  run grep -F 'Bash(bwrap:*)' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review detects containers before choosing a sandbox" {
+  run grep -F '### 0e: Select the Sandbox Mode' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'REMOTE_CONTAINERS' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F '/run/.containerenv' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review probes bwrap rather than assuming containers block it" {
+  run grep -F 'bwrap --ro-bind / / --dev /dev true' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'A missing `bwrap` binary counts as a failed probe, not an error.' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review keeps read-only outside containers" {
+  run grep -F 'Outside a container the probe never runs and `SANDBOX_MODE` is `read-only`.' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review states the sandbox mode in its confirmation" {
+  run grep -F 'sandbox: {SANDBOX_MODE} ({why})' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review documents the bwrap namespace failure" {
+  run grep -F 'bwrap: No permissions to create a new namespace' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review keys the sandbox choice off the probe exit status" {
+  run grep -F 'never the message text' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}

--- a/tests/codex_review_sandbox.bats
+++ b/tests/codex_review_sandbox.bats
@@ -71,3 +71,17 @@ setup() {
   run grep -F 'lead the report with it — above the verdict, above the findings' "$CODEX_REVIEW"
   [ "$status" -eq 0 ]
 }
+
+@test "codex-review offers a non-verdict outcome for blocked runs" {
+  run grep -F 'STATUS: INCOMPLETE' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'do NOT return a VERDICT line' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+  run grep -F 'A verdict you cannot support by reading the code is worse than no verdict.' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex-review never reports an incomplete run as a design signal" {
+  run grep -F 'no design conclusion follows' "$CODEX_REVIEW"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

`/my:codex-review` failed consistently inside devcontainers. Codex started, its
bubblewrap sandbox could not initialize (`bwrap: No permissions to create a new
namespace`), and it never read the repository.

The failure was worse than a plain error. The Phase 2d output contract offered
only `VERDICT: SHIP | REVISE | RETHINK` — all design conclusions — so a run that
inspected nothing still had to pick one. Blocked runs came back as
`VERDICT: RETHINK` about the review environment, which reads like a judgment on
the document under review.

Codex 0.146.0 removed `use_linux_sandbox_bwrap` and deprecated
`use_legacy_landlock`; bubblewrap is now the unconditional Linux backend, so
there is no config-level escape.

## Changes

Skill-layer only. No container, compose, or `ai/codex/config.toml` changes.

**`### 0e: Select the Sandbox Mode`** — detects a container
(`$REMOTE_CONTAINERS`/`$CODESPACES`, `/.dockerenv`, `/run/.containerenv`) and,
only then, probes `bwrap --ro-bind / / --dev /dev true`.

| Container | `bwrap` probe | `SANDBOX_MODE` |
|-----------|---------------|----------------|
| no | not run | `read-only` |
| yes | exit 0 | `read-only` |
| yes | non-zero or absent | `danger-full-access` |

The decision keys off the probe's **exit status**, never its message text —
bwrap's wording varies by build (two forms observed). A container that *can*
namespace still gets `read-only`; detection alone would have escalated it
unnecessarily.

**`Phase 2e: Integrity Guard`** — active only under `danger-full-access`.
Captures `git status --short`, `git diff HEAD`, and SHA-256 of the reviewed docs
before and after the run, anchored to `ROOT`, and leads the Phase 4a report with
any difference. It detects, never repairs. Hashes rather than `git checkout --`
because Phase 0d reviews the *working tree*, so uncommitted docs are the normal
path and `git checkout --` cannot restore them.

`git diff HEAD` is there because `git status --short` reports a tracked file's
*state*, not its contents: a file already modified before the run shows ` M path`
both before and after, so a write into an already-dirty file is invisible to a
status-only comparison — and reviewing mid-feature against a dirty worktree is
the normal case. One narrow gap is left open deliberately and documented in the
phase: a write into a file that was *already untracked* is caught by neither
capture. Closing it would mean hashing every file under `ROOT` twice per review.

**`STATUS: INCOMPLETE` / `REASON:`** — a non-verdict outcome in the Phase 2d
contract, with a Phase 4a branch that reports it as an environment failure and
skips Phase 4b. A run that inspected nothing can no longer return a design
conclusion.

## Escalation policy

Escalation to `danger-full-access` is automatic, with no per-run consent prompt.
This was a deliberate decision: inside a devcontainer the blast radius is already
the container, and a prompt on every review in an environment where escalation is
the *normal* path trains people to click through it. The integrity guard is the
compensating control. A Landlock read-only rung was considered and rejected —
`use_legacy_landlock` is deprecated upstream.

## Verification

- 19 bats tests in `tests/codex_review_sandbox.bats`; `make check` passes
  (902 assertions, 0 errors, 0 warnings).
- **Host, no container:** no markers present → `read-only`, probe never runs,
  Phase 2e skipped. Non-container behavior is byte-identical to before.
- **Docker, `unshare`/`setns` denied via seccomp:** `bwrap: Creating new
  namespace failed`, probe exit 1, `/.dockerenv` present — the failure
  reproduces as designed.
- **Privileged Docker:** probe exit 0 with marker present → stays `read-only`,
  confirming the positive path. (Plain `docker run` and `seccomp=unconfined`
  both fail on this host, which blocks namespaces generally; `--privileged` was
  needed to exercise this case at all.)

**Not yet verified:** the end-to-end review from a real devcontainer, and the
guard reporting clean on a live run. The tests are document-shape assertions —
nothing here executes the decision against a running Codex.

## Review notes

The whole-branch review caught a defect neither per-task review could see. Phase
3's error table told the agent, on hitting the bwrap error, to re-run with
`--sandbox danger-full-access` — a row that fires *precisely when detection
missed*, meaning Phase 2e was skipped and no pre-run snapshots existed. That
produced an unsandboxed run against a bind-mounted tree with no guard: the one
case the guard exists for. It also contradicted the Phase 3 bullet forbidding
hand-edits of the mode.

The fix re-decides `SANDBOX_MODE`, re-enters Phase 2e for the captures, and
re-runs Phase 3 **unchanged** — so the "never hand-edit the flag" rule holds
without an exception.

Two findings were about tests that could not fail: nothing pinned
`--sandbox "$SANDBOX_MODE"` (the single line where the feature takes effect —
it could have been reverted with every test green), and the `sha256sum`
assertion was satisfied by the `allowed-tools` frontmatter rather than by Phase
2e. Both now pin the real lines.

The same failure mode recurred once more while addressing CodeRabbit's review:
adding prose that *mentions* `git status --short` and `git diff HEAD` made the
substring assertions on those capture commands vacuous. Both are now `grep -Fx`
(whole-line), sabotage-checked by deleting the capture block.

## Reviewer focus

- `Re-entry after a missed container` in Phase 3 — the most inference-dependent
  instruction here. It asks the agent to jump back to Phase 2e and forward again.
- Whether the `danger-full-access` escalation plus a detect-only guard is the
  right trade for this repo.

## Rollout

The marketplace cache is a copy, not a symlink, so this is inert in Claude Code
until `~/.claude/plugins/cache/guarzo/my/0.1.0/` refreshes. Post-merge step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Codex reviews now detect available sandboxing and container environments before execution.
  - Reviews safely fall back to broader access only when read-only sandboxing cannot start.
  - Unsandboxed reviews record repository state and file hashes to identify unexpected changes.
  - Reports surface integrity-related changes first.
- **Bug Fixes**
  - Incomplete or interrupted reviews no longer produce misleading verdicts.
  - Error messages provide clearer guidance for safely re-entering container environments.
  - Review handling distinguishes failed, incomplete, and successfully completed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->