### PR TITLE
chore(projectmux): pin the installer to v0.3.0

### DIFF
--- a/config/versions.env
+++ b/config/versions.env
@@ -63,7 +63,7 @@ TREE_SITTER_SHA256_ARM64=e47dd59bf2f21ad7c15771546a724464ee3c008a60fbb61c6860bd1
 # release's SHA256SUMS; both binaries were additionally downloaded and hashed
 # directly rather than trusted from that file. Upstream publishes no
 # darwin assets, and the installer is Linux-only by design.
-PROJECTMUX_VERSION=v0.2.0
-PROJECTMUX_RELEASE_BASE=https://github.com/gambtho/projectmux/releases/download/v0.2.0
-PROJECTMUX_LINUX_AMD64_SHA256=dc7477a9c415dce14efda3c3d263071f2ca923fbdf445916fbeb209630cc5112
-PROJECTMUX_LINUX_ARM64_SHA256=3ec6bcf137345e8f2465b16eb4f721f9c3cd6890b32b646aa69d637fc3f8c7bb
+PROJECTMUX_VERSION=v0.3.0
+PROJECTMUX_RELEASE_BASE=https://github.com/gambtho/projectmux/releases/download/v0.3.0
+PROJECTMUX_LINUX_AMD64_SHA256=1347d84f67ec69644b7fa92878fc576caeff67f791e867477a295f4b0f3e33eb
+PROJECTMUX_LINUX_ARM64_SHA256=d96856dd0309ad2806213860c4b40851dceedeb91709b0bd0030751d721ed346

--- a/tests/dependency_pins.bats
+++ b/tests/dependency_pins.bats
@@ -27,7 +27,7 @@ setup() {
   [[ "$output" == *"artifact yq v4.45.1"* ]]
   [[ "$output" == *"artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"artifact vekil v0.14.0"* ]]
-  [[ "$output" == *"artifact projectmux v0.2.0"* ]]
+  [[ "$output" == *"artifact projectmux v0.3.0"* ]]
   [[ "$output" == *"artifact nerd-fonts v3.4.0"* ]]
   [[ "$output" == *"artifact nerd-font-cascadia-mono v3.4.0 $NERD_FONT_CASCADIA_MONO_SHA256"* ]]
   [[ "$output" == *"artifact nerd-font-hack v3.4.0 $NERD_FONT_HACK_SHA256"* ]]
@@ -112,7 +112,7 @@ case "$url" in
     printf 'curl: (22) The requested URL returned error: 404\n' >&2
     exit 22
     ;;
-  *gambtho/projectmux/releases) printf '[{"tag_name":"v0.2.0","prerelease":true}]\n' ;;
+  *gambtho/projectmux/releases) printf '[{"tag_name":"v0.3.0","prerelease":true}]\n' ;;
 esac
 SCRIPT
   chmod +x "$STUB_BIN/curl"
@@ -125,7 +125,7 @@ SCRIPT
   [[ "$output" == *"current artifact yq v4.45.1"* ]]
   [[ "$output" == *"current artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"current artifact vekil v0.14.0"* ]]
-  [[ "$output" == *"current artifact projectmux v0.2.0"* ]]
+  [[ "$output" == *"current artifact projectmux v0.3.0"* ]]
   [[ "$output" == *"current artifact nerd-fonts v3.4.0"* ]]
 }
 

--- a/tests/projectmux_install.bats
+++ b/tests/projectmux_install.bats
@@ -280,7 +280,7 @@ source_installer() {
     ' _ "$REPO_ROOT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MARKER=v0.2.0"* ]]
+  [[ "$output" == *"MARKER=v0.3.0"* ]]
   [ -f "$TEST_ROOT/bin/projectmux" ]
   [ ! -L "$TEST_ROOT/bin/projectmux" ]
   [ -x "$TEST_ROOT/bin/projectmux" ]
@@ -290,7 +290,7 @@ source_installer() {
   mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/state"
   printf 'installed' >"$TEST_ROOT/bin/projectmux"
   chmod 0755 "$TEST_ROOT/bin/projectmux"
-  printf 'v0.2.0\n' >"$TEST_ROOT/state/installed-version"
+  printf 'v0.3.0\n' >"$TEST_ROOT/state/installed-version"
 
   # return 99 rather than a stub download: if the short-circuit fails to fire,
   # the install errors instead of quietly succeeding with fabricated content.
@@ -309,7 +309,7 @@ source_installer() {
   # Exact equality, not a substring: the short-circuit compares installed_marker
   # to the bare tag, so a future change that leaves stray whitespace in the
   # marker read must fail this test rather than pass on a loose match.
-  [ "${lines[-1]}" = "EXACT=v0.2.0" ]
+  [ "${lines[-1]}" = "EXACT=v0.3.0" ]
 }
 
 @test "a matching marker with a symlink destination still reinstalls" {
@@ -319,7 +319,7 @@ source_installer() {
   ln -s "$TEST_ROOT/local/projectmux" "$TEST_ROOT/bin/projectmux"
   # The pathological pair the Reconciliation invariant describes: a pinned
   # marker naming a version the destination does not actually hold.
-  printf 'v0.2.0\n' >"$TEST_ROOT/state/installed-version"
+  printf 'v0.3.0\n' >"$TEST_ROOT/state/installed-version"
 
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
@@ -355,7 +355,7 @@ source_installer() {
     ' _ "$REPO_ROOT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MARKER=v0.2.0"* ]]
+  [[ "$output" == *"MARKER=v0.3.0"* ]]
   [ -f "$TEST_ROOT/bin/projectmux" ]
   [ ! -L "$TEST_ROOT/bin/projectmux" ]
   [ "$(cat "$TEST_ROOT/bin/projectmux")" = pinned ]


### PR DESCRIPTION
Pin the ProjectMux installer to v0.3.0.

Digests come from the release's `SHA256SUMS`, and both binaries were
additionally downloaded and hashed directly rather than trusted from that
file — the standard the `versions.env` comment claims.

Test fixtures carry the new version as hardcoded literals, matching the
repo convention for artifact pins: sourcing `versions.env` in the
assertions would compare the manifest to itself and stop catching a typo.
The `dependency_pins` upstream stub moves in step, or the drift check
reports drift against itself.

## Verification

`make check` passes except `localrc endpoint overrides the managed Codex
wrapper`, which is pre-existing and unrelated to this change: it fails
identically on a clean worktree of `origin/main`, and is green in CI.

**Correction:** an earlier version of this description claimed the cause was
mise leaking into the test's `HOME` sandbox. That was wrong, and was posted
before it had been tested. Bypassing the global mise config
(`MISE_GLOBAL_CONFIG_FILE=/dev/null`) changes nothing — the mise stderr during
`source zshrc` is incidental noise near the failure, not its cause.

What is actually established: the run prints `NO_MANAGED_CODEX_WRAPPER`, so the
`codex` function from `ai/vekil/env.zsh` is never defined, and the exit comes
from the test's own guard. Removing the `.localrc` write leaves the wrapper
equally undefined, so that is not the discriminator either. Tests 5 and 7 in
the same file load vekil successfully and pass; whatever differs is not yet
identified. Tracked as its own follow-up rather than guessed at again here.
