### PR TITLE
fix(tests): clear leaked mise session state in the Bats harness

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -6,6 +6,17 @@ setup_dotfiles_test() {
   export STUB_BIN="$TEST_ROOT/bin"
   mkdir -p "$HOME" "$STUB_BIN"
   export PATH="$STUB_BIN:/usr/bin:/bin"
+  # Sanitizing PATH is not enough on a machine where the interactive shell ran
+  # `mise activate` (languages/mise/env.zsh). That exports mise's session state,
+  # including __MISE_ORIG_PATH -- the real login PATH. Tests that source zshrc
+  # re-enter `mise activate`, which sees a live session and restores that PATH
+  # *ahead* of $STUB_BIN, so stubs lose to the real binaries they shadow.
+  # Clearing the session state makes the sandbox PATH authoritative. This list
+  # mirrors the teardown in mise's own activate output; __MISE_ORIG_PATH is the
+  # load-bearing one, the rest keep mise from reconstructing the session.
+  unset MISE_SHELL __MISE_SESSION __MISE_ORIG_PATH __MISE_DIFF \
+    __MISE_ZSH_PRECMD_RUN __MISE_ZSH_CHPWD_RAN \
+    __MISE_ZSH_ACTIVATE_PATH __MISE_ZSH_ACTIVATE_ENV
 }
 
 stub_command() {


### PR DESCRIPTION
## Problem

`make check` failed exactly one test locally while staying green in CI:
`localrc endpoint overrides the managed Codex wrapper` in `tests/shell_loading.bats`.

`setup_dotfiles_test` sanitizes `PATH` but not the mise session variables the interactive
shell exports. `languages/mise/env.zsh` runs `eval "$(mise activate zsh)"`, which exports
`MISE_SHELL`, `__MISE_SESSION` and `__MISE_ORIG_PATH` — the latter being the real login
PATH. Bats passes those through. Tests that source `zshrc` re-enter `mise activate`, mise
sees a live session and restores `__MISE_ORIG_PATH` **ahead** of `$STUB_BIN`, and stubs
lose to the real binaries they exist to shadow. `mise` is `/usr/bin/mise`, so it is always
on the sandbox PATH and the activation always fires.

CI has no mise session, so the sandbox PATH survives there and the suite is green.

The resulting PATH, sandbox entries demoted to last:

```
+ /home/tng/.local/bin          <- real codex wins
+ /home/tng/.local/share/mise/shims
  ...
+ /tmp/probehome/.local/bin     <- sandbox entries, now last
+ /tmp/probebin
```

## Fix

Unset the session state next to the existing PATH sanitization in `tests/test_helper.bash`.
The list mirrors the teardown mise's own `activate` output emits, so a session cannot be
reconstructed from what is left.

One point of repair covers every suite: all Bats files load `test_helper`, none define
`setup_file`, and the three that re-set `PATH` themselves (`projectmux_migrate`,
`windows_terminal_profiles`, `claude_compose_override`) call `setup_dotfiles_test` first,
so the unset stands.

## Verification

- **One-variable isolation:** `__MISE_ORIG_PATH` is load-bearing — unsetting only it fixes
  the test; unsetting only `MISE_SHELL` does not.
- **Before/after at a fixed cwd:** the failure is location-dependent, which masked it. From
  the repo root it passes; from `/tmp` it fails. Run from `/tmp`, the target test goes
  `not ok` → `ok` across this commit.
- **`make check` green:** 669/669 Bats, syntax, lint (shellcheck + `shfmt -d`), validate,
  python-test.
- Verified against a **trusted, parseable** mise config — the state that makes the leak
  reachable, and therefore the one that proves the fix. `mise doctor` reports
  *"No problems found"*, and `mise activate zsh` is byte-identical (4842 bytes, exit 0,
  zero stderr) from both the repo root and `/tmp`.

## Note for reviewers

Running the full suite from outside the repository surfaces 9 failures in
`check_file_discovery.bats`. These are **pre-existing and unrelated** — that suite resolves
files relative to cwd, and the identical 9 fail on `main` from the same cwd. Flagging it
only because it means `bats tests` is not location-independent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment isolation by preventing mise-related session settings from restoring the original PATH during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->