### PR TITLE
chore(projectmux): pin the installer to v0.4.0

### DIFF
--- a/config/versions.env
+++ b/config/versions.env
@@ -63,7 +63,7 @@ TREE_SITTER_SHA256_ARM64=e47dd59bf2f21ad7c15771546a724464ee3c008a60fbb61c6860bd1
 # release's SHA256SUMS; both binaries were additionally downloaded and hashed
 # directly rather than trusted from that file. Upstream publishes no
 # darwin assets, and the installer is Linux-only by design.
-PROJECTMUX_VERSION=v0.3.0
-PROJECTMUX_RELEASE_BASE=https://github.com/gambtho/projectmux/releases/download/v0.3.0
-PROJECTMUX_LINUX_AMD64_SHA256=1347d84f67ec69644b7fa92878fc576caeff67f791e867477a295f4b0f3e33eb
-PROJECTMUX_LINUX_ARM64_SHA256=d96856dd0309ad2806213860c4b40851dceedeb91709b0bd0030751d721ed346
+PROJECTMUX_VERSION=v0.4.0
+PROJECTMUX_RELEASE_BASE=https://github.com/gambtho/projectmux/releases/download/v0.4.0
+PROJECTMUX_LINUX_AMD64_SHA256=59b0632fb7e1fb654937750d984caec74b8c8c2e9ba6e6fd632d6bd383c05b84
+PROJECTMUX_LINUX_ARM64_SHA256=f6f050387b64f4d17bb81fdac81c50c05f6714b06392e6457468303974e6f6cb

--- a/tests/dependency_pins.bats
+++ b/tests/dependency_pins.bats
@@ -27,7 +27,7 @@ setup() {
   [[ "$output" == *"artifact yq v4.45.1"* ]]
   [[ "$output" == *"artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"artifact vekil v0.14.0"* ]]
-  [[ "$output" == *"artifact projectmux v0.3.0"* ]]
+  [[ "$output" == *"artifact projectmux v0.4.0"* ]]
   [[ "$output" == *"artifact nerd-fonts v3.4.0"* ]]
   [[ "$output" == *"artifact nerd-font-cascadia-mono v3.4.0 $NERD_FONT_CASCADIA_MONO_SHA256"* ]]
   [[ "$output" == *"artifact nerd-font-hack v3.4.0 $NERD_FONT_HACK_SHA256"* ]]
@@ -112,7 +112,7 @@ case "$url" in
     printf 'curl: (22) The requested URL returned error: 404\n' >&2
     exit 22
     ;;
-  *gambtho/projectmux/releases) printf '[{"tag_name":"v0.3.0","prerelease":true}]\n' ;;
+  *gambtho/projectmux/releases) printf '[{"tag_name":"v0.4.0","prerelease":true}]\n' ;;
 esac
 SCRIPT
   chmod +x "$STUB_BIN/curl"
@@ -125,7 +125,7 @@ SCRIPT
   [[ "$output" == *"current artifact yq v4.45.1"* ]]
   [[ "$output" == *"current artifact win32yank v0.1.1"* ]]
   [[ "$output" == *"current artifact vekil v0.14.0"* ]]
-  [[ "$output" == *"current artifact projectmux v0.3.0"* ]]
+  [[ "$output" == *"current artifact projectmux v0.4.0"* ]]
   [[ "$output" == *"current artifact nerd-fonts v3.4.0"* ]]
 }
 

--- a/tests/projectmux_install.bats
+++ b/tests/projectmux_install.bats
@@ -280,7 +280,7 @@ source_installer() {
     ' _ "$REPO_ROOT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MARKER=v0.3.0"* ]]
+  [[ "$output" == *"MARKER=v0.4.0"* ]]
   [ -f "$TEST_ROOT/bin/projectmux" ]
   [ ! -L "$TEST_ROOT/bin/projectmux" ]
   [ -x "$TEST_ROOT/bin/projectmux" ]
@@ -290,7 +290,7 @@ source_installer() {
   mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/state"
   printf 'installed' >"$TEST_ROOT/bin/projectmux"
   chmod 0755 "$TEST_ROOT/bin/projectmux"
-  printf 'v0.3.0\n' >"$TEST_ROOT/state/installed-version"
+  printf 'v0.4.0\n' >"$TEST_ROOT/state/installed-version"
 
   # return 99 rather than a stub download: if the short-circuit fails to fire,
   # the install errors instead of quietly succeeding with fabricated content.
@@ -309,7 +309,7 @@ source_installer() {
   # Exact equality, not a substring: the short-circuit compares installed_marker
   # to the bare tag, so a future change that leaves stray whitespace in the
   # marker read must fail this test rather than pass on a loose match.
-  [ "${lines[-1]}" = "EXACT=v0.3.0" ]
+  [ "${lines[-1]}" = "EXACT=v0.4.0" ]
 }
 
 @test "a matching marker with a symlink destination still reinstalls" {
@@ -319,7 +319,7 @@ source_installer() {
   ln -s "$TEST_ROOT/local/projectmux" "$TEST_ROOT/bin/projectmux"
   # The pathological pair the Reconciliation invariant describes: a pinned
   # marker naming a version the destination does not actually hold.
-  printf 'v0.3.0\n' >"$TEST_ROOT/state/installed-version"
+  printf 'v0.4.0\n' >"$TEST_ROOT/state/installed-version"
 
   run env PROJECTMUX_INSTALL_SOURCE_ONLY=1 \
     PROJECTMUX_INSTALL_DIR="$TEST_ROOT/bin" \
@@ -355,7 +355,7 @@ source_installer() {
     ' _ "$REPO_ROOT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MARKER=v0.3.0"* ]]
+  [[ "$output" == *"MARKER=v0.4.0"* ]]
   [ -f "$TEST_ROOT/bin/projectmux" ]
   [ ! -L "$TEST_ROOT/bin/projectmux" ]
   [ "$(cat "$TEST_ROOT/bin/projectmux")" = pinned ]


### PR DESCRIPTION
Bumps the ProjectMux pin from v0.3.0 to v0.4.0.

Upstream v0.4.0 closes the two v1.0 release gates (golangci-lint in CI and
reproducible builds, projectmux#25) and carries the docs corrections in #26,
#27, and #28. The local install on this machine is still on v0.2.0 — already
behind the previous pin — so this also resyncs the machine with its own
manifest.

## Digests

Both were computed by downloading each binary and hashing it directly rather
than copying them out of the release's `SHA256SUMS`, which is the standard the
comment above the pin already claims. They agree with the published file, and
`sha256sum --check` returns `OK` for both.

## Test literals

Moved with the pin, as #73 established: five fixtures in
`projectmux_install.bats` and two assertions in `dependency_pins.bats`
hardcode the tag deliberately, so that sourcing the manifest cannot make the
assertion compare `versions.env` to itself. The drift-check `curl` stub
returns the pinned tag as upstream's latest and has to move in step, or the
check reports drift against itself.

## Verification

- `bats tests/projectmux_install.bats tests/dependency_pins.bats` — 48 passed, 0 failed
- `make syntax` — exit 0
- `make lint` — exit 0
- `make pins` — reports `artifact projectmux v0.4.0`

## Note for the next pin

`projectmux_install.bats:194` asserts `git diff --exit-code config/versions.env`
to prove `PROJECTMUX_LOCAL_BINARY` never mutates the pin. That assertion cannot
pass against an uncommitted pin edit, legitimate ones included, so the suite
goes green only once the bump is committed. Confirmed passing on unmodified
`main` before concluding it was an artifact rather than a defect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled ProjectMux version from v0.3.0 to v0.4.0.
  * Added the new release URL and verified Linux AMD64 and ARM64 checksums.
  * Updated installation and release validation to recognize v0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->