### PR TITLE
feat: bind prefix U to copy a TUI-wrapped URL out of a pane

### DIFF
--- a/bin/tmux-copy-url
+++ b/bin/tmux-copy-url
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Copy a line-wrapped URL out of a tmux pane into the Windows clipboard.
+#
+# Full-screen TUIs (Claude Code's login prompt, for one) draw a long URL as
+# several padded screen lines rather than one soft-wrapped line. tmux copies
+# what is on screen, so a drag-selection yields those lines joined by newlines
+# -- a broken URL. Worse, such TUIs usually enable mouse reporting, which sets
+# #{mouse_any_flag} and makes tmux forward the drag to the application instead
+# of starting a selection at all, so there is frequently nothing to copy.
+#
+# Reassemble from the pane contents instead: start at the first line opening a
+# URL, stop at the first blank line, and concatenate what lies between with the
+# trailing padding stripped.
+#
+# The copy is also left in the tmux buffer. A status-line message is not
+# reliable feedback here: a TUI repaints over it immediately, so `tmux
+# show-buffer` is the only way to confirm after the fact.
+
+pane="${1:?usage: tmux-copy-url <pane-id>}"
+
+url=$(
+  tmux capture-pane -p -t "$pane" |
+    sed 's/[[:space:]]*$//' |
+    awk '
+      /^[[:space:]]*https?:\/\// { found = 1 }
+      found && NF == 0           { exit }
+      found                      { gsub(/^[[:space:]]+/, ""); printf "%s", $0 }
+    '
+)
+
+if [[ -z "$url" ]]; then
+  tmux display-message "copy-url: no URL visible in this pane"
+  exit 0
+fi
+
+# The buffer is set unconditionally; piping to win32yank is best-effort so that
+# a host without it (a Linux box rather than WSL) still gets a usable copy.
+printf '%s' "$url" | tmux load-buffer -
+
+if command -v win32yank >/dev/null 2>&1; then
+  printf '%s' "$url" | win32yank -i --crlf
+fi
+
+tmux display-message "copy-url: copied ${#url} chars"

--- a/tools/tmux/agent-teams-extras.conf
+++ b/tools/tmux/agent-teams-extras.conf
@@ -7,8 +7,3 @@ setw -g mode-keys vi
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y               send-keys -X copy-pipe-and-cancel "win32yank -i --crlf"
 bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "win32yank -i --crlf"
-
-# prefix U: copy the URL out of the current pane, reassembling it from the
-# screen lines a full-screen TUI wrapped it across. Mouse selection cannot do
-# this -- see bin/tmux-copy-url for why.
-bind-key U run-shell '~/.dotfiles/bin/tmux-copy-url "#{pane_id}"'

--- a/tools/tmux/agent-teams-extras.conf
+++ b/tools/tmux/agent-teams-extras.conf
@@ -7,3 +7,8 @@ setw -g mode-keys vi
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y               send-keys -X copy-pipe-and-cancel "win32yank -i --crlf"
 bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "win32yank -i --crlf"
+
+# prefix U: copy the URL out of the current pane, reassembling it from the
+# screen lines a full-screen TUI wrapped it across. Mouse selection cannot do
+# this -- see bin/tmux-copy-url for why.
+bind-key U run-shell '~/.dotfiles/bin/tmux-copy-url "#{pane_id}"'

--- a/tools/tmux/tmux.conf.symlink
+++ b/tools/tmux/tmux.conf.symlink
@@ -32,6 +32,13 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
+# prefix U: copy the URL out of the current pane, reassembling it from the
+# screen lines a full-screen TUI wrapped it across. Mouse selection cannot do
+# this -- see bin/tmux-copy-url for why. Bound here rather than in
+# agent-teams-extras.conf because that file is sourced only when win32yank is
+# present, while this works on any host (buffer-only without a clipboard tool).
+bind-key U run-shell '~/.dotfiles/bin/tmux-copy-url "#{pane_id}"'
+
 # Optional: status bar on top (uncomment if preferred)
 # set -g status-position top
 


### PR DESCRIPTION
## What

Adds `bin/tmux-copy-url` and binds it to `prefix U` in `tools/tmux/agent-teams-extras.conf`.

## Why

Copying the Claude Code login URL out of a tmux pane fails, and neither cause is obvious from the symptom (drag-select produces nothing at all, `c to copy` claims success and leaves the buffer empty).

**Mouse reporting.** Claude Code grabs the mouse, setting `#{mouse_any_flag}` on the pane. tmux's root-table binding routes on exactly that flag:

```
bind-key -T root MouseDrag1Pane \
  if-shell -F "#{||:#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -M }
```

With the flag set the drag goes to the application and no selection is started. `prefix [` works around it by setting `pane_in_mode` first, but that is non-obvious and drops the pane out of the live view. Measured: `mouse_any_flag=1` on both Claude panes, `0` on every shell pane.

**Hard-wrapped rendering.** Even in copy mode, a full-screen TUI draws a long URL as several padded screen lines, not one soft-wrapped line, so tmux copies fragments joined by newlines.

**OSC 52 is not a fallback.** `c to copy` emits OSC 52; with `set-clipboard external` tmux forwards it to Windows Terminal, which ignores clipboard writes while reporting success. Not fixed here — out of scope once `prefix U` works.

## How

`capture-pane` the pane, take from the first line that opens a URL to the first blank line, strip the padding, concatenate.

The result goes to the tmux buffer *and* the Windows clipboard. The buffer copy matters: `display-message` is not observable feedback here because the TUI repaints over the status line immediately, so `tmux show-buffer` is the only after-the-fact confirmation. The `win32yank` call is guarded, so the script degrades to a buffer-only copy on a host without it.

## Verification

- `make check` — clean (syntax, lint, 669 bats tests, python-test, validate)
- Functional: a fixture pane on a scratch tmux server rendering a URL across five padded lines. Script returned it joined and byte-identical in both the tmux buffer and the Windows clipboard.
- Empty-pane branch: exits 0 with the "no URL visible" message, leaves no buffer.
- Live: the real binding copied a 450-character login URL into the Windows clipboard, with a `state=` value distinct from the prior clipboard contents (i.e. a fresh capture, not a stale hit).

## Scope

This copies a URL, not arbitrary text. Ordinary copying is unchanged — drag and release still works in panes that have not grabbed the mouse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a tmux shortcut for extracting visible HTTP(S) URLs from the active pane.
  - Reassembles URLs wrapped across screen lines and copies them to the tmux buffer.
  - Supports optional Windows clipboard copying and reports the copied character count.
  - Displays a clear message when no URL is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->