### PR TITLE
fix(projectmux): render agent panes into an interactive login zsh

### DIFF
--- a/tests/projectmux_install.bats
+++ b/tests/projectmux_install.bats
@@ -393,7 +393,18 @@ source_installer() {
   grep -Fq "  - '$TEST_ROOT/workspace'" "$config"
   grep -Fq "  - '$TEST_ROOT/other'" "$config"
   [[ "$(cat "$config")" != *"@REPOSITORY_ROOTS@"* ]]
-  grep -Fq 'shell: true' "$config"
+  # Every pane command must reach an *interactive* login zsh. ProjectMux execs
+  # container panes as `sh -lc '<command>'` and /bin/sh is dash, so vekil --
+  # sourced from ~/.zshrc, which only runs when interactive -- never loads and
+  # the agent silently talks straight to Anthropic instead of the proxy.
+  grep -Fq "    command: zsh -lic 'exec claude'" "$config"
+  grep -Fq "        command: exec zsh -li" "$config"
+  # The two forms that reintroduce that bug: `agent:` renders as a bare
+  # `claude` argv, and `shell: true` renders an empty command, landing the pane
+  # in dash either way. Anchored to a YAML key at line start -- an unanchored
+  # substring also matches the template comment warning against these forms.
+  ! grep -Eq "^[[:space:]]*-?[[:space:]]*agent:" "$config"
+  ! grep -Eq "^[[:space:]]*-?[[:space:]]*shell:[[:space:]]*true" "$config"
   # command: null sets zero window modes and fails v1 validation.
   [[ "$(cat "$config")" != *"command: null"* ]]
   [ -d "$TEST_ROOT/config/projectmux/workspaces" ]

--- a/tools/projectmux/defaults.yaml.template
+++ b/tools/projectmux/defaults.yaml.template
@@ -16,11 +16,33 @@ devcontainer:
   enabled: auto
   start_timeout: 5m
 
+# Every pane runs through an interactive login zsh rather than the default.
+#
+# ProjectMux execs container panes as `sh -lc '<command>'`, and /bin/sh is dash.
+# Vekil is sourced from ~/.zshrc, which zsh only reads when *interactive* -- so
+# neither `sh -lc` nor `zsh -lc` loads it, and the agent would talk straight to
+# Anthropic instead of the proxy. The failure is silent: the agent runs fine,
+# just against the wrong endpoint.
+#
+# `zsh -lic` loads the full dotfiles, letting ai/vekil/env.zsh compute the
+# endpoint itself -- host.docker.internal inside a container, the proxy-host
+# state file outside -- rather than freezing a host and port here. It also sets
+# the VEKIL_MANAGED_* pair that `claude-direct` needs to opt back out.
+#
+# Do not use `agent: claude` or `shell: true`: the first renders a bare `claude`
+# argv and the second an empty command, and both land the pane in dash. The
+# secondary pane must be declared explicitly, because ProjectMux otherwise
+# injects a `{shell: true}` pane of its own (its two-pane-windows default).
+#
+# `exec` replaces the shell so no extra process sits between tmux and the agent.
+#
+# One window, one agent, one shell, split 50/50 side-by-side. A ProjectMux
+# session is already scoped to a single worktree, so working several worktrees
+# at once means several sessions rather than several windows.
 windows:
-  - name: agent-1
-    agent: claude
+  - name: agent
+    command: zsh -lic 'exec claude'
     focus: true
-  - name: agent-2
-    agent: claude
-  - name: shell
-    shell: true
+    panes:
+      - name: shell
+        command: exec zsh -li


### PR DESCRIPTION
## Problem

The shipped `defaults.yaml.template` used `agent: claude` and `shell: true`. ProjectMux renders those as a bare `claude` argv and an *empty* command respectively, and execs container panes as:

```
docker exec ... sh -lc '<command>'
```

`/bin/sh` is dash, so neither form reaches a zsh startup file. Vekil is sourced from `~/.zshrc`, which zsh reads **only when interactive** — so even `zsh -lc` would miss it. The result: agents ran against Anthropic directly instead of the proxy.

The failure is silent. The agent works fine, just against the wrong endpoint; only billing or proxy logs would reveal it.

Measured in a live devcontainer:

| command form | `ANTHROPIC_BASE_URL` |
|---|---|
| `sh -lc` | UNSET |
| `zsh -lc` | UNSET |
| `zsh -lic` | `http://host.docker.internal:1337` |

Host panes were never affected — a tmux pane inherits the server's global environment at spawn time.

## Change

```yaml
windows:
  - name: agent
    command: zsh -lic 'exec claude'
    focus: true
    panes:
      - name: shell
        command: exec zsh -li
```

- `zsh -lic` loads the full dotfiles, so `ai/vekil/env.zsh` computes the endpoint itself — `host.docker.internal` in a container, the `proxy-host` state file outside — and exports the `VEKIL_MANAGED_*` pair that `claude-direct` needs to opt back out.
- The secondary pane is declared **explicitly**. ProjectMux otherwise injects a `{shell: true}` pane of its own (its two-pane-windows default), which would be dash again and is invisible in both the YAML and `projectmux config` output.
- `exec` keeps an extra shell process from sitting between tmux and the agent.
- Collapsed to one window: a ProjectMux session is already scoped to a single worktree, so several worktrees means several sessions, not several windows.

**Rejected alternative:** a static `environment:` block. It works, but freezes host and port, picks the bridge IP where vekil would pick `host.docker.internal`, omits `VEKIL_MANAGED_*`, and duplicates logic the dotfiles already own.

## Verification

- `make check` → exit 0, **669 passing, 0 failing**; syntax, lint, python, and validate all clean.
- Rendered the template through `install_config` into a temp root and ran the real binary against it: `projectmux config --validate` → `0 problems`. The grep assertions alone don't prove the YAML parses.
- Exercised the new regression guard both directions against fixtures: comment prose accepted, real `agent:` / `shell: true` keys rejected.

## Review focus

The regression guards are **anchored to a YAML key at line start**:

```bash
! grep -Eq "^[[:space:]]*-?[[:space:]]*agent:" "$config"
```

My first attempt used an unanchored `[[ != *"agent:"* ]]`, which failed against the template's *own comment* warning against `agent: claude` — a text gate keying on prose rather than structure. Worth a second pair of eyes on the anchoring.

## Note for existing machines

`install_config` never overwrites an existing `~/.config/projectmux/defaults.yaml`; it only warns about drift. This fixes **new** installs. Machines already running need the equivalent edit by hand, then `projectmux stop <ws> && projectmux open <ws>` — panes are create-only and are never reconciled, so `open` alone will not re-exec them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default ProjectMux configuration to provide a focused agent window running Claude through an interactive login shell.
  - Added a dedicated shell pane with interactive login shell support.

- **Bug Fixes**
  - Improved default command behavior to ensure required interactive shell options are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->